### PR TITLE
fix: add test 6.1.43,44 for CSAF 2.1, improve code structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,18 +86,18 @@ csaf-validator --csaf-version 2.1 --test-id 6.1.34 my-csaf-2-1-document.json
 
 ### Mandatory Tests
 
-| Test specification | 2.0 | 2.1 (experimental) |
-| --- | --- | --- |
-| 6.1.1 | :white_check_mark:  | :white_check_mark: |
-| 6.1.2 | :white_check_mark:  | :white_check_mark: |
-| 6.1.3 | :white_check_mark:  | :white_check_mark: |
-| 6.1.4 | :white_check_mark:  | :white_check_mark: |
-| 6.1.5 | :white_check_mark:  | :white_check_mark: |
-| 6.1.6 | | |
-| 6.1.7 | | |
-| 6.1.8 | :white_check_mark: | |
-| 6.1.9 | | |
-| 6.1.10 | | |
+| Test specification | 2.0                | 2.1 (experimental) |
+| --- |--------------------|--------------------|
+| 6.1.1 | :white_check_mark: | :white_check_mark: |
+| 6.1.2 | :white_check_mark: | :white_check_mark: |
+| 6.1.3 | :white_check_mark: | :white_check_mark: |
+| 6.1.4 | :white_check_mark: | :white_check_mark: |
+| 6.1.5 | :white_check_mark: | :white_check_mark: |
+| 6.1.6 |                    |                    |
+| 6.1.7 |                    |                    |
+| 6.1.8 | :white_check_mark: |                    |
+| 6.1.9 |                    |                    |
+| 6.1.10 |                    |                    |
 | 6.1.11 | :white_check_mark: | :white_check_mark: |
 | 6.1.12 | :white_check_mark: |                    |
 | 6.1.13 |                    |                    |
@@ -130,8 +130,8 @@ csaf-validator --csaf-version 2.1 --test-id 6.1.34 my-csaf-2-1-document.json
 | 6.1.40 |                    |                    |
 | 6.1.41 |                    |                    |
 | 6.1.42 |                    |                    |
-| 6.1.43 |                    |                    |
-| 6.1.44 |                    |                    |
+| 6.1.43 | :o:                | :white_check_mark: |
+| 6.1.44 | :o:                | :white_check_mark: |
 | 6.1.45 |                    |                    |
 | 6.1.46 |                    |                    |
 | 6.1.47 |                    |                    |

--- a/csaf-rs/src/csaf/types/csaf_product_id_helper_number.rs
+++ b/csaf-rs/src/csaf/types/csaf_product_id_helper_number.rs
@@ -1,0 +1,129 @@
+use crate::schema::csaf2_0::schema::ModelNumber as ModelNumber20;
+use crate::schema::csaf2_0::schema::SerialNumber as SerialNumber20;
+use crate::schema::csaf2_1::schema::ModelNumber as ModelNumber21;
+use crate::schema::csaf2_1::schema::SerialNumber as SerialNumber21;
+use std::fmt::Display;
+
+/// A helper struct to encapsulate the logic for counting unescaped '*' characters in product identification fields.
+/// This will be extended once we get to the CSAF 2.0 -> 2.1 converter
+struct ProductIdentificationHelperNumber(String);
+
+impl ProductIdentificationHelperNumber {
+    // Inlined for easier unit testability
+    #[inline]
+    fn count_unescaped_stars_impl(s: &str) -> u32 {
+        let mut escaped = false;
+        let mut count = 0u32;
+        for c in s.chars() {
+            match c {
+                '\\' => escaped = !escaped,
+                '*' if !escaped => count += 1,
+                _ => escaped = false,
+            }
+        }
+        count
+    }
+
+    /// Counts the number of unescaped '*' characters in a given string.
+    /// An asterisk is considered "unescaped" if it is not preceded by a backslash ('\\').
+    /// Consecutive backslashes alternate between escaping or not escaping characters.
+    ///
+    /// # Arguments
+    ///
+    /// * `s` - A string slice to be analyzed.
+    ///
+    /// # Returns
+    ///
+    /// Returns the number of unescaped '*' characters found in the string.
+    pub fn count_unescaped_stars(&self) -> u32 {
+        Self::count_unescaped_stars_impl(&self.0)
+    }
+}
+
+/// Wrapper for the CSAF 2.0 / 2.1 model number field, providing a method to count unescaped '*' characters.
+pub struct CsafModelNumber(ProductIdentificationHelperNumber);
+
+impl CsafModelNumber {
+    pub fn count_unescaped_stars(&self) -> u32 {
+        self.0.count_unescaped_stars()
+    }
+}
+
+impl Display for CsafModelNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.0.fmt(f)
+    }
+}
+
+impl From<&ModelNumber20> for CsafModelNumber {
+    fn from(value: &ModelNumber20) -> Self {
+        CsafModelNumber(ProductIdentificationHelperNumber(value.to_string()))
+    }
+}
+
+impl From<&ModelNumber21> for CsafModelNumber {
+    fn from(value: &ModelNumber21) -> Self {
+        CsafModelNumber(ProductIdentificationHelperNumber(value.to_string()))
+    }
+}
+
+impl From<&str> for CsafModelNumber {
+    fn from(value: &str) -> Self {
+        CsafModelNumber(ProductIdentificationHelperNumber(value.to_string()))
+    }
+}
+
+/// Wrapper for the CSAF 2.0 / 2.1 serial number field, providing a method to count unescaped '*' characters.
+pub struct CsafSerialNumber(ProductIdentificationHelperNumber);
+
+impl Display for CsafSerialNumber {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.0.fmt(f)
+    }
+}
+
+impl CsafSerialNumber {
+    pub fn count_unescaped_stars(&self) -> u32 {
+        self.0.count_unescaped_stars()
+    }
+}
+
+impl From<&SerialNumber20> for CsafSerialNumber {
+    fn from(value: &SerialNumber20) -> Self {
+        CsafSerialNumber(ProductIdentificationHelperNumber(value.to_string()))
+    }
+}
+
+impl From<&SerialNumber21> for CsafSerialNumber {
+    fn from(value: &SerialNumber21) -> Self {
+        CsafSerialNumber(ProductIdentificationHelperNumber(value.to_string()))
+    }
+}
+
+impl From<&str> for CsafSerialNumber {
+    fn from(value: &str) -> Self {
+        CsafSerialNumber(ProductIdentificationHelperNumber(value.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProductIdentificationHelperNumber as PIHNumber;
+
+    #[test]
+    fn test_count_unescaped_stars() {
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abcdef"), 0);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("*"), 1);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc*def"), 1);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc*def*ghi"), 2);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\*def"), 0);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\\\*def"), 1);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\\\\\*def"), 0);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\\\\\\\*def"), 1);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\\\\\*\\\\\\*def"), 0);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\\\*\\\\*def"), 2);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("\\*\\*\\*"), 0);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\*def*ghi"), 1);
+        assert_eq!(PIHNumber::count_unescaped_stars_impl("abc\\\\*def\\*ghi"), 1);
+    }
+}

--- a/csaf-rs/src/csaf/types/mod.rs
+++ b/csaf-rs/src/csaf/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod csaf_datetime;
 pub mod csaf_document_category;
 pub mod csaf_hash_algo;
+pub mod csaf_product_id_helper_number;
 pub mod csaf_version_number;
 pub mod csaf_vuln_metric;

--- a/csaf-rs/src/csaf2_0/csaf_implementations.rs
+++ b/csaf-rs/src/csaf2_0/csaf_implementations.rs
@@ -1,6 +1,7 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
+use crate::csaf::types::csaf_product_id_helper_number::{CsafModelNumber, CsafSerialNumber};
 use crate::csaf::types::csaf_version_number::CsafVersionNumber;
 use crate::csaf_traits::{
     BranchTrait, CategoryOfTheBranch as CategoryOfTheBranchTrait, ContentTrait, CsafTrait, CsafVersion, Cwe,
@@ -710,12 +711,16 @@ impl ProductIdentificationHelperTrait for HelperToIdentifyTheProduct {
         self.purl.as_ref().map(std::slice::from_ref)
     }
 
-    fn get_model_numbers(&self) -> Option<impl Iterator<Item = &String> + '_> {
-        self.model_numbers.as_ref().map(|v| v.iter().map(|x| x.deref()))
+    fn get_model_numbers(&self) -> Option<Vec<CsafModelNumber>> {
+        self.model_numbers
+            .as_ref()
+            .map(|v| v.iter().map(CsafModelNumber::from).collect())
     }
 
-    fn get_serial_numbers(&self) -> Option<impl Iterator<Item = &String> + '_> {
-        self.serial_numbers.as_ref().map(|v| v.iter().map(|x| x.deref()))
+    fn get_serial_numbers(&self) -> Option<Vec<CsafSerialNumber>> {
+        self.serial_numbers
+            .as_ref()
+            .map(|v| v.iter().map(CsafSerialNumber::from).collect())
     }
 
     fn get_hashes(&self) -> &Vec<Self::HashType> {

--- a/csaf-rs/src/csaf2_1/csaf_implementations.rs
+++ b/csaf-rs/src/csaf2_1/csaf_implementations.rs
@@ -1,6 +1,7 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
+use crate::csaf::types::csaf_product_id_helper_number::{CsafModelNumber, CsafSerialNumber};
 use crate::csaf::types::csaf_version_number::CsafVersionNumber;
 use crate::csaf_traits::{
     BranchTrait, CategoryOfTheBranch as CategoryOfTheBranchTrait, ContentTrait, CsafTrait, CsafVersion, Cwe,
@@ -622,12 +623,16 @@ impl ProductIdentificationHelperTrait for HelperToIdentifyTheProduct {
         self.purls.as_deref()
     }
 
-    fn get_model_numbers(&self) -> Option<impl Iterator<Item = &String> + '_> {
-        self.model_numbers.as_ref().map(|v| v.iter().map(|x| x.deref()))
+    fn get_model_numbers(&self) -> Option<Vec<CsafModelNumber>> {
+        self.model_numbers
+            .as_ref()
+            .map(|v| v.iter().map(CsafModelNumber::from).collect())
     }
 
-    fn get_serial_numbers(&self) -> Option<impl Iterator<Item = &String> + '_> {
-        self.serial_numbers.as_ref().map(|v| v.iter().map(|x| x.deref()))
+    fn get_serial_numbers(&self) -> Option<Vec<CsafSerialNumber>> {
+        self.serial_numbers
+            .as_ref()
+            .map(|v| v.iter().map(CsafSerialNumber::from).collect())
     }
 
     fn get_hashes(&self) -> &Vec<Self::HashType> {

--- a/csaf-rs/src/csaf_traits.rs
+++ b/csaf-rs/src/csaf_traits.rs
@@ -2,6 +2,7 @@ use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf::types::csaf_datetime::CsafDateTime::{Invalid, Valid};
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
+use crate::csaf::types::csaf_product_id_helper_number::{CsafModelNumber, CsafSerialNumber};
 use crate::csaf::types::csaf_version_number::{CsafVersionNumber, ValidVersionNumber};
 use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
 use crate::csaf2_1::ssvc_dp_selection_list::SelectionList;
@@ -1115,9 +1116,9 @@ pub trait ProductIdentificationHelperTrait {
     /// Returns the PURLs identifying the associated product.
     fn get_purls(&self) -> Option<&[String]>;
 
-    fn get_model_numbers(&self) -> Option<impl Iterator<Item = &String> + '_>;
+    fn get_model_numbers(&self) -> Option<Vec<CsafModelNumber>>;
 
-    fn get_serial_numbers(&self) -> Option<impl Iterator<Item = &String> + '_>;
+    fn get_serial_numbers(&self) -> Option<Vec<CsafSerialNumber>>;
 
     fn get_hashes(&self) -> &Vec<Self::HashType>;
 }

--- a/csaf-rs/src/helpers.rs
+++ b/csaf-rs/src/helpers.rs
@@ -34,30 +34,6 @@ where
     })
 }
 
-/// Counts the number of unescaped '*' characters in a given string.
-/// An asterisk is considered "unescaped" if it is not preceded by a backslash ('\\').
-/// Consecutive backslashes alternate between escaping or not escaping characters.
-///
-/// # Arguments
-///
-/// * `s` - A string slice to be analyzed.
-///
-/// # Returns
-///
-/// Returns the number of unescaped '*' characters found in the string.
-pub fn count_unescaped_stars(s: &str) -> u32 {
-    let mut escaped = false;
-    let mut count = 0u32;
-    for c in s.chars() {
-        match c {
-            '\\' => escaped = !escaped,
-            '*' if !escaped => count += 1,
-            _ => escaped = false,
-        }
-    }
-    count
-}
-
 #[derive(RustEmbed)]
 #[folder = "assets/ssvc_decision_points/"]
 #[include = "*.json"]

--- a/csaf-rs/src/validations/test_6_1_44.rs
+++ b/csaf-rs/src/validations/test_6_1_44.rs
@@ -1,10 +1,10 @@
+use crate::csaf::types::csaf_product_id_helper_number::CsafSerialNumber;
 use crate::csaf_traits::{CsafTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::helpers::count_unescaped_stars;
 use crate::validation::ValidationError;
 
-fn create_multiple_stars_error(path: &str, index: usize) -> ValidationError {
+fn create_multiple_stars_serial_number_error(number: &CsafSerialNumber, path: &str, index: usize) -> ValidationError {
     ValidationError {
-        message: "Serial number must not contain multiple unescaped asterisks (stars)".to_string(),
+        message: format!("Serial number '{number}' must not contain multiple unescaped asterisks (stars)"),
         instance_path: format!("{path}/product_identification_helper/serial_numbers/{index}"),
     }
 }
@@ -17,11 +17,11 @@ pub fn test_6_1_44_multiple_stars_in_serial_number(doc: &impl CsafTrait) -> Resu
             if let Some(helper) = product.get_product_identification_helper()
                 && let Some(serial_numbers) = helper.get_serial_numbers()
             {
-                for (index, serial_number) in serial_numbers.enumerate() {
-                    if count_unescaped_stars(serial_number) > 1 {
+                for (index, serial_number) in serial_numbers.iter().enumerate() {
+                    if serial_number.count_unescaped_stars() > 1 {
                         errors
-                            .get_or_insert_with(Vec::new)
-                            .push(create_multiple_stars_error(path, index));
+                            .get_or_insert_default()
+                            .push(create_multiple_stars_serial_number_error(serial_number, path, index));
                     }
                 }
             }
@@ -49,18 +49,28 @@ mod tests {
 
     #[test]
     fn test_test_6_1_44() {
+        // Ideas for supplementary test cases:
+        // S01: 1 serial number, no stars
+
         // Only CSAF 2.1 has this test with 5 test cases (2 error cases, 3 success cases)
         TESTS_2_1.test_6_1_44.expect(
-            Err(vec![create_multiple_stars_error(
+            // Case 01: One serial number with two unescaped stars
+            Err(vec![create_multiple_stars_serial_number_error(
+                &CsafSerialNumber::from("P*A*"),
                 "/product_tree/full_product_names/0",
                 0,
             )]),
-            Err(vec![create_multiple_stars_error(
+            // Case 02: One serial number with one escaped and two unescaped stars
+            Err(vec![create_multiple_stars_serial_number_error(
+                &CsafSerialNumber::from("*P*\\*?*"),
                 "/product_tree/full_product_names/0",
                 0,
             )]),
+            // Case 03: 5 serial numbers, all end with one unescaped star (and some '?' in between)
             Ok(()),
+            // Case 04: 1 serial number, starts with unescaped star, 3 escaped stars
             Ok(()),
+            // Case 05: 1 serial number, 2 escaped stars, one escaped backslash
             Ok(()),
         );
     }


### PR DESCRIPTION
Resolves #376 and #377

This PR: 
- adds the CsafModelNumber and CsafSerialNumber types
- binds the count_unescaped_stars to these types
- adds unit tests for this method
- uses the methods in the respective test files

Test coverage is fine, especially not that count_unescaped_stars has been extensivly covered