### PR TITLE
feat: add test 6.2.22

### DIFF
--- a/csaf-rs/src/csaf/traits/document_trait.rs
+++ b/csaf-rs/src/csaf/traits/document_trait.rs
@@ -69,6 +69,9 @@ pub trait DocumentTrait {
     fn get_references(&self) -> Option<&Vec<Self::DocumentReferenceType>>;
 
     fn get_csaf_version(&self) -> &CsafVersion;
+
+    /// Returns the title of this document
+    fn get_title(&self) -> &str;
 }
 
 impl DocumentTrait for DocumentLevelMetaData20 {
@@ -127,6 +130,10 @@ impl DocumentTrait for DocumentLevelMetaData20 {
             CsafVersion20::X20 => &CsafVersion::X20,
         }
     }
+
+    fn get_title(&self) -> &str {
+        &self.title
+    }
 }
 
 impl DocumentTrait for DocumentLevelMetaData21 {
@@ -178,5 +185,9 @@ impl DocumentTrait for DocumentLevelMetaData21 {
         match self.csaf_version {
             CsafVersion21::X21 => &CsafVersion::X21,
         }
+    }
+
+    fn get_title(&self) -> &str {
+        &self.title
     }
 }

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -215,7 +215,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                     };
                 },
                 "6.2.21" => None, // Some(ValidatorForTest6_2_21.validate(self)),
-                "6.2.22" => None, // Some(ValidatorForTest6_2_22.validate(self)),
+                "6.2.22" => Some(ValidatorForTest6_2_22.validate(self)),
                 "6.2.23" => None, // Some(ValidatorForTest6_2_23.validate(self)),
                 "6.2.24" => None, // Some(ValidatorForTest6_2_24.validate(self)),
                 "6.2.25" => None, // Some(ValidatorForTest6_2_25.validate(self)),

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -96,6 +96,7 @@ pub mod test_6_2_17;
 pub mod test_6_2_18;
 // pub mod test_6_2_19;
 pub mod test_6_2_20;
+pub mod test_6_2_22;
 pub mod test_6_2_28;
 pub mod test_6_2_29;
 pub mod test_6_2_30;

--- a/csaf-rs/src/validations/test_6_2_22.rs
+++ b/csaf-rs/src/validations/test_6_2_22.rs
@@ -1,0 +1,68 @@
+use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
+use crate::validation::ValidationError;
+
+fn create_tracking_id_in_title_error(title: &str, tracking_id: &str) -> ValidationError {
+    ValidationError {
+        message: format!("The document title '{title}' contains the document tracking id '{tracking_id}'."),
+        instance_path: "/document/title".to_string(),
+    }
+}
+
+/// 6.2.22 Document Tracking ID in Title
+///
+/// It MUST be tested that the /document/title does not contain the /document/tracking/id.
+pub fn test_6_2_22_document_tracking_id_in_title(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+    let document = doc.get_document();
+    let title = document.get_title();
+    let tracking_id = document.get_tracking().get_id();
+
+    if title.contains(tracking_id.as_str()) {
+        return Err(vec![create_tracking_id_in_title_error(title, tracking_id)]);
+    }
+
+    Ok(())
+}
+
+crate::test_validation::impl_validator!(
+    csaf2_1,
+    ValidatorForTest6_2_22,
+    test_6_2_22_document_tracking_id_in_title
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::csaf2_1::testcases::TESTS_2_1;
+
+    #[test]
+    fn test_test_6_2_22() {
+        let case_01_starts_with_id_colon_as_sep = Err(vec![create_tracking_id_in_title_error(
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-01: Recommended Test: Document Tracking ID in Title (failing example 1)",
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-01",
+        )]);
+        let case_02_ends_with_id_in_parenthesis = Err(vec![create_tracking_id_in_title_error(
+            "Recommended Test: Document Tracking ID in Title (failing example 2) (OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-02)",
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-02",
+        )]);
+        let case_03_ends_with_id_colon_sep = Err(vec![create_tracking_id_in_title_error(
+            "Recommended Test: Document Tracking ID in Title (failing example 3) - OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-03",
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-03",
+        )]);
+        let case_04_starts_with_id_dash_sep = Err(vec![create_tracking_id_in_title_error(
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-04 - Recommended Test: Document Tracking ID in Title (failing example 4)",
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-22-04",
+        )]);
+
+        // Case 11: title does not contain its own tracking ID
+        // Case 12: title contains a different tracking ID (not its own)
+
+        TESTS_2_1.test_6_2_22.expect(
+            case_01_starts_with_id_colon_as_sep,
+            case_02_ends_with_id_in_parenthesis,
+            case_03_ends_with_id_colon_sep,
+            case_04_starts_with_id_dash_sep,
+            Ok(()),
+            Ok(()),
+        );
+    }
+}


### PR DESCRIPTION
Resolves #308 

This PR:
* adds `/document/title` to the trait
* adds test 6.2.22 for concerning `/document/title` and `/document/tracking/id`
* wires up the test
