### PR TITLE
Add `cargo check` step for .rs file re-generation in asset workflows

### DIFF
--- a/.github/workflows/asset-sync.yml
+++ b/.github/workflows/asset-sync.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Run update_assets.sh
         run: ./update_assets.sh
 
+      - name: Run cargo check (for .rs file re-generation)
+        run: cargo check
+
       - name: Commit changes (if any)
         run: |
           if [[ -n $(git status --porcelain) ]]; then

--- a/.github/workflows/update-ext-assets.yml
+++ b/.github/workflows/update-ext-assets.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Update external assets
         run: ./update_ext_assets.sh
 
+      - name: Run cargo check (for .rs file re-generation)
+        run: cargo check
+
       - name: Create PR
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
This should fix the (minor?) issue I mentioned in https://github.com/csaf-rs/csaf/pull/150#issuecomment-3562182371.

@oxisto Do we need anything else besides `chargo check`, i.e, to (automatically) fix any formatting in generated `.rs` files prior to commit?