### PR TITLE
feat: add (obsolete) test 6.2.10 for CSAF 2.1

### DIFF
--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -6629,7 +6629,11 @@ impl<
     /// # Panics
     /// Panics if any test case fails to load, parse, or doesn't match the expected result
     ///
-    pub fn expect(&self, case_01: Result<(), Vec<crate::validation::ValidationError>>) {
+    pub fn expect(
+        &self,
+        case_01: Result<(), Vec<crate::validation::ValidationError>>,
+        case_s11: Result<(), Vec<crate::validation::ValidationError>>,
+    ) {
         let test_cases = vec![
             ("01", { let path =
             "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-10-01.json";
@@ -6640,7 +6644,17 @@ impl<
             ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
             ::new(serde_json::from_str:: < serde_json::Value > (& content)
             .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
-            "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-10-01.json", "01", e))) }, case_01)
+            "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-10-01.json", "01", e))) },
+            case_01), ("s11", { let path =
+            "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json";
+            let content = std::fs::read_to_string(path).unwrap_or_else(| e |
+            panic!("Failed to load {} (case {}): {}",
+            "optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json", "s11", e)); crate
+            ::csaf::raw::RawDocument:: < crate
+            ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework >
+            ::new(serde_json::from_str:: < serde_json::Value > (& content)
+            .unwrap_or_else(| e | panic!("Failed to parse {} (case {}): {}",
+            "optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json", "s11", e))) }, case_s11)
         ];
         let validator = V::default();
         for (case_num, doc, expected) in test_cases {

--- a/csaf-rs/src/validations/test_6_2_10.rs
+++ b/csaf-rs/src/validations/test_6_2_10.rs
@@ -1,4 +1,4 @@
-use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait};
+use crate::csaf_traits::{CsafTrait, CsafVersion, DistributionTrait, DocumentTrait};
 use crate::validation::ValidationError;
 use std::sync::LazyLock;
 
@@ -6,14 +6,19 @@ use std::sync::LazyLock;
 ///
 /// `/document/distribution/tlp/label` must be set.
 pub fn test_6_2_10_missing_tlp_label(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    // We just need to consider get_distribution_20 / get_tlp_20 here, in CSAF 2.1 this field is mandatory and
-    // validated via the schema. This test will not run for CSAF 2.1 documents.
-    if let Some(distribution_20) = doc.get_document().get_distribution_20()
-        && distribution_20.get_tlp_20().is_some()
-    {
-        return Ok(());
+    // In CSAF 2.1 this field is mandatory and validated via the schema, so we skip this test
+    if doc.get_document().get_csaf_version() == &CsafVersion::X21 {
+        return Ok(()); // TODO #409 wasSkipped
     }
-    Err(vec![MISSING_TLP_LABEL_ERROR.clone()])
+    // We just need to consider get_distribution_20 / get_tlp_20 here. If either is missing, return an error
+    if doc.get_document().get_distribution_20()
+        .and_then(|d| d.get_tlp_20())
+        .is_none()
+    {
+        Err(vec![MISSING_TLP_LABEL_ERROR.clone()])
+    } else {
+        Ok(())
+    }
 }
 
 static MISSING_TLP_LABEL_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {

--- a/csaf-rs/src/validations/test_6_2_10.rs
+++ b/csaf-rs/src/validations/test_6_2_10.rs
@@ -5,13 +5,20 @@ use std::sync::LazyLock;
 /// 6.2.10 Missing TLP label
 ///
 /// `/document/distribution/tlp/label` must be set.
+///
+/// This test is obsolete in CSAF 2.1, as `distribution/tlp` is now required by the schema.
+/// The test harness for CSAF 2.1 does not include the test.
+/// If the test function was to be called programmatically on a CSAF 2.1 doc, we are returning
+/// Ok(()). (later wasSkipped TODO)
 pub fn test_6_2_10_missing_tlp_label(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     // In CSAF 2.1 this field is mandatory and validated via the schema, so we skip this test
     if doc.get_document().get_csaf_version() == &CsafVersion::X21 {
         return Ok(()); // TODO #409 wasSkipped
     }
     // We just need to consider get_distribution_20 / get_tlp_20 here. If either is missing, return an error
-    if doc.get_document().get_distribution_20()
+    if doc
+        .get_document()
+        .get_distribution_20()
         .and_then(|d| d.get_tlp_20())
         .is_none()
     {
@@ -37,7 +44,49 @@ mod tests {
     fn test_test_6_2_10() {
         let err = Err(vec![MISSING_TLP_LABEL_ERROR.clone()]);
 
-        // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_10.expect(err);
+        // Case S11: A CSAF 2.0 document with a valid TLP label
+
+        TESTS_2_0.test_6_2_10.expect(err, Ok(()));
+    }
+
+    /// Check that the test is skipped (returns Ok) for CSAF 2.1 documents.
+    #[test]
+    fn test_test_6_2_10_skipped_for_csaf_2_1() {
+        let minimal_csaf_21: crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework =
+            serde_json::from_value(serde_json::json!({
+                "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+                "document": {
+                    "category": "csaf_base",
+                    "csaf_version": "2.1",
+                    "distribution": {
+                        "tlp": { "label": "CLEAR" }
+                    },
+                    "publisher": {
+                        "category": "other",
+                        "name": "CSAF-RS Test Files",
+                        "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+                    },
+                    "title": "Optional test: Missing TLP label (valid supplementary example 1 - skipped on CSAF 2.1)",
+                    "tracking": {
+                        "current_release_date": "2024-01-24T10:00:00.000Z",
+                        "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-10-S11",
+                        "initial_release_date": "2024-01-24T10:00:00.000Z",
+                        "revision_history": [{
+                            "date": "2024-01-24T10:00:00.000Z",
+                            "number": "1",
+                            "summary": "Initial version."
+                        }],
+                        "status": "final",
+                        "version": "1"
+                    }
+                }
+            }))
+            .expect("Failed to parse CSAF 2.1 document");
+
+        let result = test_6_2_10_missing_tlp_label(&minimal_csaf_21);
+        assert!(
+            result.is_ok(),
+            "Test 6.2.10 should be skipped (Ok) for CSAF 2.1 documents"
+        );
     }
 }

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json
@@ -1,0 +1,32 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Missing TLP label (valid supplementary example 1 - with TLP label)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-10-S11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}
+

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -596,6 +596,16 @@
       ]
     },
     {
+      "id": "6.2.10",
+      "group": "optional",
+      "valid": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.2.14",
       "group": "optional",
       "failures": [


### PR DESCRIPTION
Resolves #296 

So far, if the impl was called on a CSAF 2.1, we returned an error. As the relevant properties are required by the schema on CSAF 2.1, this was wrong.

The test now contains an early return for CSAF 2.1, which should be a wasSkipped after #409.

I also added a supplemental passing CSAF 2.0 test case with a TLP label present and a unit test to assert the CSAF 2.1 behaviour described above. I also did a minor rewrite of the validation logic to match similar implementations.

