### PR TITLE
Proposal: custom tests

### DIFF
--- a/csaf-rs/src/validations/test_6_1_15.rs
+++ b/csaf-rs/src/validations/test_6_1_15.rs
@@ -62,6 +62,10 @@ mod tests {
         let err = Err(vec![MISSING_SOURCE_LANG_ERROR.clone()]);
 
         // Both CSAF 2.0 and 2.1 have 4 test cases (01, 02, 11, 12)
+        // 01 has no lang and no source_lang
+        // 02 has lang but no source_lang
+        // 11 has no lang and sourcelang
+        // 12 has lang and source_lang
         TESTS_2_0.test_6_1_15.expect(
             err.clone(),
             err.clone(),
@@ -75,5 +79,58 @@ mod tests {
             Ok(()), // case_11
             Ok(()), // case_12
         );
+    }
+}
+mod csaf_20_custom_tests {
+    use super::*;
+    use crate::schema::csaf2_0::schema::{CommonSecurityAdvisoryFramework, DocumentLevelMetaData, Publisher};
+
+    #[test]
+    fn test_publisher_category_behavior() {
+        fn create_mock(category: CategoryOfPublisher) -> CommonSecurityAdvisoryFramework {
+            CommonSecurityAdvisoryFramework::builder()
+                .document(
+                    DocumentLevelMetaData::builder()
+                        .lang("de-DE")
+                        .publisher(Publisher::builder().category(category))
+                        .try_into()
+                        .unwrap(),
+                )
+                .try_into()
+                .unwrap()
+        }
+
+        // Test with Translator category (should error)
+        assert!(test_6_1_15_translator(&create_mock(CategoryOfPublisher::Translator)).is_err());
+
+        // Test with Discoverer category (should pass)
+        assert!(test_6_1_15_translator(&create_mock(CategoryOfPublisher::Discoverer)).is_ok());
+    }
+}
+
+mod csaf_21_custom_tests {
+    use super::*;
+    use crate::schema::csaf2_1::schema::{CommonSecurityAdvisoryFramework, DocumentLevelMetaData, Publisher};
+
+    #[test]
+    fn test_publisher_category_behavior() {
+        fn create_mock(category: CategoryOfPublisher) -> CommonSecurityAdvisoryFramework {
+            CommonSecurityAdvisoryFramework::builder()
+                .document(
+                    DocumentLevelMetaData::builder()
+                        .lang("de-DE")
+                        .publisher(Publisher::builder().category(category))
+                        .try_into()
+                        .unwrap(),
+                )
+                .try_into()
+                .unwrap()
+        }
+
+        // Test with Translator category (should error)
+        assert!(test_6_1_15_translator(&create_mock(CategoryOfPublisher::Translator)).is_err());
+
+        // Test with Discoverer category (should pass)
+        assert!(test_6_1_15_translator(&create_mock(CategoryOfPublisher::Discoverer)).is_ok());
     }
 }


### PR DESCRIPTION
Currently, we have multiple tests with code paths that are not covered by the provided test cases.

I would like to discuss if we want / need something custom unit tests to cover those code paths to increase our test coverage. As an example, I implemented this for test 6.1.15.

The test checks that for publisher category `translator`, the `source_lang` field must be filled. The current test cases cover: 
 * 01: doc has no lang and no source_lang -> invalid
 * 02: doc has lang but no source_lang -> invalid
 * 11: doc has no lang and sourcelang -> valid
 * 12: doc has lang and source_lang -> valid
 
All of those test cases have a publisher category of `publisher`. So an test implementation which does not even read the publisher category would wrongly pass our current test setup and then fail on the first "real" document provided to it which has no `source_lang` set.

This is a trivial example to highlight an ongoing issue in our codebases, similiar issues appear around parsing / failing to parse more complex data structures (and I suspect in other places, too).

These tests can serve as base to discuss this with the CSAF TC, with the long-term goal being that these variants are added to the main repo as test case json files.
 
 Also, ignore the concrete implementation, I just wanted to show my point.