### PR TITLE
fix: correct CsafHashAlgorithm imports

### DIFF
--- a/csaf-rs/src/csaf_traits.rs
+++ b/csaf-rs/src/csaf_traits.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf::types::csaf_datetime::CsafDateTime::{Invalid, Valid};
-pub(crate) use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
+use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
 use crate::csaf::types::csaf_version_number::{CsafVersionNumber, ValidVersionNumber};
 use crate::csaf2_1::ssvc_dp_selection_list::SelectionList;
 use crate::helpers::resolve_product_groups;

--- a/csaf-rs/src/validations/test_6_1_25.rs
+++ b/csaf-rs/src/validations/test_6_1_25.rs
@@ -1,6 +1,6 @@
+use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
 use crate::csaf_traits::{
-    CsafHashAlgorithm, CsafTrait, FileHashTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait,
-    ProductTreeTrait,
+    CsafTrait, FileHashTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait,
 };
 use crate::validation::ValidationError;
 use std::collections::HashMap;

--- a/csaf-rs/src/validations/test_6_2_08.rs
+++ b/csaf-rs/src/validations/test_6_2_08.rs
@@ -1,6 +1,5 @@
-use crate::csaf_traits::{
-    CsafHashAlgorithm, CsafTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait,
-};
+use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
+use crate::csaf_traits::{CsafTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
 use crate::validation::ValidationError;
 
 /// 6.2.8 Use of MD5 as the only Hash Algorithm

--- a/csaf-rs/src/validations/test_6_2_09.rs
+++ b/csaf-rs/src/validations/test_6_2_09.rs
@@ -1,6 +1,5 @@
-use crate::csaf_traits::{
-    CsafHashAlgorithm, CsafTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait,
-};
+use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
+use crate::csaf_traits::{CsafTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
 use crate::validation::ValidationError;
 
 /// 6.2.9 Use of SHA1 as the only Hash Algorithm


### PR DESCRIPTION
The same IDE function that failed for the CsafDocumentCategory imports also failed here.

This PR directly imports the type, instead of channeling the import through the trait.