### PR TITLE
chore: Minor change to use https in the github url in Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The final binary will be in `target/release` and can then installed for example 
 
 ## Usage
 
-After [building](README.md#build) or downloading `csaf-validator` from [the available releases](https://github.com/csaf-poc/csaf-rust/releases), the usage is quite simple and additional help can be display using `--help`.
+After [building](README.md#build) or downloading `csaf-validator` from [the available releases](https://github.com/csaf-rs/csaf/releases), the usage is quite simple and additional help can be display using `--help`.
 
 ```
 A validator for CSAF documents

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "csaf-rs"
 description = "A parser for the CSAF standard written in Rust"
 license = "Apache-2.0"
-repository = "https://github.com/csaf-poc/csaf-rust"
+repository = "https://github.com/csaf-rs/csaf"
 keywords = ["csaf"]
 readme = "../README.md"
 version = "0.1.2"

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "csaf-rs"
 description = "A parser for the CSAF standard written in Rust"
 license = "Apache-2.0"
-repository = "http://github.com/csaf-poc/csaf-rust"
+repository = "https://github.com/csaf-poc/csaf-rust"
 keywords = ["csaf"]
 readme = "../README.md"
 version = "0.1.2"

--- a/csaf-validator/Cargo.toml
+++ b/csaf-validator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "csaf-validator"
 description = "A validator for the CSAF standard written in Rust"
 license = "Apache-2.0"
-repository = "https://github.com/csaf-poc/csaf-rust"
+repository = "https://github.com/csaf-rs/csaf"
 keywords = ["csaf"]
 readme = "../README.md"
 version = "0.1.2"

--- a/csaf-validator/Cargo.toml
+++ b/csaf-validator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "csaf-validator"
 description = "A validator for the CSAF standard written in Rust"
 license = "Apache-2.0"
-repository = "http://github.com/csaf-poc/csaf-rust"
+repository = "https://github.com/csaf-poc/csaf-rust"
 keywords = ["csaf"]
 readme = "../README.md"
 version = "0.1.2"


### PR DESCRIPTION
GitHub redirects to the address with https anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/97