### PR TITLE
v0.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "csaf-rs"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "glob",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "csaf-validator"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 repository = "http://github.com/csaf-poc/csaf-rust"
 keywords = ["csaf"]
 readme = "../README.md"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/csaf-validator/Cargo.toml
+++ b/csaf-validator/Cargo.toml
@@ -5,10 +5,10 @@ license = "Apache-2.0"
 repository = "http://github.com/csaf-poc/csaf-rust"
 keywords = ["csaf"]
 readme = "../README.md"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-csaf-rs = { path = "../csaf-rs", version = "0.1.2" }
+csaf-rs = { path = "../csaf-rs", version = "0.2.0" }
 anyhow = "1.0.93"
 clap = { version = "4.5.23", features = ["derive"] }


### PR DESCRIPTION
Published at https://crates.io/crates/csaf-rs. This bumps the version number after publishing.