### PR TITLE
feat: validation API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
-        "csaf"
+        "csaf",
+        "Validatable"
     ]
 }


### PR DESCRIPTION
This PR adds a new validation API that should provide a better experience for the `csaf-validator` binary and other users of this library. Core features are:
- Three level of validation using `validate_preset`, `validate_tests`, `validate_by_test`
- All validation functions return a `ValidationResult` containing individual test results and errors
