### PR TITLE
feat: add test 6.3.2

### DIFF
--- a/csaf-rs/src/csaf2_0/validation.rs
+++ b/csaf-rs/src/csaf2_0/validation.rs
@@ -166,7 +166,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
             match test_id {
                 // informative tests
                 "6.3.1" => Some(ValidatorForTest6_3_1.validate(self)),
-                "6.3.2" => None, // Some(ValidatorForTest6_3_2.validate(self)),
+                "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
                 "6.3.3" => Some(ValidatorForTest6_3_3.validate(self)),
                 "6.3.4" => Some(ValidatorForTest6_3_4.validate(self)),
                 "6.3.5" => Some(ValidatorForTest6_3_5.validate(self)),

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -264,7 +264,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
             match test_id {
                 // informative tests
                 "6.3.1" => None,  // Some(ValidatorForTests6_3_1.validate(self)),
-                "6.3.2" => None,  // Some(ValidatorForTests6_3_2.validate(self)),
+                "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
                 "6.3.3" => None,  // Some(ValidatorForTests6_3_3.validate(self)),
                 "6.3.4" => None,  // Some(ValidatorForTests6_3_4.validate(self)),
                 "6.3.5" => None,  // Some(ValidatorForTests6_3_5.validate(self)),

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -263,7 +263,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
             Severity::Info,
             match test_id {
                 // informative tests
-                "6.3.1" => None,  // Some(ValidatorForTests6_3_1.validate(self)),
+                "6.3.1" => None, // Some(ValidatorForTests6_3_1.validate(self)),
                 "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
                 "6.3.3" => None,  // Some(ValidatorForTests6_3_3.validate(self)),
                 "6.3.4" => None,  // Some(ValidatorForTests6_3_4.validate(self)),

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -107,8 +107,8 @@ pub mod test_6_2_41;
 pub mod test_6_2_48;
 pub mod test_6_2_52;
 
-pub mod test_6_3_1;
 pub mod test_6_3_02;
+pub mod test_6_3_1;
 pub mod test_6_3_3;
 pub mod test_6_3_4;
 pub mod test_6_3_5;

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -108,7 +108,7 @@ pub mod test_6_2_48;
 pub mod test_6_2_52;
 
 pub mod test_6_3_1;
-// pub mod test_6_3_2;
+pub mod test_6_3_2;
 pub mod test_6_3_3;
 pub mod test_6_3_4;
 pub mod test_6_3_5;

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -108,7 +108,7 @@ pub mod test_6_2_48;
 pub mod test_6_2_52;
 
 pub mod test_6_3_1;
-pub mod test_6_3_2;
+pub mod test_6_3_02;
 pub mod test_6_3_3;
 pub mod test_6_3_4;
 pub mod test_6_3_5;

--- a/csaf-rs/src/validations/test_6_1_16.rs
+++ b/csaf-rs/src/validations/test_6_1_16.rs
@@ -21,11 +21,11 @@ pub fn test_6_1_16_latest_document_version(doc: &impl CsafTrait) -> Result<(), V
         let doc_version = tracking.get_version();
         // As there are additional criteria to the equality check, we cant just use the Eq impl
         match (&latest_number, &doc_version) {
-            (CsafVersionNumber::IntVer(last_number), CsafVersionNumber::IntVer(doc_version)) => {
+            (CsafVersionNumber::IntVer(last_number), CsafVersionNumber::IntVer(doc_version))
+                if doc_version == last_number =>
+            {
                 // For integer version numbers, the eq compares the u64 ints
-                if doc_version == last_number {
-                    return Ok(());
-                }
+                return Ok(());
             },
             (CsafVersionNumber::SemVer(last_number), CsafVersionNumber::SemVer(doc_version)) => {
                 // Manually compare the semver instances according to test requirements

--- a/csaf-rs/src/validations/test_6_1_33.rs
+++ b/csaf-rs/src/validations/test_6_1_33.rs
@@ -31,7 +31,7 @@ pub fn test_6_1_33_multiple_flags_with_vex_codes_per_product(doc: &impl CsafTrai
                 // iterate over all group ids, resolve each group id separately
                 if let Some(group_ids) = flag.get_group_ids() {
                     for group_id in group_ids {
-                        if let Some(resolved_product_ids) = resolve_product_groups(doc, [group_id].into_iter()) {
+                        if let Some(resolved_product_ids) = resolve_product_groups(doc, [group_id]) {
                             // add the resolved product ids to the product_id_to_flags map with group id
                             for product_id in resolved_product_ids {
                                 product_id_to_flags_map.entry(product_id).or_default().push((

--- a/csaf-rs/src/validations/test_6_3_02.rs
+++ b/csaf-rs/src/validations/test_6_3_02.rs
@@ -1,14 +1,14 @@
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
 use crate::validation::ValidationError;
 
-fn create_cvss_v3_0_used_error(content_path: &String) -> ValidationError {
+fn create_cvss_v3_0_used_error(content_path: &str) -> ValidationError {
     ValidationError {
         message: "CVSS v3.0 is used (version is '3.0').".to_string(),
         instance_path: format!("{content_path}/cvss_v3/version"),
     }
 }
 
-fn create_cvss_v3_0_vector_string_error(content_path: &String) -> ValidationError {
+fn create_cvss_v3_0_vector_string_error(content_path: &str) -> ValidationError {
     ValidationError {
         message: "CVSS v3.0 is used (vectorString prefix is 'CVSS:3.0/').".to_string(),
         instance_path: format!("{content_path}/cvss_v3/vectorString"),
@@ -20,7 +20,7 @@ fn create_cvss_v3_0_vector_string_error(content_path: &String) -> ValidationErro
 /// For each item in the list of metrics which contains the cvss_v3 object under content
 /// it MUST be tested that CVSS v3.0 is not used.
 ///
-/// Using the cvss deserialization here is to resource intensive for this simple test.
+/// Using the CVSS deserialization here is too resource-intensive for this simple test.
 /// We only need to check if the two relevant fields `cvss_v3/version` and `cvss_v3/vectorString`
 /// indicate CVSS v3.0, which can be done with simple string comparisons.
 ///
@@ -75,25 +75,25 @@ mod tests {
     #[test]
     fn test_test_6_3_2() {
         let case_01_v3_0_used_csaf_20 = Err(vec![
-            create_cvss_v3_0_used_error(&"/vulnerabilities/0/scores/0".to_string()),
-            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/scores/0".to_string()),
+            create_cvss_v3_0_used_error("/vulnerabilities/0/scores/0"),
+            create_cvss_v3_0_vector_string_error("/vulnerabilities/0/scores/0"),
         ]);
         let case_01_v3_0_used_csaf_21 = Err(vec![
-            create_cvss_v3_0_used_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
-            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
+            create_cvss_v3_0_used_error("/vulnerabilities/0/metrics/0/content"),
+            create_cvss_v3_0_vector_string_error("/vulnerabilities/0/metrics/0/content"),
         ]);
 
         let case_02_mixed_some_with_v3_0_csaf_20 = Err(vec![
-            create_cvss_v3_0_used_error(&"/vulnerabilities/0/scores/0".to_string()),
-            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/scores/0".to_string()),
-            create_cvss_v3_0_used_error(&"/vulnerabilities/2/scores/0".to_string()),
-            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/2/scores/0".to_string()),
+            create_cvss_v3_0_used_error("/vulnerabilities/0/scores/0"),
+            create_cvss_v3_0_vector_string_error("/vulnerabilities/0/scores/0"),
+            create_cvss_v3_0_used_error("/vulnerabilities/2/scores/0"),
+            create_cvss_v3_0_vector_string_error("/vulnerabilities/2/scores/0"),
         ]);
         let case_02_mixed_some_with_v3_0_csaf_21 = Err(vec![
-            create_cvss_v3_0_used_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
-            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
-            create_cvss_v3_0_used_error(&"/vulnerabilities/2/metrics/0/content".to_string()),
-            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/2/metrics/0/content".to_string()),
+            create_cvss_v3_0_used_error("/vulnerabilities/0/metrics/0/content"),
+            create_cvss_v3_0_vector_string_error("/vulnerabilities/0/metrics/0/content"),
+            create_cvss_v3_0_used_error("/vulnerabilities/2/metrics/0/content"),
+            create_cvss_v3_0_vector_string_error("/vulnerabilities/2/metrics/0/content"),
         ]);
 
         // Case 11: 1 vuln with v3.1

--- a/csaf-rs/src/validations/test_6_3_2.rs
+++ b/csaf-rs/src/validations/test_6_3_2.rs
@@ -1,0 +1,115 @@
+use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
+use crate::validation::ValidationError;
+
+fn create_cvss_v3_0_used_error(content_path: &String) -> ValidationError {
+    ValidationError {
+        message: "CVSS v3.0 is used (version is '3.0').".to_string(),
+        instance_path: format!("{content_path}/cvss_v3/version"),
+    }
+}
+
+fn create_cvss_v3_0_vector_string_error(content_path: &String) -> ValidationError {
+    ValidationError {
+        message: "CVSS v3.0 is used (vectorString prefix is 'CVSS:3.0/').".to_string(),
+        instance_path: format!("{content_path}/cvss_v3/vectorString"),
+    }
+}
+
+/// 6.3.2 Use of CVSS v3.0
+///
+/// For each item in the list of metrics which contains the cvss_v3 object under content
+/// it MUST be tested that CVSS v3.0 is not used.
+///
+/// Using the cvss deserialization here is to resource intensive for this simple test.
+/// We only need to check if the two relevant fields `cvss_v3/version` and `cvss_v3/vectorString`
+/// indicate CVSS v3.0, which can be done with simple string comparisons.
+///
+/// Returns up to two errors, if `version` is `3.0` and / or `vectorString` starts with `CVSS:3.0/`.
+pub fn test_6_3_2_use_of_cvss_v3_0(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+    let mut errors: Option<Vec<ValidationError>> = None;
+
+    for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
+        if let Some(metrics) = vuln.get_metrics() {
+            for (m_i, metric) in metrics.iter().enumerate() {
+                let content = metric.get_content();
+                if let Some(cvss_v3_map) = content.get_cvss_v3() {
+                    let content_path = content.get_content_json_path(v_i, m_i);
+
+                    // if version is "3.0", add an error
+                    if cvss_v3_map
+                        .get("version")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|v| v == "3.0")
+                    {
+                        errors
+                            .get_or_insert_default()
+                            .push(create_cvss_v3_0_used_error(&content_path));
+                    }
+
+                    // if vectorString starts with "CVSS:3.0/", add an error
+                    if cvss_v3_map
+                        .get("vectorString")
+                        .and_then(|v| v.as_str())
+                        .is_some_and(|v| v.starts_with("CVSS:3.0/"))
+                    {
+                        errors
+                            .get_or_insert_default()
+                            .push(create_cvss_v3_0_vector_string_error(&content_path));
+                    }
+                }
+            }
+        }
+    }
+
+    errors.map_or(Ok(()), Err)
+}
+
+crate::test_validation::impl_validator!(ValidatorForTest6_3_2, test_6_3_2_use_of_cvss_v3_0);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::TESTS_2_1;
+
+    #[test]
+    fn test_test_6_3_2() {
+        let case_01_v3_0_used_csaf_20 = Err(vec![
+            create_cvss_v3_0_used_error(&"/vulnerabilities/0/scores/0".to_string()),
+            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/scores/0".to_string()),
+        ]);
+        let case_01_v3_0_used_csaf_21 = Err(vec![
+            create_cvss_v3_0_used_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
+            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
+        ]);
+
+        let case_02_mixed_some_with_v3_0_csaf_20 = Err(vec![
+            create_cvss_v3_0_used_error(&"/vulnerabilities/0/scores/0".to_string()),
+            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/scores/0".to_string()),
+            create_cvss_v3_0_used_error(&"/vulnerabilities/2/scores/0".to_string()),
+            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/2/scores/0".to_string()),
+        ]);
+        let case_02_mixed_some_with_v3_0_csaf_21 = Err(vec![
+            create_cvss_v3_0_used_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
+            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/0/metrics/0/content".to_string()),
+            create_cvss_v3_0_used_error(&"/vulnerabilities/2/metrics/0/content".to_string()),
+            create_cvss_v3_0_vector_string_error(&"/vulnerabilities/2/metrics/0/content".to_string()),
+        ]);
+
+        // Case 11: 1 vuln with v3.1
+        // Case 12: 3 vulns with v3.1
+
+        TESTS_2_0.test_6_3_2.expect(
+            case_01_v3_0_used_csaf_20,
+            case_02_mixed_some_with_v3_0_csaf_20,
+            Ok(()),
+            Ok(()),
+        );
+        TESTS_2_1.test_6_3_2.expect(
+            case_01_v3_0_used_csaf_21,
+            case_02_mixed_some_with_v3_0_csaf_21,
+            Ok(()),
+            Ok(()),
+        );
+    }
+}


### PR DESCRIPTION
Resolves #138 
Resolves #270 

This PR adds test 6.3.2. 

We have the cvss derserialization now, but I decided against using it, as the overhead ist not justified for what can be achieved with two string compares.

Lets discuss if we should add the following supplemental test cases:
* mix of 3.0 / 3.1 in version / vector  
* version or vector missing

These are prevented by the json schema of cvss v3.x, but the validation against that is only done in 6.1.8.
To this test, the cvss_v3 object is a plain json object, which could contain anything.

-> Opened an issue for this: #578 
