### PR TITLE
refactor: move util function, improve doc, code structure

### DIFF
--- a/csaf-rs/src/csaf/traits/util/mod.rs
+++ b/csaf-rs/src/csaf/traits/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod extract_references;
 pub mod generic_with;
 pub mod not_present_20;
+pub mod resolve_product_groups;

--- a/csaf-rs/src/csaf/traits/util/resolve_product_groups.rs
+++ b/csaf-rs/src/csaf/traits/util/resolve_product_groups.rs
@@ -6,8 +6,10 @@ use std::collections::{BTreeSet, HashSet};
 /// Looks up each given group ID in the document's product tree and collects
 /// all product IDs belonging to groups.
 ///
-/// Returns a deduplicated, sorted set of product IDs, or `None` if the document
-/// has no product tree or none of the requested group IDs matched.
+/// Returns `Some` with a deduplicated, sorted set of product IDs, or `None` if the document
+/// has no product tree or if there were no product IDs resolved for the given group IDs.
+/// The latter can be caused by the group IDs not existing in the product tree and / or the
+/// group IDs not being associated with any product IDs.
 ///
 /// # Arguments
 ///

--- a/csaf-rs/src/csaf/traits/util/resolve_product_groups.rs
+++ b/csaf-rs/src/csaf/traits/util/resolve_product_groups.rs
@@ -1,0 +1,41 @@
+use crate::csaf_traits::{CsafTrait, ProductGroupTrait, ProductTreeTrait};
+use std::collections::{BTreeSet, HashSet};
+
+/// Resolves a set of product group IDs to the individual product IDs they contain.
+///
+/// Looks up each given group ID in the document's product tree and collects
+/// all product IDs belonging to groups.
+///
+/// Returns a deduplicated, sorted set of product IDs, or `None` if the document
+/// has no product tree or none of the requested group IDs matched.
+///
+/// # Arguments
+///
+/// * `doc` - A CSAF document implementing [`CsafTrait`], used to access the product tree
+/// * `product_groups` - An iterator of product group ID strings to resolve
+pub fn resolve_product_groups<'a, I>(doc: &impl CsafTrait, product_groups: I) -> Option<BTreeSet<String>>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    // early return if there isn't a product tree
+    let product_tree = doc.get_product_tree()?;
+
+    // collect requested group IDs into a hashset for O(1) lookup
+    let product_groups: HashSet<&String> = product_groups.into_iter().collect();
+
+    let product_ids: BTreeSet<String> = product_tree
+        .get_product_groups()
+        .iter()
+        // filter out all non-queried group ids
+        .filter(|x| product_groups.contains(x.get_group_id()))
+        // resolve the group into its product ids
+        .flat_map(|x| x.get_product_ids())
+        .map(|p| p.to_string())
+        .collect();
+
+    if product_ids.is_empty() {
+        None
+    } else {
+        Some(product_ids)
+    }
+}

--- a/csaf-rs/src/csaf/traits/vulnerabilities/remediation_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/remediation_trait.rs
@@ -1,5 +1,7 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime;
-use crate::csaf_traits::{CsafTrait, WithOptionalDate, WithOptionalGroupIds, WithOptionalProductIds};
+use crate::csaf_traits::{
+    CsafTrait, WithOptionalDate, WithOptionalGroupIds, WithOptionalProductIds, resolve_product_groups,
+};
 use crate::schema::csaf2_0::schema::{
     CategoryOfTheRemediation as CategoryOfTheRemediation20, Remediation as Remediation20,
 };
@@ -38,7 +40,7 @@ pub trait RemediationTrait: WithOptionalGroupIds + WithOptionalProductIds + With
                 None => BTreeSet::new(),
             };
             if let Some(product_groups) = self.get_group_ids()
-                && let Some(product_ids) = crate::helpers::resolve_product_groups(doc, product_groups)
+                && let Some(product_ids) = resolve_product_groups(doc, product_groups)
             {
                 product_set.extend(product_ids.iter().map(|id| id.to_owned()));
             }

--- a/csaf-rs/src/csaf_traits.rs
+++ b/csaf-rs/src/csaf_traits.rs
@@ -25,6 +25,7 @@ pub use crate::csaf::traits::shared::note_trait::NoteTrait;
 pub use crate::csaf::traits::util::generic_with::{
     WithDate, WithOptionalDate, WithOptionalGroupIds, WithOptionalProductIds,
 };
+pub use crate::csaf::traits::util::resolve_product_groups::resolve_product_groups;
 pub use crate::csaf::traits::vulnerabilities::content_trait::ContentTrait;
 pub use crate::csaf::traits::vulnerabilities::epss_trait::EpssTrait;
 pub use crate::csaf::traits::vulnerabilities::file_hash_trait::FileHashTrait;

--- a/csaf-rs/src/helpers.rs
+++ b/csaf-rs/src/helpers.rs
@@ -1,28 +1,10 @@
-use crate::csaf_traits::{CsafTrait, ProductGroupTrait, ProductTreeTrait};
 use crate::csaf2_1::ssvc_dp::DecisionPoint;
 use chrono::NaiveDate;
 use rust_embed::RustEmbed;
 use serde_json::Value;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
 use std::sync::LazyLock;
-
-pub fn resolve_product_groups<'a, I>(doc: &impl CsafTrait, product_groups: I) -> Option<BTreeSet<String>>
-where
-    I: IntoIterator<Item = &'a String>,
-{
-    let product_groups: Vec<&String> = product_groups.into_iter().collect();
-
-    doc.get_product_tree().map(|product_tree| {
-        product_tree
-            .get_product_groups()
-            .iter()
-            .filter(|x| product_groups.iter().any(|g| *g == x.get_group_id()))
-            .flat_map(|x| x.get_product_ids())
-            .map(|p| p.to_string())
-            .collect()
-    })
-}
 
 #[derive(RustEmbed)]
 #[folder = "assets/ssvc_decision_points/"]

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -1,10 +1,10 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
+use crate::csaf_traits::resolve_product_groups;
 use crate::csaf_traits::{
     CsafTrait, DocumentTrait, ProductStatusTrait, ThreatTrait, VulnerabilityTrait, WithOptionalGroupIds,
     WithOptionalProductIds,
 };
 use crate::document_category_test_helper::DocumentCategoryTestConfig;
-use crate::helpers::resolve_product_groups;
 use crate::schema::csaf2_1::schema::CategoryOfTheThreat;
 use crate::validation::ValidationError;
 use std::collections::{HashMap, HashSet};

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -4,8 +4,6 @@ use crate::csaf_traits::{
     CsafTrait, DocumentTrait, ProductStatusTrait, ThreatTrait, VulnerabilityTrait, WithOptionalGroupIds,
     WithOptionalProductIds,
 };
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
-use crate::helpers::resolve_product_groups;
 use crate::schema::csaf2_1::schema::CategoryOfTheThreat;
 use crate::validation::ValidationError;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -1,8 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::resolve_product_groups;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
-use crate::helpers::resolve_product_groups;
 use crate::validation::ValidationError;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 use std::collections::{HashMap, HashSet};

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
+use crate::csaf_traits::resolve_product_groups;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
 use crate::document_category_test_helper::DocumentCategoryTestConfig;
-use crate::helpers::resolve_product_groups;
 use crate::validation::ValidationError;
 use std::collections::{HashMap, HashSet};
 

--- a/csaf-rs/src/validations/test_6_1_33.rs
+++ b/csaf-rs/src/validations/test_6_1_33.rs
@@ -1,5 +1,5 @@
+use crate::csaf_traits::resolve_product_groups;
 use crate::csaf_traits::{CsafTrait, FlagTrait, VulnerabilityTrait, WithOptionalGroupIds, WithOptionalProductIds};
-use crate::helpers::resolve_product_groups;
 use crate::schema::csaf2_1::schema::LabelOfTheFlag;
 use crate::validation::ValidationError;
 use std::collections::HashMap;


### PR DESCRIPTION
This PR:
* move the last helper function into the need file structure
* improves code structure with an early return for non-existent product trees
* adds doc comment
* improves performance by:
  * group ids are now collected into a hashset into a vec, which changes iter().any() into contains(), which is O(1) instead of O(n) for that lookup
  
  