### PR TITLE
fix: remove writing in build for docs.rs build because they have a readonly file system

### DIFF
--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -44,6 +44,9 @@ uuid = { version = "1.17.0", features = ["v7", "serde", "js"] }
 [dev-dependencies]
 rstest = "0.26.1"
 
+[package.metadata.docs.rs]
+rustc-args = ["--cfg", "docsrs"]
+
 [build-dependencies]
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/csaf-rs/build.rs
+++ b/csaf-rs/build.rs
@@ -27,6 +27,12 @@ pub enum BuildError {
 fn main() -> Result<(), BuildError> {
     println!("cargo:rerun-if-changed=build.rs");
 
+    // On docs.rs builds the filesystem is read-only. The generated files are
+    // already committed, so we can skip code generation entirely.
+    if std::env::var("DOCS_RS").is_ok() {
+        return Ok(());
+    }
+
     // All schema files for change watching
     let schema_configs = [
         (


### PR DESCRIPTION
When publishing on crates.io a build is triggered to generate the documentation. In our case this build could trigger that files will we updated. Because the used container on crates.io uses a readonly filesystem, this step would break the build and the documentation won't get updated.