### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @csaf-rs/service-dev


### PR DESCRIPTION
For now everything is "owned" by @csaf-rs/service-dev to trigger automatic review requests.