### PR TITLE
feat: add test 6.1.34

### DIFF
--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -7156,6 +7156,7 @@ impl<
         &self,
         case_01: Result<(), Vec<crate::validation::ValidationError>>,
         case_02: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s01: Result<(), Vec<crate::validation::ValidationError>>,
         case_11: Result<(), Vec<crate::validation::ValidationError>>,
     ) {
         let test_cases = vec![
@@ -7179,7 +7180,17 @@ impl<
             ::new(serde_json::from_str:: < serde_json::Value > (& content)
             .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
             "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-34-02.json", "02", e))) },
-            case_02), ("11", { let path =
+            case_02), ("s01", { let path =
+            "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-34-s01.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_1-6-1-34-s01.json", "s01", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_1-6-1-34-s01.json", "s01", e))) }, case_s01),
+            ("11", { let path =
             "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-34-11.json";
             let content = std::fs::read_to_string(path).unwrap_or_else(| e |
             panic!("Failed to load {} (case {}): {}",

--- a/csaf-rs/src/validations/test_6_1_34.rs
+++ b/csaf-rs/src/validations/test_6_1_34.rs
@@ -11,16 +11,20 @@ fn create_excessive_branch_depth_error(branch_index: usize, path: &str) -> Valid
 }
 
 pub fn test_6_1_34_branches_recursion_depth(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    if let Some(tree) = doc.get_product_tree().as_ref()
-        && let Some(branches) = tree.get_branches()
-    {
-        for (i, branch) in branches.iter().enumerate() {
-            if let Some(path) = branch.find_excessive_branch_depth(MAX_DEPTH) {
-                return Err(vec![create_excessive_branch_depth_error(i, &path)]);
-            }
+    // TODO This can be wasSkipped in the future
+    let Some(branches) = doc.get_product_tree().as_ref().and_then(|t| t.get_branches()) else {
+        return Ok(());
+    };
+
+    let mut errors: Option<Vec<ValidationError>> = None;
+    for (i, branch) in branches.iter().enumerate() {
+        if let Some(path) = branch.find_excessive_branch_depth(MAX_DEPTH) {
+            errors
+                .get_or_insert_default()
+                .push(create_excessive_branch_depth_error(i, &path));
         }
     }
-    Ok(())
+    errors.map_or(Ok(()), Err)
 }
 
 impl crate::test_validation::TestValidator<crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework>
@@ -41,24 +45,33 @@ mod tests {
 
     #[test]
     fn test_test_6_1_34() {
-        // Only CSAF 2.1 has this test with 3 test cases
+        // Case 01: One long branch structure with depth of 31
+        // Case 02: More complex branch structure with 3 sub-branches, one of which has depth of 31
+        // Case S01: Two long branch structures with depth of 31
+        // Case 11: One long branch structure with depth of 30
+
+        let one_too_long_branch_path = "/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0";
+        let one_too_long_branch_error = Err(vec![create_excessive_branch_depth_error(0, one_too_long_branch_path)]);
+        let two_too_long_branches_error = Err(vec![
+            create_excessive_branch_depth_error(0, one_too_long_branch_path),
+            create_excessive_branch_depth_error(1, one_too_long_branch_path),
+        ]);
+        let more_complex_too_long_branch_error = Err(vec![create_excessive_branch_depth_error(
+            0,
+            "/branches/0/branches/1/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
+                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0",
+        )]);
         TESTS_2_1.test_6_1_34.expect(
-            Err(vec![create_excessive_branch_depth_error(
-                0,
-                "/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0",
-            )]),
-            Err(vec![create_excessive_branch_depth_error(
-                0,
-                "/branches/0/branches/1/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
-                /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0",
-            )]),
+            one_too_long_branch_error,
+            more_complex_too_long_branch_error,
+            two_too_long_branches_error,
             Ok(()),
         );
     }

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-34-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-34-s01.json
@@ -1,0 +1,413 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Mandatory Test: Branches Recursion Depth (failing supplementary example 1 - 2 items in root branches property)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-1-34-S01",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "branches": [
+                  {
+                    "branches": [
+                      {
+                        "branches": [
+                          {
+                            "branches": [
+                              {
+                                "branches": [
+                                  {
+                                    "branches": [
+                                      {
+                                        "branches": [
+                                          {
+                                            "branches": [
+                                              {
+                                                "branches": [
+                                                  {
+                                                    "branches": [
+                                                      {
+                                                        "branches": [
+                                                          {
+                                                            "branches": [
+                                                              {
+                                                                "branches": [
+                                                                  {
+                                                                    "branches": [
+                                                                      {
+                                                                        "branches": [
+                                                                          {
+                                                                            "branches": [
+                                                                              {
+                                                                                "branches": [
+                                                                                  {
+                                                                                    "branches": [
+                                                                                      {
+                                                                                        "branches": [
+                                                                                          {
+                                                                                            "branches": [
+                                                                                              {
+                                                                                                "branches": [
+                                                                                                  {
+                                                                                                    "branches": [
+                                                                                                      {
+                                                                                                        "branches": [
+                                                                                                          {
+                                                                                                            "branches": [
+                                                                                                              {
+                                                                                                                "branches": [
+                                                                                                                  {
+                                                                                                                    "branches": [
+                                                                                                                      {
+                                                                                                                        "branches": [
+                                                                                                                          {
+                                                                                                                            "branches": [
+                                                                                                                              {
+                                                                                                                                "category": "product_name",
+                                                                                                                                "name": "branches",
+                                                                                                                                "product": {
+                                                                                                                                  "name": "Example Company uses a deeply nested structure for this hypothetical product which seem unnecessary and more or less unrealistic but they are testing the limits and fail the test with 31 branches",
+                                                                                                                                  "product_id": "CSAFPID-9080700"
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "category": "product_family",
+                                                                                                                            "name": "31"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "category": "product_family",
+                                                                                                                        "name": "with"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "category": "product_family",
+                                                                                                                    "name": "test"
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                "category": "product_family",
+                                                                                                                "name": "the"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "category": "product_family",
+                                                                                                            "name": "fail"
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "category": "product_family",
+                                                                                                        "name": "and"
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "category": "product_family",
+                                                                                                    "name": "limits"
+                                                                                                  }
+                                                                                                ],
+                                                                                                "category": "product_family",
+                                                                                                "name": "the"
+                                                                                              }
+                                                                                            ],
+                                                                                            "category": "product_family",
+                                                                                            "name": "testing"
+                                                                                          }
+                                                                                        ],
+                                                                                        "category": "product_family",
+                                                                                        "name": "are"
+                                                                                      }
+                                                                                    ],
+                                                                                    "category": "product_family",
+                                                                                    "name": "they"
+                                                                                  }
+                                                                                ],
+                                                                                "category": "product_family",
+                                                                                "name": "but"
+                                                                              }
+                                                                            ],
+                                                                            "category": "product_family",
+                                                                            "name": "unrealistic"
+                                                                          }
+                                                                        ],
+                                                                        "category": "product_family",
+                                                                        "name": "less"
+                                                                      }
+                                                                    ],
+                                                                    "category": "product_family",
+                                                                    "name": "or"
+                                                                  }
+                                                                ],
+                                                                "category": "product_family",
+                                                                "name": "more"
+                                                              }
+                                                            ],
+                                                            "category": "product_family",
+                                                            "name": "and"
+                                                          }
+                                                        ],
+                                                        "category": "product_family",
+                                                        "name": "unnecessary"
+                                                      }
+                                                    ],
+                                                    "category": "product_family",
+                                                    "name": "seem"
+                                                  }
+                                                ],
+                                                "category": "product_family",
+                                                "name": "which"
+                                              }
+                                            ],
+                                            "category": "product_family",
+                                            "name": "product"
+                                          }
+                                        ],
+                                        "category": "product_family",
+                                        "name": "hypothetical"
+                                      }
+                                    ],
+                                    "category": "product_family",
+                                    "name": "this"
+                                  }
+                                ],
+                                "category": "product_family",
+                                "name": "for"
+                              }
+                            ],
+                            "category": "product_family",
+                            "name": "structure"
+                          }
+                        ],
+                        "category": "product_family",
+                        "name": "nested"
+                      }
+                    ],
+                    "category": "product_family",
+                    "name": "deeply"
+                  }
+                ],
+                "category": "product_family",
+                "name": "a"
+              }
+            ],
+            "category": "product_family",
+            "name": "uses"
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      },
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "branches": [
+                  {
+                    "branches": [
+                      {
+                        "branches": [
+                          {
+                            "branches": [
+                              {
+                                "branches": [
+                                  {
+                                    "branches": [
+                                      {
+                                        "branches": [
+                                          {
+                                            "branches": [
+                                              {
+                                                "branches": [
+                                                  {
+                                                    "branches": [
+                                                      {
+                                                        "branches": [
+                                                          {
+                                                            "branches": [
+                                                              {
+                                                                "branches": [
+                                                                  {
+                                                                    "branches": [
+                                                                      {
+                                                                        "branches": [
+                                                                          {
+                                                                            "branches": [
+                                                                              {
+                                                                                "branches": [
+                                                                                  {
+                                                                                    "branches": [
+                                                                                      {
+                                                                                        "branches": [
+                                                                                          {
+                                                                                            "branches": [
+                                                                                              {
+                                                                                                "branches": [
+                                                                                                  {
+                                                                                                    "branches": [
+                                                                                                      {
+                                                                                                        "branches": [
+                                                                                                          {
+                                                                                                            "branches": [
+                                                                                                              {
+                                                                                                                "branches": [
+                                                                                                                  {
+                                                                                                                    "branches": [
+                                                                                                                      {
+                                                                                                                        "branches": [
+                                                                                                                          {
+                                                                                                                            "branches": [
+                                                                                                                              {
+                                                                                                                                "category": "product_name",
+                                                                                                                                "name": "branches",
+                                                                                                                                "product": {
+                                                                                                                                  "name": "Example Company uses a deeply nested structure for this hypothetical product which seem unnecessary and more or less unrealistic but they are testing the limits and fail the test with 31 branches",
+                                                                                                                                  "product_id": "CSAFPID-9080700"
+                                                                                                                                }
+                                                                                                                              }
+                                                                                                                            ],
+                                                                                                                            "category": "product_family",
+                                                                                                                            "name": "31"
+                                                                                                                          }
+                                                                                                                        ],
+                                                                                                                        "category": "product_family",
+                                                                                                                        "name": "with"
+                                                                                                                      }
+                                                                                                                    ],
+                                                                                                                    "category": "product_family",
+                                                                                                                    "name": "test"
+                                                                                                                  }
+                                                                                                                ],
+                                                                                                                "category": "product_family",
+                                                                                                                "name": "the"
+                                                                                                              }
+                                                                                                            ],
+                                                                                                            "category": "product_family",
+                                                                                                            "name": "fail"
+                                                                                                          }
+                                                                                                        ],
+                                                                                                        "category": "product_family",
+                                                                                                        "name": "and"
+                                                                                                      }
+                                                                                                    ],
+                                                                                                    "category": "product_family",
+                                                                                                    "name": "limits"
+                                                                                                  }
+                                                                                                ],
+                                                                                                "category": "product_family",
+                                                                                                "name": "the"
+                                                                                              }
+                                                                                            ],
+                                                                                            "category": "product_family",
+                                                                                            "name": "testing"
+                                                                                          }
+                                                                                        ],
+                                                                                        "category": "product_family",
+                                                                                        "name": "are"
+                                                                                      }
+                                                                                    ],
+                                                                                    "category": "product_family",
+                                                                                    "name": "they"
+                                                                                  }
+                                                                                ],
+                                                                                "category": "product_family",
+                                                                                "name": "but"
+                                                                              }
+                                                                            ],
+                                                                            "category": "product_family",
+                                                                            "name": "unrealistic"
+                                                                          }
+                                                                        ],
+                                                                        "category": "product_family",
+                                                                        "name": "less"
+                                                                      }
+                                                                    ],
+                                                                    "category": "product_family",
+                                                                    "name": "or"
+                                                                  }
+                                                                ],
+                                                                "category": "product_family",
+                                                                "name": "more"
+                                                              }
+                                                            ],
+                                                            "category": "product_family",
+                                                            "name": "and"
+                                                          }
+                                                        ],
+                                                        "category": "product_family",
+                                                        "name": "unnecessary"
+                                                      }
+                                                    ],
+                                                    "category": "product_family",
+                                                    "name": "seem"
+                                                  }
+                                                ],
+                                                "category": "product_family",
+                                                "name": "which"
+                                              }
+                                            ],
+                                            "category": "product_family",
+                                            "name": "product"
+                                          }
+                                        ],
+                                        "category": "product_family",
+                                        "name": "hypothetical"
+                                      }
+                                    ],
+                                    "category": "product_family",
+                                    "name": "this"
+                                  }
+                                ],
+                                "category": "product_family",
+                                "name": "for"
+                              }
+                            ],
+                            "category": "product_family",
+                            "name": "structure"
+                          }
+                        ],
+                        "category": "product_family",
+                        "name": "nested"
+                      }
+                    ],
+                    "category": "product_family",
+                    "name": "deeply"
+                  }
+                ],
+                "category": "product_family",
+                "name": "a"
+              }
+            ],
+            "category": "product_family",
+            "name": "uses"
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      }
+    ]
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -307,6 +307,16 @@
           "valid": true
         }
       ]
+    },
+    {
+      "id": "6.1.34",
+      "group": "mandatory",
+      "failures": [
+        {
+          "name": "mandatory/csaf-rs_csaf-csaf_2_1-6-1-34-s01.json",
+          "valid": false
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Resolves #367 

This PR:
* improves code structure & documentation
* aligns the test behaviour with the prose in the standard
* adds a test for that improved behaviour

> For each product defined under /product_tree/branches[] it MUST be tested that the complete JSON path does not contain more than 30 instances of branches.

So far, we only checked until we found the first branch with a depth > 30. Now we check all "root" branches, as described in the prose, and then return an error for each root branch with depth > 30.

Please discuss if you see value in a more verbose error generation, i.e. if we should return an error for each time a sub-branch of a branch hits the depth limit. For example: The branch at index 0 is a long line until a branch depth of 29. There, it splits into three branches: first with length 2, second with length 1, third with length two. 

This would currently generate one error, but one could argue that generating two errors would also make sense.