### PR TITLE
Refactor validation functions to collect and aggregate errors

### DIFF
--- a/csaf-rs/src/csaf/csaf2_0/csaf_implementations.rs
+++ b/csaf-rs/src/csaf/csaf2_0/csaf_implementations.rs
@@ -289,12 +289,12 @@ impl DocumentTrait for DocumentLevelMetaData {
     }
 
     /// Return distribution or a Validation error to satisfy CSAF 2.1 semantics
-    fn get_distribution_21(&self) -> Result<&Self::DistributionType, Vec<ValidationError>> {
+    fn get_distribution_21(&self) -> Result<&Self::DistributionType, ValidationError> {
         match self.distribution.as_ref() {
-            None => Err(vec![ValidationError {
+            None => Err(ValidationError {
                 message: "CSAF 2.1 requires the distribution property, but it is not set.".to_string(),
                 instance_path: "/document/distribution".to_string()
-            }]),
+            }),
             Some(distribution) => Ok(distribution)
         }
     }
@@ -326,12 +326,12 @@ impl DistributionTrait for RulesForSharingDocument {
     }
 
     /// Return TLP or a ValidationError to satisfy CSAF 2.1 semantics
-    fn get_tlp_21(&self) -> Result<&Self::TlpType, Vec<ValidationError>> {
+    fn get_tlp_21(&self) -> Result<&Self::TlpType, ValidationError> {
         match self.tlp.as_ref() {
-            None => Err(vec![ValidationError {
+            None => Err(ValidationError {
                 message: "CSAF 2.1 requires the TLP property, but it is not set.".to_string(),
                 instance_path: "/document/distribution/sharing_group/tlp".to_string()
-            }]),
+            }),
             Some(tlp) => Ok(tlp)
         }
     }

--- a/csaf-rs/src/csaf/csaf2_1/csaf_implementations.rs
+++ b/csaf-rs/src/csaf/csaf2_1/csaf_implementations.rs
@@ -268,7 +268,7 @@ impl DocumentTrait for DocumentLevelMetaData {
     }
 
     /// We normalize to Option here because property was optional in CSAF 2.0
-    fn get_distribution_21(&self) -> Result<&Self::DistributionType, Vec<ValidationError>> {
+    fn get_distribution_21(&self) -> Result<&Self::DistributionType, ValidationError> {
         Ok(&self.distribution)
     }
 
@@ -304,7 +304,7 @@ impl DistributionTrait for RulesForDocumentSharing {
     }
 
     /// Always return the value because it is mandatory
-    fn get_tlp_21(&self) -> Result<&Self::TlpType, Vec<ValidationError>> {
+    fn get_tlp_21(&self) -> Result<&Self::TlpType, ValidationError> {
         Ok(&self.tlp)
     }
 }

--- a/csaf-rs/src/csaf/validations/test_6_1_13.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_13.rs
@@ -8,10 +8,11 @@ use std::sync::LazyLock;
 static PURL_REGEX: LazyLock<Regex> = LazyLock::new(||
     Regex::new(r"^pkg:[A-Za-z.\-+][A-Za-z0-9.\-+]*/.+").unwrap()
 );
-
 pub fn test_6_1_13_purl(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
+    let mut errors: Option<Vec<ValidationError>> = None;
+
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {
             if let Some(helper) = product.get_product_identification_helper() {
@@ -19,28 +20,27 @@ pub fn test_6_1_13_purl(
                     for (i, purl_str) in purls.iter().enumerate() {
                         // Check against PURL regex
                         if !PURL_REGEX.is_match(purl_str) {
-                            return Err(vec![ValidationError {
+                            errors.get_or_insert_with(Vec::new).push(ValidationError {
                                 message: format!("PURL doesn't comply with CSAF PURL regex: {}", purl_str),
                                 instance_path: format!("{}/product_identification_helper/purls/{}", path, i),
-                            }]);
+                            });
+                            continue;
                         }
                         // Parse the PURL
-                        match PackageUrl::from_str(purl_str) {
-                            Ok(_) => {},
-                            Err(e) => {
-                                return Err(vec![ValidationError {
-                                    message: format!("Invalid PURL format: {}, Error: {}", purl_str, e),
-                                    instance_path: format!("{}/product_identification_helper/purls/{}", path, i),
-                                }]);
-                            }
-                        };
+                        if let Err(e) = PackageUrl::from_str(purl_str) {
+                            errors.get_or_insert_with(Vec::new).push(ValidationError {
+                                message: format!("Invalid PURL format: {}, Error: {}", purl_str, e),
+                                instance_path: format!("{}/product_identification_helper/purls/{}", path, i),
+                            });
+                        }
                     }
                 }
             }
             Ok(())
         })?;
     }
-    Ok(())
+
+    errors.map_or(Ok(()), Err)
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/csaf/validations/test_6_1_38.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_38.rs
@@ -22,10 +22,10 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_38_non_public_sharing_group_max_uuid(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
-    let distribution = doc.get_document().get_distribution_21()?;
+    let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group() {
-        if sharing_group.get_id() == MAX_UUID && distribution.get_tlp_21()?.get_label() != Clear {
+        if sharing_group.get_id() == MAX_UUID && distribution.get_tlp_21().map_err(|e| vec![e])?.get_label() != Clear {
             return Err(vec![ValidationError {
                 message: "Document must be public (TLD CLEAR) when using max UUID as sharing group ID.".to_string(),
                 instance_path: "/document/distribution/sharing_group/tlp/label".to_string()

--- a/csaf-rs/src/csaf/validations/test_6_1_39.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_39.rs
@@ -23,9 +23,9 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_39_public_sharing_group_with_no_max_uuid(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
-    let distribution = doc.get_document().get_distribution_21()?;
+    let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
-    if distribution.get_tlp_21()?.get_label() == Clear {
+    if distribution.get_tlp_21().map_err(|e| vec![e])?.get_label() == Clear {
         if let Some(sharing_group) = distribution.get_sharing_group() {
             let sharing_group_id = sharing_group.get_id();
             return if sharing_group_id == MAX_UUID {

--- a/csaf-rs/src/csaf/validations/test_6_1_40.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_40.rs
@@ -24,7 +24,7 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_40_invalid_sharing_group_name(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
-    let distribution = doc.get_document().get_distribution_21()?;
+    let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group() {
         if let Some(sharing_group_name) = sharing_group.get_name() {

--- a/csaf-rs/src/csaf/validations/test_6_1_41.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_41.rs
@@ -22,7 +22,7 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_41_missing_sharing_group_name(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
-    let distribution = doc.get_document().get_distribution_21()?;
+    let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group() {
         // Check if max UUID is used

--- a/csaf-rs/src/csaf/validations/test_6_1_42.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_42.rs
@@ -6,6 +6,8 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_42_purl_consistency(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
+    let mut errors: Option<Vec<ValidationError>> = None;
+
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {
             if let Some(helper) = product.get_product_identification_helper() {
@@ -21,10 +23,11 @@ pub fn test_6_1_42_purl_consistency(
                         let mut purl = match PackageUrl::from_str(purl_str) {
                             Ok(p) => p,
                             Err(_) => {
-                                return Err(vec![ValidationError {
+                                errors.get_or_insert_with(Vec::new).push(ValidationError {
                                     message: format!("Invalid PURL format: {}", purl_str),
                                     instance_path: format!("{}/product_identification_helper/purls/{}", path, i),
-                                }]);
+                                });
+                                continue;
                             }
                         };
 
@@ -34,10 +37,10 @@ pub fn test_6_1_42_purl_consistency(
                         if let Some(ref base) = base_parts {
                             // Must always match
                             if current_parts != *base {
-                                return Err(vec![ValidationError {
+                                errors.get_or_insert_with(Vec::new).push(ValidationError {
                                     message: String::from("PURLs within the same product_identification_helper must only differ in qualifiers"),
                                     instance_path: format!("{}/product_identification_helper/purls/{}", path, i),
-                                }]);
+                                });
                             }
                         } else {
                             // The first PURL becomes the base for comparison
@@ -49,7 +52,8 @@ pub fn test_6_1_42_purl_consistency(
             Ok(())
         })?;
     }
-    Ok(())
+
+    errors.map_or(Ok(()), Err)
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/csaf/validations/test_6_1_43.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_43.rs
@@ -5,16 +5,18 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_43_multiple_stars_in_model_number(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
+    let mut errors: Option<Vec<ValidationError>> = None;
+
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {
             if let Some(helper) = product.get_product_identification_helper() {
                 if let Some(model_numbers) = helper.get_model_numbers() {
                     for (index, model_number) in model_numbers.enumerate() {
                         if count_unescaped_stars(model_number) > 1 {
-                            return Err(vec![ValidationError {
+                            errors.get_or_insert_with(Vec::new).push(ValidationError {
                                 message: "Model number must not contain multiple unescaped asterisks (stars)".to_string(),
                                 instance_path: format!("{}/product_identification_helper/model_numbers/{}", path, index),
-                            }]);
+                            });
                         }
                     }
                 }
@@ -22,7 +24,8 @@ pub fn test_6_1_43_multiple_stars_in_model_number(
             Ok(())
         })?;
     }
-    Ok(())
+
+    errors.map_or(Ok(()), Err)
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/csaf/validations/test_6_1_44.rs
+++ b/csaf-rs/src/csaf/validations/test_6_1_44.rs
@@ -5,16 +5,18 @@ use crate::csaf::validation::ValidationError;
 pub fn test_6_1_44_multiple_stars_in_serial_number(
     doc: &impl CsafTrait,
 ) -> Result<(), Vec<ValidationError>> {
+    let mut errors: Option<Vec<ValidationError>> = None;
+
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {
             if let Some(helper) = product.get_product_identification_helper() {
                 if let Some(serial_numbers) = helper.get_serial_numbers() {
                     for (index, serial_number) in serial_numbers.enumerate() {
                         if count_unescaped_stars(serial_number) > 1 {
-                            return Err(vec![ValidationError {
+                            errors.get_or_insert_with(Vec::new).push(ValidationError {
                                 message: "Serial number must not contain multiple unescaped asterisks (stars)".to_string(),
                                 instance_path: format!("{}/product_identification_helper/serial_numbers/{}", path, index),
-                            }]);
+                            });
                         }
                     }
                 }
@@ -22,7 +24,8 @@ pub fn test_6_1_44_multiple_stars_in_serial_number(
             Ok(())
         })?;
     }
-    Ok(())
+
+    errors.map_or(Ok(()), Err)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Reverted some returns back to non-Vec returns in Traits.
- Fixed semantics of `visit_all_products[_generic]` and `visit_branches_rec` functions.
- Fixed semantics of related tests to collect errors into a lazy-init `Option<Vec<...>>` where suitable.

Partially fixes #148 