### PR TITLE
refactor: visit_all_branches util function

### DIFF
--- a/csaf-rs/src/validations/test_6_1_31.rs
+++ b/csaf-rs/src/validations/test_6_1_31.rs
@@ -76,26 +76,20 @@ pub fn test_6_1_31_version_range_in_product_version_branch_name(
 ) -> Result<(), Vec<ValidationError>> {
     let mut errors: Option<Vec<ValidationError>> = None;
     if let Some(product_tree) = doc.get_product_tree().as_ref() {
-        if let Some(branches) = product_tree.get_branches().as_ref() {
-            for (i, branch) in branches.iter().enumerate() {
-                branch.visit_branches_rec(&format!("/product_tree/branches/{}", i), &mut |branch, path| {
-                    if branch.get_category() == &CategoryOfTheBranch::ProductVersion {
-                        // if there are any forbidden substrings found, create an error
-                        if let Some(forbidden_substrings) =
-                            check_branch_name_for_forbidden_substrings(branch.get_name())
-                        {
-                            errors
-                                .get_or_insert_with(Vec::new)
-                                .push(create_forbidden_strings_in_version_error(
-                                    branch.get_name(),
-                                    forbidden_substrings,
-                                    path,
-                                ));
-                        }
-                    }
-                });
+        product_tree.visit_all_branches(&mut |branch, path| {
+            if branch.get_category() == &CategoryOfTheBranch::ProductVersion {
+                // if there are any forbidden substrings found, create an error
+                if let Some(forbidden_substrings) = check_branch_name_for_forbidden_substrings(branch.get_name()) {
+                    errors
+                        .get_or_insert_with(Vec::new)
+                        .push(create_forbidden_strings_in_version_error(
+                            branch.get_name(),
+                            forbidden_substrings,
+                            path,
+                        ));
+                }
             }
-        }
+        })
     }
 
     errors.map_or(Ok(()), Err)

--- a/csaf-rs/src/validations/test_6_2_18.rs
+++ b/csaf-rs/src/validations/test_6_2_18.rs
@@ -20,19 +20,15 @@ pub fn test_6_2_18_product_version_range_without_vers(doc: &impl CsafTrait) -> R
     let mut errors: Option<Vec<ValidationError>> = None;
 
     if let Some(product_tree) = doc.get_product_tree().as_ref() {
-        if let Some(branches) = product_tree.get_branches().as_ref() {
-            for (i, branch) in branches.iter().enumerate() {
-                branch.visit_branches_rec(&format!("/product_tree/branches/{}", i), &mut |branch, path| {
-                    if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange
-                        && !VERS_REGEX.is_match(branch.get_name())
-                    {
-                        errors
-                            .get_or_insert_with(Vec::new)
-                            .push(create_product_version_range_without_vers_error(branch.get_name(), path));
-                    }
-                });
+        product_tree.visit_all_branches(&mut |branch, path| {
+            if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange
+                && !VERS_REGEX.is_match(branch.get_name())
+            {
+                errors
+                    .get_or_insert_with(Vec::new)
+                    .push(create_product_version_range_without_vers_error(branch.get_name(), path));
             }
-        }
+        });
     }
 
     errors.map_or(Ok(()), Err)

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -15,17 +15,13 @@ pub fn test_6_3_10_usage_of_product_version_range(doc: &impl CsafTrait) -> Resul
     let mut errors: Option<Vec<ValidationError>> = None;
 
     if let Some(product_tree) = doc.get_product_tree().as_ref() {
-        if let Some(branches) = product_tree.get_branches().as_ref() {
-            for (i, branch) in branches.iter().enumerate() {
-                branch.visit_branches_rec(&format!("/product_tree/branches/{}", i), &mut |branch, path| {
-                    if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange {
-                        errors
-                            .get_or_insert_with(Vec::new)
-                            .push(create_product_version_range_error(path));
-                    }
-                });
+        product_tree.visit_all_branches(&mut |branch, path| {
+            if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange {
+                errors
+                    .get_or_insert_with(Vec::new)
+                    .push(create_product_version_range_error(path));
             }
-        }
+        });
     }
 
     errors.map_or(Ok(()), Err)

--- a/csaf-rs/src/validations/test_6_3_11.rs
+++ b/csaf-rs/src/validations/test_6_3_11.rs
@@ -23,19 +23,15 @@ pub fn test_6_3_11_usage_of_v_as_version_indicator(doc: &impl CsafTrait) -> Resu
     let mut errors: Option<Vec<ValidationError>> = None;
 
     if let Some(product_tree) = doc.get_product_tree().as_ref() {
-        if let Some(branches) = product_tree.get_branches().as_ref() {
-            for (i, branch) in branches.iter().enumerate() {
-                branch.visit_branches_rec(&format!("/product_tree/branches/{}", i), &mut |branch, path| {
-                    if branch.get_category() == &CategoryOfTheBranch::ProductVersion
-                        && V_AS_VERSION_INDICATOR_REGEX.is_match(branch.get_name())
-                    {
-                        errors
-                            .get_or_insert_with(Vec::new)
-                            .push(create_v_version_indicator_error(branch.get_name(), path));
-                    }
-                });
+        product_tree.visit_all_branches(&mut |branch, path| {
+            if branch.get_category() == &CategoryOfTheBranch::ProductVersion
+                && V_AS_VERSION_INDICATOR_REGEX.is_match(branch.get_name())
+            {
+                errors
+                    .get_or_insert_with(Vec::new)
+                    .push(create_v_version_indicator_error(branch.get_name(), path));
             }
-        }
+        });
     }
 
     errors.map_or(Ok(()), Err)


### PR DESCRIPTION
Some tests share the need to run a callback for each branch of the product tree, recursivly.

So far, each test implemented this themselves, additionally the same functionality is also part of the recursive visit_all_products functionality.

I extracted the subfunction from visit_all_products and used in the relevant tests.

Additionally, I would like to discuss if it makes sense to add another util function on document level, which also hides the "is there even a product tree" check and accepts a branch category to filter for, as there will at least be one more of these tests (6.1.50) in CSAF 2.1.