### PR TITLE
feat: add test 6.2.14

### DIFF
--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -48,12 +48,12 @@ impl ValidCsafLanguage {
     /// Gets the "reasons" a language tag is private use.
     ///
     /// If there are reasons this tag is private, they are inherently ordered to match the order in the tag, i.e.
-    /// 1. [PrivateUseReason::PrivateUsePrimaryLangSubtag] (exp. `qaa`)
-    /// 2. [PrivateUseReason::PrivateUseScriptSubtag] (exp. `Qaaa`)
-    /// 3. [PrivateUseReason::PrivateUseRegionSubtag] (exp. `QM`)
-    /// 4. [PrivateUseReason::PrivateUseSubtag] (exp. `x-private-use`)
+    /// 1. [PrivateUseReason::PrivateUsePrimaryLangSubtag] (e.g. `qaa`)
+    /// 2. [PrivateUseReason::PrivateUseScriptSubtag] (e.g. `Qaaa`)
+    /// 3. [PrivateUseReason::PrivateUseRegionSubtag] (e.g. `QM`)
+    /// 4. [PrivateUseReason::PrivateUseSubtag] (e.g. `x-private-use`)
     ///
-    /// If the language tag is a "only private use"  tag (exp. `x-private-use`), only a [PrivateUseReason::PrivateUseSubtag] will be
+    /// If the language tag is a "standalone" private use tag (e.g. `x-private-use`), only a [PrivateUseReason::PrivateUseSubtag] will be
     /// returned.
     ///
     /// Returns:
@@ -104,6 +104,21 @@ pub enum PrivateUseReason {
     PrivateUsePrimaryLangSubtag(String),
     PrivateUseScriptSubtag(String),
     PrivateUseRegionSubtag(String),
+}
+
+/// So far, only used during 6.2.14, if we get more use cases for it, we should consider moving
+/// this into the specific test.
+impl Display for PrivateUseReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Private use subtag '{subtag}'"),
+            PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => {
+                write!(f, "Private use primary language subtag '{primary_lang}'")
+            },
+            PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Private use script subtag '{script}'"),
+            PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Private use region subtag '{region}'"),
+        }
+    }
 }
 
 impl Deref for ValidCsafLanguage {

--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -8,7 +8,7 @@ use std::ops::Deref;
 /// Newtype wrapper around [`oxilangtag::LanguageTag`] representing a valid CSAF language tag.
 ///
 /// This includes regular language tags (e.g. `en-US`), the default language tag (`i-default`),
-/// and private use language tags (e.g. `x-private`, `de-x-foo-bar`).
+/// and private-use language tags (e.g. `x-private`, `de-x-foo-bar`).
 ///
 /// Exposes the API of [`oxilangtag::LanguageTag`] and some additional utility methods for validation tests.
 #[derive(Debug, Clone)]
@@ -36,8 +36,8 @@ impl ValidCsafLanguage {
         self.0.as_str().eq_ignore_ascii_case("i-default")
     }
 
-    /// Checks if this language tag contains a private use component (e.g. `x-private` or `de-x-foo`)
-    /// or if the primary language, script or region subtag itself is registered as private use (e.g. `qtx` from `qaa..qtz`).
+    /// Checks if this language tag contains a private-use subtag (e.g. `x-private` or `de-x-foo`)
+    /// or if the primary language, script or region subtag itself is registered as private-use (e.g. `qtx` from `qaa..qtz`).
     pub fn is_private_use(&self) -> bool {
         self.0.private_use().is_some()
             || is_language_private_use(self.0.primary_language())
@@ -45,7 +45,7 @@ impl ValidCsafLanguage {
             || self.0.region().is_some_and(is_region_private_use)
     }
 
-    /// Gets the "reasons" a language tag is private use.
+    /// Gets the "reasons" a language tag is private-use.
     ///
     /// If there are reasons this tag is private, they are inherently ordered to match the order in the tag, i.e.
     /// 1. [PrivateUseReason::PrivateUsePrimaryLangSubtag] (e.g. `qaa`)
@@ -53,13 +53,13 @@ impl ValidCsafLanguage {
     /// 3. [PrivateUseReason::PrivateUseRegionSubtag] (e.g. `QM`)
     /// 4. [PrivateUseReason::PrivateUseSubtag] (e.g. `x-private-use`)
     ///
-    /// If the language tag is a "standalone" private use tag (e.g. `x-private-use`), only a [PrivateUseReason::PrivateUseSubtag] will be
+    /// If the language tag is a "standalone" private-use tag (e.g. `x-private-use`), only a [PrivateUseReason::PrivateUseSubtag] will be
     /// returned.
     ///
     /// Returns:
-    /// * `Some(Vec<PrivateUseReason>)` if the language tag is private use, with the vector containing
-    ///   the specific [PrivateUseReason]'s listed above
-    /// * `None` if the language tag is not private use
+    /// * `Some(Vec<PrivateUseReason>)` if the language tag is private-use, with the vector containing
+    ///   the specific [PrivateUseReason] values listed above
+    /// * `None` if the language tag is not private-use
     pub fn get_private_use(&self) -> Option<Vec<PrivateUseReason>> {
         let mut result: Option<Vec<PrivateUseReason>> = None;
         if is_language_private_use(self.0.primary_language()) {
@@ -111,12 +111,12 @@ pub enum PrivateUseReason {
 impl Display for PrivateUseReason {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Private use subtag '{subtag}'"),
+            PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Private-use subtag '{subtag}'"),
             PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => {
-                write!(f, "Private use primary language subtag '{primary_lang}'")
+                write!(f, "Private-use primary language subtag '{primary_lang}'")
             },
-            PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Private use script subtag '{script}'"),
-            PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Private use region subtag '{region}'"),
+            PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Private-use script subtag '{script}'"),
+            PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Private-use region subtag '{region}'"),
         }
     }
 }
@@ -171,7 +171,7 @@ mod tests {
     #[case("En", true)]
     // with region
     #[case("en-US", true)]
-    // with private use
+    // with private-use
     #[case("en-x-private", true)]
     // not en
     #[case("es", false)]
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[rstest]
-    // private-use extension
+    // private-use subtag
     #[case("x-private", true)]
     #[case("en-x-foo", true)]
     // private-use primary language subtag (qaa..qtz)
@@ -201,7 +201,7 @@ mod tests {
     // private-use region subtag (XA..XZ, ZZ)
     #[case("en-XA", true)]
     #[case("en-ZZ", true)]
-    // not private use
+    // not private-use
     #[case("en", false)]
     #[case("en-US", false)]
     #[case("fr-Latn", false)]
@@ -216,16 +216,16 @@ mod tests {
     }
 
     #[rstest]
-    // not private use
+    // not private-use
     #[case("en-US", None)]
     #[case("i-default", None)]
-    // private use primary language subtag
+    // private-use primary language subtag
     #[case("qaa", Some(vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string())]))]
-    // private use script subtag
+    // private-use script subtag
     #[case("en-Qaaa", Some(vec![PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string())]))]
-    // private use region subtag
+    // private-use region subtag
     #[case("en-QM", Some(vec![PrivateUseReason::PrivateUseRegionSubtag("QM".to_string())]))]
-    // private use extension subtag
+    // private-use subtag
     #[case("x-private-use", Some(vec![PrivateUseReason::PrivateUseSubtag("x-private-use".to_string())]))]
     // two reasons combined
     #[case("qaa-Qaaa", Some(vec![

--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -55,7 +55,7 @@ impl ValidCsafLanguage {
     ///
     /// Returns:
     /// * `Some(Vec<PrivateUseReason>)` if the language tag is private use, with the vector containing
-    /// the specific [PrivateUseReason]'s listed above
+    ///   the specific [PrivateUseReason]'s listed above
     /// * `None` if the language tag is not private use
     pub fn get_private_use(&self) -> Option<Vec<PrivateUseReason>> {
         let mut result: Option<Vec<PrivateUseReason>> = None;

--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -45,10 +45,48 @@ impl ValidCsafLanguage {
             || self.0.region().is_some_and(is_region_private_use)
     }
 
+    /// Collects the "reasons" are language tag is private use.
+    ///
+    /// If there are reasons this tag is private, they are inherently ordered to match the order in the tag, i.e.
+    /// 1. Primary Language (exp. `qaa`)
+    /// 2. Script (exp. `Qaaa`)
+    /// 3. Region (exp. `QM`)
+    /// 4. Dedicated Private Use Tag (exp. `x-private-use`)
+    ///
+    /// Returns:
+    /// * `Some(Vec<PrivateUseReason>)` if the language tag is private use, with the vector containing
+    /// the specific [PrivateUseReason]'s listed above
+    /// * `None` if the language tag is not private use
+    pub fn get_private_use(&self) -> Option<Vec<PrivateUseReason>> {
+        let mut result: Option<Vec<PrivateUseReason>> = None;
+        if is_language_private_use(self.0.primary_language()) {
+            result.get_or_insert_default().push(PrivateUseReason::PrivateUsePrimaryLangSubtag(self.0.primary_language().to_string()));
+        }
+        if self.0.script().is_some_and(is_script_private_use) {
+            result.get_or_insert_default().push(PrivateUseReason::PrivateUseScriptSubtag(self.0.script().unwrap().to_string()));
+        }
+        if self.0.region().is_some_and(is_region_private_use) {
+            result.get_or_insert_default().push(PrivateUseReason::PrivateUseRegionSubtag(self.0.region().unwrap().to_string()));
+        }
+        if let Some(private_use_subtag) = self.0.private_use() {
+            result.get_or_insert_default().push(PrivateUseReason::PrivateUseSubtag(private_use_subtag.to_string()));
+        }
+        result
+    }
+
     /// Checks if the primary language subtag is case-insensitive `"en"` (English).
     pub fn is_english(&self) -> bool {
         self.0.primary_language().eq_ignore_ascii_case("en")
     }
+}
+
+/// Utility enum used in the return value in [ValidCsafLanguage::get_private_use]
+#[derive(Debug, PartialEq)]
+pub enum PrivateUseReason {
+    PrivateUseSubtag(String),
+    PrivateUsePrimaryLangSubtag(String),
+    PrivateUseScriptSubtag(String),
+    PrivateUseRegionSubtag(String),
 }
 
 impl Deref for ValidCsafLanguage {
@@ -143,5 +181,29 @@ mod tests {
             expected,
             "Unexpected is_private_use() result for '{input}'"
         );
+    }
+
+    #[rstest]
+    // not private use
+    #[case("en-US", None)]
+    #[case("i-default", None)]
+    // private use primary language subtag
+    #[case("qaa", Some(vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string())]))]
+    // private use script subtag
+    #[case("en-Qaaa", Some(vec![PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string())]))]
+    // private use region subtag
+    #[case("en-QM", Some(vec![PrivateUseReason::PrivateUseRegionSubtag("QM".to_string())]))]
+    // private use extension subtag
+    #[case("x-private-use", Some(vec![PrivateUseReason::PrivateUseSubtag("x-private-use".to_string())]))]
+    // multiple reasons combined
+    #[case("qaa-Qaaa-QM-x-private-use", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),
+        PrivateUseReason::PrivateUseRegionSubtag("QM".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-private-use".to_string()),
+    ]))]
+    fn test_get_private_use(#[case] input: &str, #[case] expected: Option<Vec<PrivateUseReason>>) {
+        let lang = ValidCsafLanguage::new_for_tests(input);
+        assert_eq!(lang.get_private_use(), expected, "Mismatch for '{input}'");
     }
 }

--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -45,13 +45,16 @@ impl ValidCsafLanguage {
             || self.0.region().is_some_and(is_region_private_use)
     }
 
-    /// Collects the "reasons" are language tag is private use.
+    /// Gets the "reasons" a language tag is private use.
     ///
     /// If there are reasons this tag is private, they are inherently ordered to match the order in the tag, i.e.
-    /// 1. Primary Language (exp. `qaa`)
-    /// 2. Script (exp. `Qaaa`)
-    /// 3. Region (exp. `QM`)
-    /// 4. Dedicated Private Use Tag (exp. `x-private-use`)
+    /// 1. [PrivateUseReason::PrivateUsePrimaryLangSubtag] (exp. `qaa`)
+    /// 2. [PrivateUseReason::PrivateUseScriptSubtag] (exp. `Qaaa`)
+    /// 3. [PrivateUseReason::PrivateUseRegionSubtag] (exp. `QM`)
+    /// 4. [PrivateUseReason::PrivateUseSubtag] (exp. `x-private-use`)
+    ///
+    /// If the language tag is a "only private use"  tag (exp. `x-private-use`), only a [PrivateUseReason::PrivateUseSubtag] will be
+    /// returned.
     ///
     /// Returns:
     /// * `Some(Vec<PrivateUseReason>)` if the language tag is private use, with the vector containing
@@ -66,19 +69,19 @@ impl ValidCsafLanguage {
                     self.0.primary_language().to_string(),
                 ));
         }
-        if self.0.script().is_some_and(is_script_private_use) {
+        if let Some(script) = self.0.script()
+            && is_script_private_use(script)
+        {
             result
                 .get_or_insert_default()
-                .push(PrivateUseReason::PrivateUseScriptSubtag(
-                    self.0.script().unwrap().to_string(),
-                ));
+                .push(PrivateUseReason::PrivateUseScriptSubtag(script.to_string()));
         }
-        if self.0.region().is_some_and(is_region_private_use) {
+        if let Some(region) = self.0.region()
+            && is_region_private_use(region)
+        {
             result
                 .get_or_insert_default()
-                .push(PrivateUseReason::PrivateUseRegionSubtag(
-                    self.0.region().unwrap().to_string(),
-                ));
+                .push(PrivateUseReason::PrivateUseRegionSubtag(region.to_string()));
         }
         if let Some(private_use_subtag) = self.0.private_use() {
             result
@@ -209,7 +212,49 @@ mod tests {
     #[case("en-QM", Some(vec![PrivateUseReason::PrivateUseRegionSubtag("QM".to_string())]))]
     // private use extension subtag
     #[case("x-private-use", Some(vec![PrivateUseReason::PrivateUseSubtag("x-private-use".to_string())]))]
-    // multiple reasons combined
+    // two reasons combined
+    #[case("qaa-Qaaa", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),
+    ]))]
+    #[case("qaa-QM", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseRegionSubtag("QM".to_string()),
+    ]))]
+    #[case("qaa-x-foo", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-foo".to_string()),
+    ]))]
+    #[case("en-Qaaa-x-foo", Some(vec![
+        PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-foo".to_string()),
+    ]))]
+    #[case("en-XZ-x-bar", Some(vec![
+        PrivateUseReason::PrivateUseRegionSubtag("XZ".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-bar".to_string()),
+    ]))]
+    // three reasons combined
+    #[case("qaa-Qaaa-QM", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),
+        PrivateUseReason::PrivateUseRegionSubtag("QM".to_string()),
+    ]))]
+    #[case("qaa-Qaaa-x-baz", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-baz".to_string()),
+    ]))]
+    #[case("qaa-QM-x-quux", Some(vec![
+        PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
+        PrivateUseReason::PrivateUseRegionSubtag("QM".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-quux".to_string()),
+    ]))]
+    #[case("en-Qaaa-XA-x-test", Some(vec![
+        PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),
+        PrivateUseReason::PrivateUseRegionSubtag("XA".to_string()),
+        PrivateUseReason::PrivateUseSubtag("x-test".to_string()),
+    ]))]
+    // all four reasons combined
     #[case("qaa-Qaaa-QM-x-private-use", Some(vec![
         PrivateUseReason::PrivateUsePrimaryLangSubtag("qaa".to_string()),
         PrivateUseReason::PrivateUseScriptSubtag("Qaaa".to_string()),

--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -60,16 +60,30 @@ impl ValidCsafLanguage {
     pub fn get_private_use(&self) -> Option<Vec<PrivateUseReason>> {
         let mut result: Option<Vec<PrivateUseReason>> = None;
         if is_language_private_use(self.0.primary_language()) {
-            result.get_or_insert_default().push(PrivateUseReason::PrivateUsePrimaryLangSubtag(self.0.primary_language().to_string()));
+            result
+                .get_or_insert_default()
+                .push(PrivateUseReason::PrivateUsePrimaryLangSubtag(
+                    self.0.primary_language().to_string(),
+                ));
         }
         if self.0.script().is_some_and(is_script_private_use) {
-            result.get_or_insert_default().push(PrivateUseReason::PrivateUseScriptSubtag(self.0.script().unwrap().to_string()));
+            result
+                .get_or_insert_default()
+                .push(PrivateUseReason::PrivateUseScriptSubtag(
+                    self.0.script().unwrap().to_string(),
+                ));
         }
         if self.0.region().is_some_and(is_region_private_use) {
-            result.get_or_insert_default().push(PrivateUseReason::PrivateUseRegionSubtag(self.0.region().unwrap().to_string()));
+            result
+                .get_or_insert_default()
+                .push(PrivateUseReason::PrivateUseRegionSubtag(
+                    self.0.region().unwrap().to_string(),
+                ));
         }
         if let Some(private_use_subtag) = self.0.private_use() {
-            result.get_or_insert_default().push(PrivateUseReason::PrivateUseSubtag(private_use_subtag.to_string()));
+            result
+                .get_or_insert_default()
+                .push(PrivateUseReason::PrivateUseSubtag(private_use_subtag.to_string()));
         }
         result
     }

--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -6922,6 +6922,8 @@ impl<
         case_06: Result<(), Vec<crate::validation::ValidationError>>,
         case_07: Result<(), Vec<crate::validation::ValidationError>>,
         case_08: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s01: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s02: Result<(), Vec<crate::validation::ValidationError>>,
         case_11: Result<(), Vec<crate::validation::ValidationError>>,
         case_12: Result<(), Vec<crate::validation::ValidationError>>,
     ) {
@@ -7006,7 +7008,27 @@ impl<
             ::new(serde_json::from_str:: < serde_json::Value > (& content)
             .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
             "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-14-08.json", "08", e))) },
-            case_08), ("11", { let path =
+            case_08), ("s01", { let path =
+            "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json", "s01", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json", "s01", e))) }, case_s01),
+            ("s02", { let path =
+            "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json", "s02", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json", "s02", e))) }, case_s02),
+            ("11", { let path =
             "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-14-11.json";
             let content = std::fs::read_to_string(path).unwrap_or_else(| e |
             panic!("Failed to load {} (case {}): {}",

--- a/csaf-rs/src/csaf2_0/validation.rs
+++ b/csaf-rs/src/csaf2_0/validation.rs
@@ -140,7 +140,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                         status: TestResultStatus::Skipped,
                     };
                 },
-                "6.2.14" => None, // Some(ValidatorForTest6_2_14.validate(self)),
+                "6.2.14" => Some(ValidatorForTest6_2_14.validate(self)),
                 "6.2.15" => Some(ValidatorForTest6_2_15.validate(self)),
                 "6.2.16" => Some(ValidatorForTest6_2_16.validate(self)),
                 "6.2.17" => Some(ValidatorForTest6_2_17.validate(self)),

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -13460,6 +13460,8 @@ impl<
         case_06: Result<(), Vec<crate::validation::ValidationError>>,
         case_07: Result<(), Vec<crate::validation::ValidationError>>,
         case_08: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s01: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s02: Result<(), Vec<crate::validation::ValidationError>>,
         case_11: Result<(), Vec<crate::validation::ValidationError>>,
         case_12: Result<(), Vec<crate::validation::ValidationError>>,
     ) {
@@ -13544,7 +13546,27 @@ impl<
             ::new(serde_json::from_str:: < serde_json::Value > (& content)
             .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
             "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-14-08.json", "08", e))) },
-            case_08), ("11", { let path =
+            case_08), ("s01", { let path =
+            "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json", "s01", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json", "s01", e))) },
+            case_s01), ("s02", { let path =
+            "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json", "s02", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json", "s02", e))) },
+            case_s02), ("11", { let path =
             "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-14-11.json";
             let content = std::fs::read_to_string(path).unwrap_or_else(| e |
             panic!("Failed to load {} (case {}): {}",

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -201,7 +201,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                         status: TestResultStatus::Skipped,
                     };
                 },
-                "6.2.14" => None, // Some(ValidatorForTest6_2_14.validate(self)),
+                "6.2.14" => Some(ValidatorForTest6_2_14.validate(self)),
                 "6.2.15" => Some(ValidatorForTest6_2_15.validate(self)),
                 "6.2.16" => Some(ValidatorForTest6_2_16.validate(self)),
                 "6.2.17" => Some(ValidatorForTest6_2_17.validate(self)),

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -89,7 +89,7 @@ pub mod test_6_2_10;
 pub mod test_6_2_11;
 pub mod test_6_2_12;
 pub mod test_6_2_13;
-// pub mod test_6_2_14;
+pub mod test_6_2_14;
 pub mod test_6_2_15;
 pub mod test_6_2_16;
 pub mod test_6_2_17;

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -1,0 +1,191 @@
+use std::fmt::{Display, Formatter};
+use crate::csaf::types::language::CsafLanguage;
+use crate::csaf::types::language::valid_language::PrivateUseReason;
+use crate::csaf_traits::{CsafTrait, DocumentTrait};
+use crate::validation::ValidationError;
+
+/// 6.2.14 Use of Private Language
+///
+/// For each element of type `/$defs/lang_t` it MUST be tested that the language code does not
+/// contain subtags reserved for private use.
+pub fn test_6_2_14_use_of_private_language(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+    let document = doc.get_document();
+
+    if document.get_lang().is_none() && document.get_source_lang().is_none() {
+        return Ok(()); // This should be a wasSkipped later (see #409)
+    }
+
+    let mut errors: Option<Vec<ValidationError>> = None;
+
+    validate_private_language(document.get_lang(), "/document/lang", &mut errors);
+    validate_private_language(document.get_source_lang(), "/document/source_lang", &mut errors);
+
+    errors.map_or(Ok(()), Err)
+}
+
+/// Helper function to validate a `lang` tag and check if it contains subtags reserved for private use.
+///
+/// If the optional language tag is `Some`, is a valid tag, and contains private use subtags,
+/// an error will be added to `errors` vector.
+///
+/// # Arguments
+/// - `lang`: The (optional) language tag to validate
+/// - `json_path`: The JSON path to the language tag
+/// - `errors`: A mutable reference to the errors vector
+fn validate_private_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+    if let Some(CsafLanguage::Valid(valid_lang)) = lang
+        && let Some(private_use_reasons) = valid_lang.get_private_use()
+    {
+        errors.get_or_insert_default().push(create_private_language_error_from_reasons(
+            valid_lang.as_str().to_string(),
+            &private_use_reasons,
+            json_path,
+        ));
+    }
+}
+
+/// Keeping this in, if we ever want less "detailed" error messages.
+#[allow(dead_code)]
+fn create_private_language_error(lang_tag: String, instance_path: &str) -> ValidationError {
+    ValidationError {
+        message: format!("The language tag '{lang_tag}' contains subtags reserved for private use"),
+        instance_path: instance_path.to_string(),
+    }
+}
+
+// Display specific to this test
+impl Display for PrivateUseReason {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Subtag '{subtag}' is a private use subtag"),
+            PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => write!(f, "Primary Language Subtag '{primary_lang}' is private use"),
+            PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Script subtag '{script}' is private use"),
+            PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Region subtag '{region}' is private use"),
+        }
+    }
+}
+
+fn create_private_language_error_from_reasons(lang_tag: String, reasons: &Vec<PrivateUseReason>, instance_path: &str) -> ValidationError {
+    // Reasons are constructed in a sorted order, so no sorting is necessary here
+    let reasons_str = reasons.iter().map(|reason| reason.to_string())
+        .collect::<Vec<String>>()
+        .join(", ");
+    ValidationError {
+        message: format!("The language tag '{lang_tag}' contains subtags reserved for private use: {reasons_str}"),
+        instance_path: instance_path.to_string()
+    }
+}
+
+crate::test_validation::impl_validator!(ValidatorForTest6_2_14, test_6_2_14_use_of_private_language);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::TESTS_2_1;
+
+    #[test]
+    fn test_test_6_2_14() {
+        let case_01_private_primary_lang = Err(vec![create_private_language_error_from_reasons(
+            "qtx".to_string(),
+            &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qtx".to_string())],
+            "/document/lang",
+        )]);
+        let case_02_private_primary_source_lang = Err(vec![create_private_language_error_from_reasons(
+            "qcb".to_string(),
+            &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qcb".to_string())],
+            "/document/source_lang",
+        )]);
+        let case_03_both_private_primary_lang = Err(vec![
+            create_private_language_error_from_reasons(
+                "qdq".to_string(),
+                &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qdq".to_string())],
+                "/document/lang",
+            ),
+            create_private_language_error_from_reasons(
+                "qcb".to_string(),
+                &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qcb".to_string())],
+                "/document/source_lang",
+            ),
+        ]);
+
+        let case_04_private_region_qm = Err(vec![create_private_language_error_from_reasons(
+            "en-QM".to_string(),
+            &vec![PrivateUseReason::PrivateUseRegionSubtag("QM".to_string())],
+            "/document/lang",
+        )]);
+
+        let case_05_private_region_xp = Err(vec![create_private_language_error_from_reasons(
+            "en-XP".to_string(),
+            &vec![PrivateUseReason::PrivateUseRegionSubtag("XP".to_string())],
+            "/document/lang",
+        )]);
+
+        let case_06_private_script_qabc = Err(vec![create_private_language_error_from_reasons(
+            "en-Qabc".to_string(),
+            &vec![PrivateUseReason::PrivateUseScriptSubtag("Qabc".to_string())],
+            "/document/lang",
+        )]);
+
+        let case_07_private_region_aa = Err(vec![create_private_language_error_from_reasons(
+            "en-AA".to_string(),
+            &vec![PrivateUseReason::PrivateUseRegionSubtag("AA".to_string())],
+            "/document/lang",
+        )]);
+
+        let case_08_private_region_zz = Err(vec![create_private_language_error_from_reasons(
+            "fr-ZZ".to_string(),
+            &vec![PrivateUseReason::PrivateUseRegionSubtag("ZZ".to_string())],
+            "/document/lang",
+        )]);
+
+        let case_s01_private_use_tag = Err(vec![create_private_language_error_from_reasons(
+            "en-x-this-is-private".to_string(),
+            &vec![PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string())],
+            "/document/lang",
+        )]);
+
+        let case_s02_multiple_reasons = Err(vec![create_private_language_error_from_reasons(
+            "qtx-Qabc-XP-x-this-is-private".to_string(),
+            &vec![
+                PrivateUseReason::PrivateUsePrimaryLangSubtag("qtx".to_string()),
+                PrivateUseReason::PrivateUseScriptSubtag("Qabc".to_string()),
+                PrivateUseReason::PrivateUseRegionSubtag("XP".to_string()),
+                PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string()),
+            ],
+            "/document/lang",
+        )]);
+
+        // Case 11: /document/lang is set to a non-private language
+        // Case 12: Both are set to non-private languages
+
+        TESTS_2_0.test_6_2_14.expect(
+            case_01_private_primary_lang.clone(),
+            case_02_private_primary_source_lang.clone(),
+            case_03_both_private_primary_lang.clone(),
+            case_04_private_region_qm.clone(),
+            case_05_private_region_xp.clone(),
+            case_06_private_script_qabc.clone(),
+            case_07_private_region_aa.clone(),
+            case_08_private_region_zz.clone(),
+            case_s01_private_use_tag.clone(),
+            case_s02_multiple_reasons.clone(),
+            Ok(()),
+            Ok(()),
+        );
+        TESTS_2_1.test_6_2_14.expect(
+            case_01_private_primary_lang,
+            case_02_private_primary_source_lang,
+            case_03_both_private_primary_lang,
+            case_04_private_region_qm,
+            case_05_private_region_xp,
+            case_06_private_script_qabc,
+            case_07_private_region_aa,
+            case_08_private_region_zz,
+            case_s01_private_use_tag,
+            case_s02_multiple_reasons,
+            Ok(()),
+            Ok(()),
+        );
+    }
+}

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -98,66 +98,66 @@ mod tests {
     fn test_test_6_2_14() {
         let case_01_private_primary_lang = Err(vec![create_private_language_error_from_reasons(
             "qtx".to_string(),
-            &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qtx".to_string())],
+            &[PrivateUseReason::PrivateUsePrimaryLangSubtag("qtx".to_string())],
             "/document/lang",
         )]);
         let case_02_private_primary_source_lang = Err(vec![create_private_language_error_from_reasons(
             "qcb".to_string(),
-            &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qcb".to_string())],
+            &[PrivateUseReason::PrivateUsePrimaryLangSubtag("qcb".to_string())],
             "/document/source_lang",
         )]);
         let case_03_both_private_primary_lang = Err(vec![
             create_private_language_error_from_reasons(
                 "qdq".to_string(),
-                &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qdq".to_string())],
+                &[PrivateUseReason::PrivateUsePrimaryLangSubtag("qdq".to_string())],
                 "/document/lang",
             ),
             create_private_language_error_from_reasons(
                 "qcb".to_string(),
-                &vec![PrivateUseReason::PrivateUsePrimaryLangSubtag("qcb".to_string())],
+                &[PrivateUseReason::PrivateUsePrimaryLangSubtag("qcb".to_string())],
                 "/document/source_lang",
             ),
         ]);
 
         let case_04_private_region_qm = Err(vec![create_private_language_error_from_reasons(
             "en-QM".to_string(),
-            &vec![PrivateUseReason::PrivateUseRegionSubtag("QM".to_string())],
+            &[PrivateUseReason::PrivateUseRegionSubtag("QM".to_string())],
             "/document/lang",
         )]);
 
         let case_05_private_region_xp = Err(vec![create_private_language_error_from_reasons(
             "en-XP".to_string(),
-            &vec![PrivateUseReason::PrivateUseRegionSubtag("XP".to_string())],
+            &[PrivateUseReason::PrivateUseRegionSubtag("XP".to_string())],
             "/document/lang",
         )]);
 
         let case_06_private_script_qabc = Err(vec![create_private_language_error_from_reasons(
             "en-Qabc".to_string(),
-            &vec![PrivateUseReason::PrivateUseScriptSubtag("Qabc".to_string())],
+            &[PrivateUseReason::PrivateUseScriptSubtag("Qabc".to_string())],
             "/document/lang",
         )]);
 
         let case_07_private_region_aa = Err(vec![create_private_language_error_from_reasons(
             "en-AA".to_string(),
-            &vec![PrivateUseReason::PrivateUseRegionSubtag("AA".to_string())],
+            &[PrivateUseReason::PrivateUseRegionSubtag("AA".to_string())],
             "/document/lang",
         )]);
 
         let case_08_private_region_zz = Err(vec![create_private_language_error_from_reasons(
             "fr-ZZ".to_string(),
-            &vec![PrivateUseReason::PrivateUseRegionSubtag("ZZ".to_string())],
+            &[PrivateUseReason::PrivateUseRegionSubtag("ZZ".to_string())],
             "/document/lang",
         )]);
 
         let case_s01_private_use_tag = Err(vec![create_private_language_error_from_reasons(
             "en-x-this-is-private".to_string(),
-            &vec![PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string())],
+            &[PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string())],
             "/document/lang",
         )]);
 
         let case_s02_multiple_reasons = Err(vec![create_private_language_error_from_reasons(
             "qtx-Qabc-XP-x-this-is-private".to_string(),
-            &vec![
+            &[
                 PrivateUseReason::PrivateUsePrimaryLangSubtag("qtx".to_string()),
                 PrivateUseReason::PrivateUseScriptSubtag("Qabc".to_string()),
                 PrivateUseReason::PrivateUseRegionSubtag("XP".to_string()),

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -71,7 +71,7 @@ impl Display for PrivateUseReason {
 
 fn create_private_language_error_from_reasons(
     lang_tag: String,
-    reasons: &Vec<PrivateUseReason>,
+    reasons: &[PrivateUseReason],
     instance_path: &str,
 ) -> ValidationError {
     // Reasons are constructed in a sorted order, so no sorting is necessary here

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -2,7 +2,6 @@ use crate::csaf::types::language::CsafLanguage;
 use crate::csaf::types::language::valid_language::PrivateUseReason;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
 use crate::validation::ValidationError;
-use std::fmt::{Display, Formatter};
 
 /// 6.2.14 Use of Private Language
 ///
@@ -55,26 +54,12 @@ fn create_private_language_error(lang_tag: String, instance_path: &str) -> Valid
     }
 }
 
-// Display specific to this test
-impl Display for PrivateUseReason {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Subtag '{subtag}' is a private use subtag"),
-            PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => {
-                write!(f, "Primary Language Subtag '{primary_lang}' is private use")
-            },
-            PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Script subtag '{script}' is private use"),
-            PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Region subtag '{region}' is private use"),
-        }
-    }
-}
-
 fn create_private_language_error_from_reasons(
     lang_tag: String,
     reasons: &[PrivateUseReason],
     instance_path: &str,
 ) -> ValidationError {
-    // Reasons are constructed in a sorted order, so no sorting is necessary here
+    // Reasons are constructed in the fixed order from ValidCsafLanguage::get_private_use, so no sorting is necessary here
     let reasons_str = reasons
         .iter()
         .map(|reason| reason.to_string())
@@ -149,11 +134,18 @@ mod tests {
             "/document/lang",
         )]);
 
-        let case_s01_private_use_tag = Err(vec![create_private_language_error_from_reasons(
-            "en-x-this-is-private".to_string(),
-            &[PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string())],
-            "/document/lang",
-        )]);
+        let case_s01_private_use_tag = Err(vec![
+            create_private_language_error_from_reasons(
+                "x-this-is-private".to_string(),
+                &[PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string())],
+                "/document/lang",
+            ),
+            create_private_language_error_from_reasons(
+                "en-x-this-is-private".to_string(),
+                &[PrivateUseReason::PrivateUseSubtag("x-this-is-private".to_string())],
+                "/document/source_lang",
+            ),
+        ]);
 
         let case_s02_multiple_reasons = Err(vec![create_private_language_error_from_reasons(
             "qtx-Qabc-XP-x-this-is-private".to_string(),

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -1,8 +1,8 @@
-use std::fmt::{Display, Formatter};
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf::types::language::valid_language::PrivateUseReason;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
 use crate::validation::ValidationError;
+use std::fmt::{Display, Formatter};
 
 /// 6.2.14 Use of Private Language
 ///
@@ -36,11 +36,13 @@ fn validate_private_language(lang: Option<CsafLanguage>, json_path: &str, errors
     if let Some(CsafLanguage::Valid(valid_lang)) = lang
         && let Some(private_use_reasons) = valid_lang.get_private_use()
     {
-        errors.get_or_insert_default().push(create_private_language_error_from_reasons(
-            valid_lang.as_str().to_string(),
-            &private_use_reasons,
-            json_path,
-        ));
+        errors
+            .get_or_insert_default()
+            .push(create_private_language_error_from_reasons(
+                valid_lang.as_str().to_string(),
+                &private_use_reasons,
+                json_path,
+            ));
     }
 }
 
@@ -58,21 +60,29 @@ impl Display for PrivateUseReason {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Subtag '{subtag}' is a private use subtag"),
-            PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => write!(f, "Primary Language Subtag '{primary_lang}' is private use"),
+            PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => {
+                write!(f, "Primary Language Subtag '{primary_lang}' is private use")
+            },
             PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Script subtag '{script}' is private use"),
             PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Region subtag '{region}' is private use"),
         }
     }
 }
 
-fn create_private_language_error_from_reasons(lang_tag: String, reasons: &Vec<PrivateUseReason>, instance_path: &str) -> ValidationError {
+fn create_private_language_error_from_reasons(
+    lang_tag: String,
+    reasons: &Vec<PrivateUseReason>,
+    instance_path: &str,
+) -> ValidationError {
     // Reasons are constructed in a sorted order, so no sorting is necessary here
-    let reasons_str = reasons.iter().map(|reason| reason.to_string())
+    let reasons_str = reasons
+        .iter()
+        .map(|reason| reason.to_string())
         .collect::<Vec<String>>()
         .join(", ");
     ValidationError {
         message: format!("The language tag '{lang_tag}' contains subtags reserved for private use: {reasons_str}"),
-        instance_path: instance_path.to_string()
+        instance_path: instance_path.to_string(),
     }
 }
 

--- a/csaf-rs/src/validations/test_6_2_15.rs
+++ b/csaf-rs/src/validations/test_6_2_15.rs
@@ -22,7 +22,7 @@ pub fn test_6_2_15_use_of_default_language(doc: &impl CsafTrait) -> Result<(), V
 
 /// Helper function to validate a `lang` tag and check if it is the default language.
 ///
-/// If the optional language tag is `Some` and is the default language (`i-default`), an
+/// If the optional language tag is `Some`, is a valid tag, and is the default language (`i-default`, case-insensitive), an
 /// error will be added to `errors` vector.
 ///
 /// # Arguments

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json
@@ -2,12 +2,13 @@
   "document": {
     "category": "csaf_base",
     "csaf_version": "2.0",
-    "lang": "en-x-this-is-private",
+    "lang": "x-this-is-private",
     "publisher": {
       "category": "other",
       "name": "CSAF-RS Test Files",
       "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
+    "source_lang": "en-x-this-is-private",
     "title": "Optional test: Use of Private Language (failing supplementary example 1 - private use subtag)",
     "tracking": {
       "current_release_date": "2021-07-21T10:00:00.000Z",

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json
@@ -1,0 +1,28 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "lang": "en-x-this-is-private",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Use of Private Language (failing supplementary example 1 - private use subtag)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-14-S01",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json
@@ -1,0 +1,28 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "lang": "qtx-Qabc-XP-x-this-is-private",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Use of Private Language (failing supplementary example 2 - multiple private use reasons)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-14-S02",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -560,6 +560,20 @@
     },
 
     {
+      "id": "6.2.14",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json",
+          "valid": false
+        },
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json",
+          "valid": false
+        }
+      ]
+    },
+    {
       "id": "6.2.15",
       "group": "optional",
       "failures": [

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json
@@ -8,12 +8,13 @@
         "label": "CLEAR"
       }
     },
-    "lang": "en-x-this-is-private",
+    "lang": "x-this-is-private",
     "publisher": {
       "category": "other",
       "name": "CSAF-RS Test Files",
       "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
+    "source_lang": "en-x-this-is-private",
     "title": "Recommended Test: Use of Private Language (failing supplementary example 1 - private use subtag)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "lang": "en-x-this-is-private",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Use of Private Language (failing supplementary example 1 - private use subtag)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-14-S01",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "lang": "qtx-Qabc-XP-x-this-is-private",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Use of Private Language (failing supplementary example 2 - multiple private use reasons)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-14-S02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -617,6 +617,20 @@
       ]
     },
     {
+      "id": "6.2.14",
+      "group": "recommended",
+      "failures": [
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json",
+          "valid": false
+        },
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json",
+          "valid": false
+        }
+      ]
+    },
+    {
       "id": "6.2.15",
       "group": "recommended",
       "failures": [


### PR DESCRIPTION
Resolves #130 

During #472 / #521, I added the support for private use detection needed for this test.

This PR: 
* adds test 6.2.14
* adds ValidCsafLanguage::get_private_use, which returns the specific reasons this language tag was detected to be private use, and some unit tests for it
* adds two supplemental test cases for 6.2.14 that cover:
  * "dedicated" private use tags like `en-x-private-use` or `x-private-use`
  * language tags with multiple "reasons" to be private use, exp. primary language subtag **and** script subtag are marked as private use
  
TODO:
- [x] Request clarification of handling of "dedicated" private use tags
- [x] Upstream the two+ test cases

Issue for this: https://github.com/oasis-tcs/csaf/issues/1377