### PR TITLE
feat: turn 6.1.26 unit test into test case jsons

### DIFF
--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -3349,6 +3349,9 @@ impl<
         case_02: Result<(), Vec<crate::validation::ValidationError>>,
         case_03: Result<(), Vec<crate::validation::ValidationError>>,
         case_04: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s01: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s02: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s03: Result<(), Vec<crate::validation::ValidationError>>,
         case_11: Result<(), Vec<crate::validation::ValidationError>>,
         case_12: Result<(), Vec<crate::validation::ValidationError>>,
     ) {
@@ -3393,7 +3396,37 @@ impl<
             ::new(serde_json::from_str:: < serde_json::Value > (& content)
             .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
             "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-04.json", "04", e))) },
-            case_04), ("11", { let path =
+            case_04), ("s01", { let path =
+            "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s01.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s01.json", "s01", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s01.json", "s01", e))) }, case_s01),
+            ("s02", { let path =
+            "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s02.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s02.json", "s02", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s02.json", "s02", e))) }, case_s02),
+            ("s03", { let path =
+            "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s03.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s03.json", "s03", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s03.json", "s03", e))) }, case_s03),
+            ("11", { let path =
             "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-11.json";
             let content = std::fs::read_to_string(path).unwrap_or_else(| e |
             panic!("Failed to load {} (case {}): {}",

--- a/csaf-rs/src/validations/test_6_1_26.rs
+++ b/csaf-rs/src/validations/test_6_1_26.rs
@@ -147,11 +147,29 @@ mod tests {
             &CsafVersion::X21,
         )]);
 
+        // Supplementary test cases
+        // CSAF 2.1 categories that should fail on CSAF 2.0
+        let deprecated_sec_advisory_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
+            &CsafDocumentCategory::from("csaf_deprecated_security_advisory"),
+            &CsafVersion::X20,
+        )]);
+        let withdrawn_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
+            &CsafDocumentCategory::from("csaf_withdrawn"),
+            &CsafVersion::X20,
+        )]);
+        let superseded_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
+            &CsafDocumentCategory::from("csaf_superseded"),
+            &CsafVersion::X20,
+        )]);
+
         TESTS_2_0.test_6_1_26.expect(
             case_01_shared.clone(),
             case_02_csaf20,
             case_03_csaf20,
             case_04_csaf20,
+            deprecated_sec_advisory_csaf20,
+            withdrawn_csaf20,
+            superseded_csaf20,
             Ok(()),
             Ok(()),
         );
@@ -185,15 +203,5 @@ mod tests {
         assert!(validate_document_category(&CsafDocumentCategory::from("Superseded"), &version).is_err());
         assert!(validate_document_category(&CsafDocumentCategory::from("V_eX"), &version).is_err());
         assert!(validate_document_category(&CsafDocumentCategory::from("veX"), &version).is_err());
-    }
-
-    #[test]
-    fn test_csaf_21_known_categories_fail_on_csaf_20() {
-        let version_20 = CsafVersion::X20;
-        assert!(
-            validate_document_category(&CsafDocumentCategory::CsafDeprecatedSecurityAdvisory, &version_20).is_err()
-        );
-        assert!(validate_document_category(&CsafDocumentCategory::CsafWithdrawn, &version_20).is_err());
-        assert!(validate_document_category(&CsafDocumentCategory::CsafSuperseded, &version_20).is_err());
     }
 }

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s01.json
@@ -1,0 +1,27 @@
+{
+  "document": {
+    "category": "csaf_deprecated_security_advisory",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Mandatory test 6.1.26: CSAF 2.1 category csaf_deprecated_security_advisory fails on CSAF 2.0",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-1-26-S01",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s02.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s02.json
@@ -1,0 +1,27 @@
+{
+  "document": {
+    "category": "csaf_withdrawn",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Mandatory test 6.1.26: CSAF 2.1 category csaf_withdrawn fails on CSAF 2.0",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-1-26-S02",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s03.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s03.json
@@ -1,0 +1,27 @@
+{
+  "document": {
+    "category": "csaf_superseded",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Mandatory test 6.1.26: CSAF 2.1 category csaf_superseded fails on CSAF 2.0",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-1-26-S03",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -251,6 +251,24 @@
       ]
     },
     {
+      "id": "6.1.26",
+      "group": "mandatory",
+      "failures": [
+        {
+          "name": "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s01.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s02.json",
+          "valid": false
+        },
+        {
+          "name": "mandatory/csaf-rs_csaf-csaf_2_0-6-1-26-s03.json",
+          "valid": false
+        }
+      ]
+    },
+    {
       "id": "6.1.27.5",
       "group": "mandatory",
       "failures": [


### PR DESCRIPTION
Resolves #359 

This PR: 
* transforms the unit test that ensured that the known categories added in CSAF 2.1 (deprecated_security_advisory, withdrawn, superseded) fail the test on CSAF 2.0 into test case jsons
