### PR TITLE
format: fmt

### DIFF
--- a/csaf-rs/src/validations/test_6_1_07.rs
+++ b/csaf-rs/src/validations/test_6_1_07.rs
@@ -5,8 +5,7 @@ use crate::csaf_traits::{
 use crate::validation::ValidationError;
 use std::collections::{HashMap, HashSet};
 
-type ProductMetricsMap =
-    HashMap<String, HashMap<(VulnerabilityMetric, Option<String>), Vec<String>>>;
+type ProductMetricsMap = HashMap<String, HashMap<(VulnerabilityMetric, Option<String>), Vec<String>>>;
 fn gather_product_metrics(
     vulnerability: &impl VulnerabilityTrait,
     vulnerability_index: usize,
@@ -15,8 +14,7 @@ fn gather_product_metrics(
 
     metrics?;
 
-    let mut product_metrics: ProductMetricsMap =
-        HashMap::new();
+    let mut product_metrics: ProductMetricsMap = HashMap::new();
     for (metric_index, metric) in metrics.unwrap().iter().enumerate() {
         let content = metric.get_content();
         let mut present_metric_types = HashSet::<VulnerabilityMetric>::new();
@@ -66,11 +64,7 @@ pub fn test_6_1_07_multiple_same_scores_per_product(doc: &impl CsafTrait) -> Res
                         for path in paths {
                             errors.get_or_insert_with(Vec::new).push(ValidationError {
                                 message: create_error_message(metric_type, p),
-                                instance_path: format!(
-                                    "{}/{}",
-                                    path,
-                                    get_metric_prop_name(metric_type.to_owned())
-                                ),
+                                instance_path: format!("{}/{}", path, get_metric_prop_name(metric_type.to_owned())),
                             });
                         }
                     }
@@ -82,11 +76,7 @@ pub fn test_6_1_07_multiple_same_scores_per_product(doc: &impl CsafTrait) -> Res
 }
 
 fn create_error_message(score_type: &VulnerabilityMetric, product_id: &str) -> String {
-    format!(
-        "Multiple {} scores are given for {}.",
-        score_type,
-        product_id
-    )
+    format!("Multiple {} scores are given for {}.", score_type, product_id)
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/validations/test_6_1_08.rs
+++ b/csaf-rs/src/validations/test_6_1_08.rs
@@ -78,7 +78,7 @@ fn evaluate_cvss(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_helper::{run_csaf20_tests};
+    use crate::test_helper::run_csaf20_tests;
     use crate::validation::ValidationError;
     use crate::validations::test_6_1_08::test_6_1_08_invalid_cvss;
     use std::collections::HashMap;

--- a/csaf-rs/src/validations/test_6_1_24.rs
+++ b/csaf-rs/src/validations/test_6_1_24.rs
@@ -20,9 +20,7 @@ pub fn test_6_1_24_multiple_definition_in_involvements(doc: &impl CsafTrait) -> 
             for (inv_r, involvement) in involvements.iter().enumerate() {
                 if let Some(date) = involvement.get_date() {
                     let party = involvement.get_party();
-                    let paths = date_party_paths_map
-                        .entry((date.clone(), party))
-                        .or_default();
+                    let paths = date_party_paths_map.entry((date.clone(), party)).or_default();
                     paths.push(inv_r);
                 }
             }

--- a/csaf-rs/src/validations/test_6_1_25.rs
+++ b/csaf-rs/src/validations/test_6_1_25.rs
@@ -24,9 +24,7 @@ pub fn test_6_1_25_multiple_use_of_same_hash_algorithm(doc: &impl CsafTrait) -> 
                     // Iterate over file_hashes, build hashmap of all encountered algos and their indices
                     let mut algorithms = HashMap::<String, Vec<usize>>::new();
                     for (file_hash_i, file_hash) in hash.get_file_hashes().iter().enumerate() {
-                        let file_hash_is = algorithms
-                            .entry(file_hash.get_algorithm().to_string())
-                            .or_default();
+                        let file_hash_is = algorithms.entry(file_hash.get_algorithm().to_string()).or_default();
                         file_hash_is.push(file_hash_i);
                     }
                     // For each algo found multiple times, generate error message for all indices with the algo

--- a/csaf-rs/src/validations/test_6_1_27_11.rs
+++ b/csaf-rs/src/validations/test_6_1_27_11.rs
@@ -14,19 +14,19 @@ pub fn test_6_1_27_11_vulnerabilities(doc: &impl CsafTrait) -> Result<(), Vec<Va
     // check if document is relevant document category in csaf 2.0
     if *doc.get_document().get_csaf_version() == CsafVersion::X20
         && doc_category != DocumentCategory::CsafSecurityAdvisory
-        && doc_category != DocumentCategory::CsafVex {
-            return Ok(());
-        }
+        && doc_category != DocumentCategory::CsafVex
+    {
+        return Ok(());
+    }
 
     // check if document is relevant document category in csaf 2.1
     if *doc.get_document().get_csaf_version() == CsafVersion::X21
-            && doc_category != DocumentCategory::CsafSecurityAdvisory
-            && doc_category != DocumentCategory::CsafVex
-            && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
-        {
-            return Ok(());
-        }
-
+        && doc_category != DocumentCategory::CsafSecurityAdvisory
+        && doc_category != DocumentCategory::CsafVex
+        && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
+    {
+        return Ok(());
+    }
 
     if doc.get_vulnerabilities().is_empty() {
         return Err(vec![test_6_1_27_11_err_generator(&doc_category)]);

--- a/csaf-rs/src/validations/test_6_1_27_4.rs
+++ b/csaf-rs/src/validations/test_6_1_27_4.rs
@@ -14,20 +14,19 @@ pub fn test_6_1_27_4_product_tree(doc: &impl CsafTrait) -> Result<(), Vec<Valida
     // check if document is relevant document category in csaf 2.0
     if *doc.get_document().get_csaf_version() == CsafVersion::X20
         && doc_category != DocumentCategory::CsafSecurityAdvisory
-        && doc_category != DocumentCategory::CsafVex {
-            return Ok(());
-        }
-
+        && doc_category != DocumentCategory::CsafVex
+    {
+        return Ok(());
+    }
 
     // check if document is relevant document category in csaf 2.1
     if *doc.get_document().get_csaf_version() == CsafVersion::X21
-            && doc_category != DocumentCategory::CsafSecurityAdvisory
-            && doc_category != DocumentCategory::CsafVex
-            && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
-        {
-            return Ok(());
-        }
-
+        && doc_category != DocumentCategory::CsafSecurityAdvisory
+        && doc_category != DocumentCategory::CsafVex
+        && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
+    {
+        return Ok(());
+    }
 
     // return error if there are there isn't a product tree
     if doc.get_product_tree().is_none() {

--- a/csaf-rs/src/validations/test_6_1_27_5.rs
+++ b/csaf-rs/src/validations/test_6_1_27_5.rs
@@ -13,19 +13,20 @@ pub fn test_6_1_27_5_vulnerability_notes(doc: &impl CsafTrait) -> Result<(), Vec
 
     // check if document is relevant document category in csaf 2.0
     if *doc.get_document().get_csaf_version() == CsafVersion::X20
-        && doc_category != DocumentCategory::CsafSecurityAdvisory && doc_category != DocumentCategory::CsafVex {
-            return Ok(());
-        }
-
+        && doc_category != DocumentCategory::CsafSecurityAdvisory
+        && doc_category != DocumentCategory::CsafVex
+    {
+        return Ok(());
+    }
 
     // check if document is relevant document category in csaf 2.1
     if *doc.get_document().get_csaf_version() == CsafVersion::X21
-            && doc_category != DocumentCategory::CsafSecurityAdvisory
-            && doc_category != DocumentCategory::CsafVex
-            && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
-        {
-            return Ok(());
-        }
+        && doc_category != DocumentCategory::CsafSecurityAdvisory
+        && doc_category != DocumentCategory::CsafVex
+        && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
+    {
+        return Ok(());
+    }
 
     let mut errors: Option<Vec<ValidationError>> = None;
     // return error if there are vulnerabilities without notes

--- a/csaf-rs/src/validations/test_6_1_27_6.rs
+++ b/csaf-rs/src/validations/test_6_1_27_6.rs
@@ -13,19 +13,18 @@ pub fn test_6_1_27_6_product_status(doc: &impl CsafTrait) -> Result<(), Vec<Vali
 
     // check if document is relevant document category in csaf 2.0
     if *doc.get_document().get_csaf_version() == CsafVersion::X20
-        && doc_category != DocumentCategory::CsafSecurityAdvisory {
-            return Ok(());
-        }
-
+        && doc_category != DocumentCategory::CsafSecurityAdvisory
+    {
+        return Ok(());
+    }
 
     // check if document is relevant document category in csaf 2.1
     if *doc.get_document().get_csaf_version() == CsafVersion::X21
         && doc_category != DocumentCategory::CsafSecurityAdvisory
-            && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
-        {
-            return Ok(());
-        }
-
+        && doc_category != DocumentCategory::CsafDeprecatedSecurityAdvisory
+    {
+        return Ok(());
+    }
 
     let mut errors: Option<Vec<ValidationError>> = None;
     // return error if there are vulnerabilities without product_status

--- a/csaf-rs/src/validations/test_6_1_39.rs
+++ b/csaf-rs/src/validations/test_6_1_39.rs
@@ -27,7 +27,9 @@ pub fn test_6_1_39_public_sharing_group_with_no_max_uuid(doc: &impl CsafTrait) -
         if let Some(sharing_group) = distribution.get_sharing_group() {
             let sharing_group_id = sharing_group.get_id();
             return if sharing_group_id == MAX_UUID
-                || (sharing_group_id == NIL_UUID && doc.get_document().get_tracking().get_status() == DocumentStatus::Draft){
+                || (sharing_group_id == NIL_UUID
+                    && doc.get_document().get_tracking().get_status() == DocumentStatus::Draft)
+            {
                 Ok(())
             } else {
                 Err(vec![ValidationError {


### PR DESCRIPTION
The combination of cargo fmt not working for the validations due to #209 and concurrent changes from the same main commit in #210 have caused the pipeline on main to fail. This should not be able to happen.

This highlights a misconfiguration of our build pipelines: Each change to a branch should re-run the pipelines of all PRs that point to this branch as their traget brach. This is not currently the case.

This PR just contains the cargo fmt changes. I'll create a seperate issue to address the pipeline misconfig.