### PR TITLE
fix: remove user-facing panic's

### DIFF
--- a/csaf-rs/src/csaf/traits/document/tracking_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/tracking_trait.rs
@@ -87,7 +87,7 @@ pub trait TrackingTrait {
                     });
                 },
                 Invalid(error) => {
-                    panic!("{}", error)
+                    continue; // TODO: Remove this afer return type refactor
                 },
             }
         }

--- a/csaf-rs/src/csaf/traits/document/tracking_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/tracking_trait.rs
@@ -86,7 +86,7 @@ pub trait TrackingTrait {
                         valid_date,
                     });
                 },
-                Invalid(error) => {
+                Invalid(_) => {
                     continue; // TODO: Remove this afer return type refactor
                 },
             }

--- a/csaf-rs/src/validations/test_6_2_05.rs
+++ b/csaf-rs/src/validations/test_6_2_05.rs
@@ -24,9 +24,12 @@ pub fn test_6_2_05_older_init_release_than_rev_history(doc: &impl CsafTrait) -> 
     let mut rev_history = doc.get_document().get_tracking().get_revision_history_tuples();
     rev_history.inplace_sort_by_date_then_number();
     // We can safely unwrap here because empty revision histories would not parse schema validation
-    let earliest_rev_history_item_date = rev_history.first().unwrap();
+    let earliest_rev_history_item_date = match rev_history.first() {
+        None => return Ok(()), // TODO #409 return a precondition failed here,
+        Some(x) => x
+    };
     let Valid(initial_release_date) = initial_release_date else {
-        panic!();
+        return Ok(()) // TODO #409 return a precondition failed here, 
     };
     if initial_release_date.get_as_utc() < earliest_rev_history_item_date.date {
         return Err(vec![create_older_initial_release_date_error(

--- a/csaf-rs/src/validations/test_6_2_05.rs
+++ b/csaf-rs/src/validations/test_6_2_05.rs
@@ -26,10 +26,10 @@ pub fn test_6_2_05_older_init_release_than_rev_history(doc: &impl CsafTrait) -> 
     // We can safely unwrap here because empty revision histories would not parse schema validation
     let earliest_rev_history_item_date = match rev_history.first() {
         None => return Ok(()), // TODO #409 return a precondition failed here,
-        Some(x) => x
+        Some(x) => x,
     };
     let Valid(initial_release_date) = initial_release_date else {
-        return Ok(()) // TODO #409 return a precondition failed here, 
+        return Ok(()); // TODO #409 return a precondition failed here, 
     };
     if initial_release_date.get_as_utc() < earliest_rev_history_item_date.date {
         return Err(vec![create_older_initial_release_date_error(

--- a/csaf-rs/src/validations/test_6_2_06.rs
+++ b/csaf-rs/src/validations/test_6_2_06.rs
@@ -1,5 +1,5 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime::Valid;
-use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionHistoryItem, RevisionHistorySortable, TrackingTrait};
+use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionHistorySortable, TrackingTrait};
 use crate::validation::ValidationError;
 
 fn create_older_current_release_date_error(
@@ -26,10 +26,10 @@ pub fn test_6_2_06_older_current_release_than_rev_history(doc: &impl CsafTrait) 
     // We can safely unwrap here because empty revision histories would not parse schema validation
     let newest_rev_history_item_date = match rev_history.last() {
         None => return Ok(()), // TODO #409 return a precondition failed here,
-        Some(x) => x
+        Some(x) => x,
     };
     let Valid(current_release_date) = current_release_date else {
-        return Ok(()) // TODO #409 return a precondition failed here
+        return Ok(()); // TODO #409 return a precondition failed here
     };
     if current_release_date.get_as_utc() < newest_rev_history_item_date.date {
         return Err(vec![create_older_current_release_date_error(

--- a/csaf-rs/src/validations/test_6_2_06.rs
+++ b/csaf-rs/src/validations/test_6_2_06.rs
@@ -1,5 +1,5 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime::Valid;
-use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionHistorySortable, TrackingTrait};
+use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionHistoryItem, RevisionHistorySortable, TrackingTrait};
 use crate::validation::ValidationError;
 
 fn create_older_current_release_date_error(
@@ -24,9 +24,12 @@ pub fn test_6_2_06_older_current_release_than_rev_history(doc: &impl CsafTrait) 
     let mut rev_history = doc.get_document().get_tracking().get_revision_history_tuples();
     rev_history.inplace_sort_by_date_then_number();
     // We can safely unwrap here because empty revision histories would not parse schema validation
-    let newest_rev_history_item_date = rev_history.last().unwrap();
+    let newest_rev_history_item_date = match rev_history.last() {
+        None => return Ok(()), // TODO #409 return a precondition failed here,
+        Some(x) => x
+    };
     let Valid(current_release_date) = current_release_date else {
-        panic!();
+        return Ok(()) // TODO #409 return a precondition failed here
     };
     if current_release_date.get_as_utc() < newest_rev_history_item_date.date {
         return Err(vec![create_older_current_release_date_error(


### PR DESCRIPTION
Remove 3 panic/unwrap cases in user-facing code, that will be removed fully with the revision history refactor.