### PR TITLE
chore: add infrastructure for additional tests

### DIFF
--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -1,0 +1,6 @@
+{
+  "testschema_version": "2.0",
+  "tests": [
+    
+  ]
+}

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -1,0 +1,6 @@
+{
+  "testschema_version": "2.1",
+  "tests": [
+
+  ]
+}

--- a/type-generator/src/main.rs
+++ b/type-generator/src/main.rs
@@ -43,12 +43,14 @@ fn main() -> Result<(), BuildError> {
     if args.create_test_definitions {
         _ = generate_testcases(
             "../csaf/csaf_2.0/test/validator/data/testcases.json",
+            "assets/tests/csaf_2.0/testcases.json",
             "csaf2_0/testcases.generated.rs",
             CsafVersion::V2_0,
             &args.target_folder,
         );
         _ = generate_testcases(
             "../csaf/csaf_2.1/test/validator/data/testcases.json",
+            "assets/tests/csaf_2.1/testcases.json",
             "csaf2_1/testcases.generated.rs",
             CsafVersion::V2_1,
             &args.target_folder,


### PR DESCRIPTION
this provides the capability to add additional test cases to our tests. They reside in the test-generator module and get incorporated into the usual test classes, so they are typesafe etc.