### PR TITLE
 chore: use `get_or_insert_default` 

### DIFF
--- a/csaf-rs/src/validations/test_6_1_01.rs
+++ b/csaf-rs/src/validations/test_6_1_01.rs
@@ -14,9 +14,7 @@ fn validate_missing_product_id<Doc: CsafTrait>(doc: &Doc) -> Result<(), Vec<Vali
     let mut errors: Option<Vec<ValidationError>> = Option::None;
     for (ref_id, ref_path) in references.iter() {
         if !definitions_set.contains(ref_id) {
-            errors
-                .get_or_insert_default()
-                .push(generate_err_msg(ref_id, ref_path));
+            errors.get_or_insert_default().push(generate_err_msg(ref_id, ref_path));
         }
     }
     errors.map_or(Ok(()), Err)

--- a/csaf-rs/src/validations/test_6_1_01.rs
+++ b/csaf-rs/src/validations/test_6_1_01.rs
@@ -15,7 +15,7 @@ fn validate_missing_product_id<Doc: CsafTrait>(doc: &Doc) -> Result<(), Vec<Vali
     for (ref_id, ref_path) in references.iter() {
         if !definitions_set.contains(ref_id) {
             errors
-                .get_or_insert_with(Vec::new)
+                .get_or_insert_default()
                 .push(generate_err_msg(ref_id, ref_path));
         }
     }

--- a/csaf-rs/src/validations/test_6_1_02.rs
+++ b/csaf-rs/src/validations/test_6_1_02.rs
@@ -18,7 +18,7 @@ pub fn test_6_1_02_multiple_definition_of_product_id(doc: &impl CsafTrait) -> Re
             if paths.len() > 1 {
                 for path in paths {
                     errors
-                        .get_or_insert_with(Vec::new)
+                        .get_or_insert_default()
                         .push(generate_err_msg(&product_id, &path));
                 }
             }

--- a/csaf-rs/src/validations/test_6_1_03.rs
+++ b/csaf-rs/src/validations/test_6_1_03.rs
@@ -82,7 +82,7 @@ pub fn test_6_1_03_circular_definition_of_product_id(doc: &impl CsafTrait) -> Re
             let rel_prod_id = pp.get_full_product_name().get_product_id();
             if pp.get_beginning_product_reference() == rel_prod_id {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(generate_self_reference_product_error(
                         version,
                         &pp.get_json_path_for_product_path_beginning_product_reference(pp_i),
@@ -93,7 +93,7 @@ pub fn test_6_1_03_circular_definition_of_product_id(doc: &impl CsafTrait) -> Re
                 .position(|next| *next == rel_prod_id)
             {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(generate_self_reference_relates_to_error(
                         version,
                         &pp.get_json_path_for_product_path_subpath_product_reference(pp_i, sp_i),
@@ -133,7 +133,7 @@ pub fn test_6_1_03_circular_definition_of_product_id(doc: &impl CsafTrait) -> Re
             let mut visited = HashSet::new();
             if let Some((cycle, relation_index)) = find_cycle(&relation_map, product_id, &mut visited) {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(generate_cycle_error(version, &cycle, relation_index));
             }
         }

--- a/csaf-rs/src/validations/test_6_1_04.rs
+++ b/csaf-rs/src/validations/test_6_1_04.rs
@@ -21,7 +21,7 @@ pub fn test_6_1_04_missing_definition_of_product_group_id(doc: &impl CsafTrait) 
         for (ref_id, ref_path) in product_group_references.iter() {
             if !known_groups.contains(ref_id) {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(generate_err_msg(ref_id, ref_path));
             }
         }

--- a/csaf-rs/src/validations/test_6_1_04.rs
+++ b/csaf-rs/src/validations/test_6_1_04.rs
@@ -20,9 +20,7 @@ pub fn test_6_1_04_missing_definition_of_product_group_id(doc: &impl CsafTrait) 
         let product_group_references = doc.get_all_group_references();
         for (ref_id, ref_path) in product_group_references.iter() {
             if !known_groups.contains(ref_id) {
-                errors
-                    .get_or_insert_default()
-                    .push(generate_err_msg(ref_id, ref_path));
+                errors.get_or_insert_default().push(generate_err_msg(ref_id, ref_path));
             }
         }
     }

--- a/csaf-rs/src/validations/test_6_1_06.rs
+++ b/csaf-rs/src/validations/test_6_1_06.rs
@@ -29,7 +29,7 @@ pub fn test_6_1_06_contradicting_product_status(doc: &impl CsafTrait) -> Result<
                 if groups.len() > 1 {
                     let mut affected_groups = groups;
                     affected_groups.sort();
-                    errors.get_or_insert_with(Vec::new).push(generate_err_msg(
+                    errors.get_or_insert_default().push(generate_err_msg(
                         &product_id,
                         &affected_groups,
                         vulnerability_index,

--- a/csaf-rs/src/validations/test_6_1_07.rs
+++ b/csaf-rs/src/validations/test_6_1_07.rs
@@ -51,7 +51,7 @@ pub fn test_6_1_07_multiple_same_scores_per_product(doc: &impl CsafTrait) -> Res
                     for (s, paths) in metrics_map_2.iter() {
                         if paths.len() > 1 {
                             for path in paths {
-                                errors.get_or_insert_with(Vec::new).push(create_validation_error(
+                                errors.get_or_insert_default().push(create_validation_error(
                                     m,
                                     p,
                                     path.to_owned(),

--- a/csaf-rs/src/validations/test_6_1_13.rs
+++ b/csaf-rs/src/validations/test_6_1_13.rs
@@ -94,23 +94,25 @@ pub fn test_6_1_13_purl(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>
                 for (i, purl_str) in purls.iter().enumerate() {
                     // Check against PURL spec, because it has to be valid
                     if let Err(e) = PackageUrl::from_str(purl_str) {
-                        errors
-                            .get_or_insert_default()
-                            .push(generate_purl_format_error_message(version, purl_str, e.into(), path, i));
+                        errors.get_or_insert_default().push(generate_purl_format_error_message(
+                            version,
+                            purl_str,
+                            e.into(),
+                            path,
+                            i,
+                        ));
                         continue;
                     }
 
                     // Check against regex from standard, because it is more strict in some ways (e.g. it prohibits double // after scheme)
                     if !PURL_REGEX.is_match(purl_str) {
-                        errors
-                            .get_or_insert_default()
-                            .push(generate_purl_format_error_message(
-                                version,
-                                purl_str,
-                                PurlParseError::CsafError,
-                                path,
-                                i,
-                            ));
+                        errors.get_or_insert_default().push(generate_purl_format_error_message(
+                            version,
+                            purl_str,
+                            PurlParseError::CsafError,
+                            path,
+                            i,
+                        ));
                     }
                 }
             }

--- a/csaf-rs/src/validations/test_6_1_13.rs
+++ b/csaf-rs/src/validations/test_6_1_13.rs
@@ -95,7 +95,7 @@ pub fn test_6_1_13_purl(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>
                     // Check against PURL spec, because it has to be valid
                     if let Err(e) = PackageUrl::from_str(purl_str) {
                         errors
-                            .get_or_insert_with(Vec::new)
+                            .get_or_insert_default()
                             .push(generate_purl_format_error_message(version, purl_str, e.into(), path, i));
                         continue;
                     }
@@ -103,7 +103,7 @@ pub fn test_6_1_13_purl(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>
                     // Check against regex from standard, because it is more strict in some ways (e.g. it prohibits double // after scheme)
                     if !PURL_REGEX.is_match(purl_str) {
                         errors
-                            .get_or_insert_with(Vec::new)
+                            .get_or_insert_default()
                             .push(generate_purl_format_error_message(
                                 version,
                                 purl_str,

--- a/csaf-rs/src/validations/test_6_1_27_05.rs
+++ b/csaf-rs/src/validations/test_6_1_27_05.rs
@@ -22,7 +22,7 @@ pub fn test_6_1_27_05_vulnerability_notes(doc: &impl CsafTrait) -> Result<(), Ve
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if vulnerability.get_notes().is_none() {
             errors
-                .get_or_insert_with(Vec::new)
+                .get_or_insert_default()
                 .push(test_6_1_27_05_err_generator(&doc_category, &v_i));
         }
     }

--- a/csaf-rs/src/validations/test_6_1_27_06.rs
+++ b/csaf-rs/src/validations/test_6_1_27_06.rs
@@ -22,7 +22,7 @@ pub fn test_6_1_27_06_product_status(doc: &impl CsafTrait) -> Result<(), Vec<Val
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if vulnerability.get_product_status().is_none() {
             errors
-                .get_or_insert_with(Vec::new)
+                .get_or_insert_default()
                 .push(test_6_1_27_06_err_generator(&doc_category, &v_i));
         }
     }

--- a/csaf-rs/src/validations/test_6_1_27_07.rs
+++ b/csaf-rs/src/validations/test_6_1_27_07.rs
@@ -26,7 +26,7 @@ pub fn test_6_1_27_07_vex_product_status(doc: &impl CsafTrait) -> Result<(), Vec
                 || product_status.get_under_investigation().is_some())
         {
             errors
-                .get_or_insert_with(Vec::new)
+                .get_or_insert_default()
                 .push(test_6_1_27_07_err_generator(&doc_category, &v_i));
         }
     }

--- a/csaf-rs/src/validations/test_6_1_27_08.rs
+++ b/csaf-rs/src/validations/test_6_1_27_08.rs
@@ -21,7 +21,7 @@ pub fn test_6_1_27_08_vulnerability_id(doc: &impl CsafTrait) -> Result<(), Vec<V
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if vulnerability.get_cve().is_none() && vulnerability.get_ids().is_none() {
             errors
-                .get_or_insert_with(Vec::new)
+                .get_or_insert_default()
                 .push(test_6_1_27_08_err_generator(&doc_category, &v_i));
         }
     }

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -89,7 +89,7 @@ pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
 
         // generate errors for all remaining known_not_affected product or group ids
         for known_not_affected_group_id in known_not_affected_product_or_group_ids.iter() {
-            errors.get_or_insert_with(Vec::new).push(test_6_1_27_09_err_generator(
+            errors.get_or_insert_default().push(test_6_1_27_09_err_generator(
                 known_not_affected_group_id.0.to_string(),
                 v_i,
                 *known_not_affected_group_id.1,

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -67,7 +67,7 @@ pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
 
         // generate errors for all remaining known_affected product or group ids
         for known_affected_product_or_group_id in known_affected_product_or_group_ids.iter() {
-            errors.get_or_insert_with(Vec::new).push(test_6_1_27_10_err_generator(
+            errors.get_or_insert_default().push(test_6_1_27_10_err_generator(
                 known_affected_product_or_group_id.0.to_string(),
                 v_i,
                 *known_affected_product_or_group_id.1,

--- a/csaf-rs/src/validations/test_6_1_29.rs
+++ b/csaf-rs/src/validations/test_6_1_29.rs
@@ -29,7 +29,7 @@ pub fn test_6_1_29_remediation_without_product_reference(doc: &impl CsafTrait) -
             // Through the schema, it is ensured that if they are not None, they contain at least one entry
             if remediation.get_product_ids().is_none() && remediation.get_group_ids().is_none() {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(create_missing_product_reference_error(vuln_i, rem_i));
             }
         }

--- a/csaf-rs/src/validations/test_6_1_32.rs
+++ b/csaf-rs/src/validations/test_6_1_32.rs
@@ -29,7 +29,7 @@ pub fn test_6_1_32_flag_without_product_reference(doc: &impl CsafTrait) -> Resul
                 // Through the schema, it is ensured that if they are not None, they contain at least one entry
                 if flag.get_product_ids().is_none() && flag.get_group_ids().is_none() {
                     errors
-                        .get_or_insert_with(Vec::new)
+                        .get_or_insert_default()
                         .push(create_flag_without_product_reference_error(vuln_i, flag_i));
                 }
             }

--- a/csaf-rs/src/validations/test_6_1_33.rs
+++ b/csaf-rs/src/validations/test_6_1_33.rs
@@ -55,7 +55,7 @@ pub fn test_6_1_33_multiple_flags_with_vex_codes_per_product(doc: &impl CsafTrai
                     flag_flag_i_group_ids_arr.iter().map(|(label, _, _)| *label).collect();
                 // generate error
                 for (label, flag_i, group_id) in flag_flag_i_group_ids_arr {
-                    errors.get_or_insert_with(Vec::new).push(test_6_1_33_err_generator(
+                    errors.get_or_insert_default().push(test_6_1_33_err_generator(
                         &product_id,
                         &labels,
                         label,

--- a/csaf-rs/src/validations/test_6_1_42.rs
+++ b/csaf-rs/src/validations/test_6_1_42.rs
@@ -44,7 +44,7 @@ pub fn test_6_1_42_purl_consistency(doc: &impl CsafTrait) -> Result<(), Vec<Vali
                         // Must always match
                         if current_value != *base_value {
                             errors
-                                .get_or_insert_with(Vec::new)
+                                .get_or_insert_default()
                                 .push(create_purl_consistency_error(path, i));
                         }
                     } else {

--- a/csaf-rs/src/validations/test_6_2_01.rs
+++ b/csaf-rs/src/validations/test_6_2_01.rs
@@ -32,7 +32,7 @@ pub fn test_6_2_01_unused_definition_of_product_id(doc: &impl CsafTrait) -> Resu
         tree.visit_all_products(&mut |fpn, path| {
             if !references.contains(fpn.get_product_id()) {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(create_unused_product_id_error(fpn.get_product_id(), path));
             }
         });

--- a/csaf-rs/src/validations/test_6_2_02.rs
+++ b/csaf-rs/src/validations/test_6_2_02.rs
@@ -30,14 +30,12 @@ fn check_product_status_group_for_missing_remediations<'a>(
     // if not, generate an error
     for (sg_p_i, product_id) in status_group_product_ids.enumerate() {
         if !remediation_product_ids.contains(product_id) {
-            errors
-                .get_or_insert_default()
-                .push(create_missing_remediation_error(
-                    vulnerability_index,
-                    status_group_name,
-                    sg_p_i,
-                    product_id,
-                ));
+            errors.get_or_insert_default().push(create_missing_remediation_error(
+                vulnerability_index,
+                status_group_name,
+                sg_p_i,
+                product_id,
+            ));
         }
     }
 }

--- a/csaf-rs/src/validations/test_6_2_02.rs
+++ b/csaf-rs/src/validations/test_6_2_02.rs
@@ -31,7 +31,7 @@ fn check_product_status_group_for_missing_remediations<'a>(
     for (sg_p_i, product_id) in status_group_product_ids.enumerate() {
         if !remediation_product_ids.contains(product_id) {
             errors
-                .get_or_insert_with(Vec::new)
+                .get_or_insert_default()
                 .push(create_missing_remediation_error(
                     vulnerability_index,
                     status_group_name,

--- a/csaf-rs/src/validations/test_6_2_03.rs
+++ b/csaf-rs/src/validations/test_6_2_03.rs
@@ -29,7 +29,7 @@ fn check_product_status_group_for_missing_metrics<'a>(
     // if not, generate an error
     for (sg_p_i, product_id) in status_group_product_ids.enumerate() {
         if !remediation_product_ids.contains(product_id) {
-            errors.get_or_insert_with(Vec::new).push(create_missing_metric_error(
+            errors.get_or_insert_default().push(create_missing_metric_error(
                 vulnerability_index,
                 status_group_name,
                 sg_p_i,

--- a/csaf-rs/src/validations/test_6_2_07.rs
+++ b/csaf-rs/src/validations/test_6_2_07.rs
@@ -14,7 +14,7 @@ pub fn test_6_2_07_missing_date_in_involvements(doc: &impl CsafTrait) -> Result<
                 // if not, generate an error
                 if involvement.get_date().is_none() {
                     errors
-                        .get_or_insert_with(Vec::new)
+                        .get_or_insert_default()
                         .push(create_missing_date_in_involvements_error(v_i, inv_i));
                 }
             }

--- a/csaf-rs/src/validations/test_6_2_16.rs
+++ b/csaf-rs/src/validations/test_6_2_16.rs
@@ -14,7 +14,7 @@ pub fn test_6_2_16_missing_product_identification_helper(doc: &impl CsafTrait) -
         tree.visit_all_products(&mut |fpn, path| {
             if fpn.get_product_identification_helper().is_none() {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(create_missing_product_identification_helper_error(path));
             }
         });

--- a/csaf-rs/src/validations/test_6_2_17.rs
+++ b/csaf-rs/src/validations/test_6_2_17.rs
@@ -23,7 +23,7 @@ pub fn test_6_2_17_cve_in_field_ids(doc: &impl CsafTrait) -> Result<(), Vec<Vali
             for (i_i, id) in ids.iter().enumerate() {
                 if CVE_REGEX.is_match(id.get_text()) {
                     errors
-                        .get_or_insert_with(Vec::new)
+                        .get_or_insert_default()
                         .push(create_cve_in_ids_error(id.get_text(), v_i, i_i));
                 }
             }

--- a/csaf-rs/src/validations/test_6_2_18.rs
+++ b/csaf-rs/src/validations/test_6_2_18.rs
@@ -25,7 +25,7 @@ pub fn test_6_2_18_product_version_range_without_vers(doc: &impl CsafTrait) -> R
                 && !VERS_REGEX.is_match(branch.get_name())
             {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(create_product_version_range_without_vers_error(branch.get_name(), path));
             }
         });

--- a/csaf-rs/src/validations/test_6_3_1.rs
+++ b/csaf-rs/src/validations/test_6_3_1.rs
@@ -50,7 +50,7 @@ pub fn test_6_3_1_use_of_cvss_v2_as_only_scoring_system(doc: &impl CsafTrait) ->
                 if let Some(paths) = product_path_map.get(product) {
                     for path in paths {
                         errors
-                            .get_or_insert_with(Vec::new)
+                            .get_or_insert_default()
                             .push(create_cvss_v2_only_error(path.clone()));
                     }
                 }

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -18,7 +18,7 @@ pub fn test_6_3_10_usage_of_product_version_range(doc: &impl CsafTrait) -> Resul
         product_tree.visit_all_branches(&mut |branch, path| {
             if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(create_product_version_range_error(path));
             }
         });

--- a/csaf-rs/src/validations/test_6_3_11.rs
+++ b/csaf-rs/src/validations/test_6_3_11.rs
@@ -27,7 +27,7 @@ pub fn test_6_3_11_usage_of_v_as_version_indicator(doc: &impl CsafTrait) -> Resu
                 && V_AS_VERSION_INDICATOR_REGEX.is_match(branch.get_name())
             {
                 errors
-                    .get_or_insert_with(Vec::new)
+                    .get_or_insert_default()
                     .push(create_v_version_indicator_error(branch.get_name(), path));
             }
         });

--- a/csaf-rs/src/validations/test_6_3_3.rs
+++ b/csaf-rs/src/validations/test_6_3_3.rs
@@ -16,7 +16,7 @@ pub fn test_6_3_3_missing_cve(doc: &impl CsafTrait) -> Result<(), Vec<Validation
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if vuln.get_cve().is_none() {
-            errors.get_or_insert_with(Vec::new).push(create_missing_cve_error(v_i));
+            errors.get_or_insert_default().push(create_missing_cve_error(v_i));
         }
     }
 

--- a/csaf-rs/src/validations/test_6_3_4.rs
+++ b/csaf-rs/src/validations/test_6_3_4.rs
@@ -16,7 +16,7 @@ pub fn test_6_3_4_missing_cwe(doc: &impl CsafTrait) -> Result<(), Vec<Validation
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if vuln.get_cwe().is_none() {
-            errors.get_or_insert_with(Vec::new).push(create_missing_cwe_error(v_i));
+            errors.get_or_insert_default().push(create_missing_cwe_error(v_i));
         }
     }
 

--- a/csaf-rs/src/validations/test_6_3_5.rs
+++ b/csaf-rs/src/validations/test_6_3_5.rs
@@ -34,7 +34,7 @@ pub fn test_6_3_5_use_of_short_hash(doc: &impl CsafTrait) -> Result<(), Vec<Vali
                     for (fh_i, file_hash) in hash.get_file_hashes().iter().enumerate() {
                         let file_hash_len = file_hash.get_hash().len();
                         if file_hash_len < 64 {
-                            errors.get_or_insert_with(Vec::new).push(create_short_hash_error(
+                            errors.get_or_insert_default().push(create_short_hash_error(
                                 path,
                                 h_i,
                                 fh_i,


### PR DESCRIPTION
`'s/get_or_insert_with(Vec::new)/get_or_insert_default()/g'`

The two are identical in function, `get_or_insert_default` is more idiomatic IMO (and we have been using it in most of the other code)