### PR TITLE
chore: add clippy::needless_collect lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["csaf-validator", "csaf-rs", "type-generator", "csaf-converter"]
 resolver = "2"
+
+[workspace.lints.clippy]
+needless_collect = "deny"
+

--- a/csaf-converter/Cargo.toml
+++ b/csaf-converter/Cargo.toml
@@ -10,6 +10,9 @@ edition = "2024"
 rust-version = "1.88.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 csaf-rs = { path = "../csaf-rs", version = "0.4.1", features = ["default", "converter"] }
 anyhow = "1.0.93"

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -9,6 +9,9 @@ version = "0.4.1"
 edition = "2024"
 rust-version = "1.88.0"
 
+[lints]
+workspace = true
+
 [lib]
 name = "csaf"
 crate-type = ["cdylib", "rlib"]

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -71,7 +71,7 @@ pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
 
         // merge the resolved product ids from group ids into the directly found product ids
         if let Some(resolved_product_ids) =
-            resolve_product_groups(doc, &found_group_ids.into_iter().collect::<Vec<_>>())
+            resolve_product_groups(doc, &found_group_ids)
         {
             found_product_ids.extend(resolved_product_ids.iter().map(|product_id| product_id.to_owned()));
         }

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -48,29 +48,23 @@ pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
             vulnerability
                 .get_flags_group_references()
                 .iter()
-                .map(|(group_id, _)| group_id.to_owned())
-                .collect::<Vec<String>>(),
+                .map(|(group_id, _)| group_id.to_owned()),
         );
         found_product_ids.extend(
             vulnerability
                 .get_flags_product_references()
                 .iter()
-                .map(|(product_id, _)| product_id.to_owned())
-                .collect::<Vec<String>>(),
+                .map(|(product_id, _)| product_id.to_owned()),
         );
 
         // gather from threats with category impact
         for threat in vulnerability.get_threats().iter() {
             if threat.get_category() == CategoryOfTheThreat::Impact {
                 if let Some(group_ids) = threat.get_group_ids() {
-                    found_group_ids.extend(group_ids.map(|group_id| group_id.to_owned()).collect::<Vec<String>>());
+                    found_group_ids.extend(group_ids.map(|group_id| group_id.to_owned()));
                 }
                 if let Some(product_ids) = threat.get_product_ids() {
-                    found_product_ids.extend(
-                        product_ids
-                            .map(|product_id| product_id.to_owned())
-                            .collect::<Vec<String>>(),
-                    );
+                    found_product_ids.extend(product_ids.map(|product_id| product_id.to_owned()));
                 }
             }
         }

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -70,9 +70,7 @@ pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
         }
 
         // merge the resolved product ids from group ids into the directly found product ids
-        if let Some(resolved_product_ids) =
-            resolve_product_groups(doc, &found_group_ids)
-        {
+        if let Some(resolved_product_ids) = resolve_product_groups(doc, &found_group_ids) {
             found_product_ids.extend(resolved_product_ids.iter().map(|product_id| product_id.to_owned()));
         }
 

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -42,15 +42,13 @@ pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
             vulnerability
                 .get_remediations_product_references()
                 .iter()
-                .map(|(product_id, _)| product_id.to_owned())
-                .collect::<Vec<String>>(),
+                .map(|(product_id, _)| product_id.to_owned()),
         );
         found_group_ids.extend(
             vulnerability
                 .get_remediations_group_references()
                 .iter()
-                .map(|(group_id, _)| group_id.to_owned())
-                .collect::<Vec<String>>(),
+                .map(|(group_id, _)| group_id.to_owned()),
         );
 
         // merge the resolved product ids from group ids into the directly found product ids

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -52,9 +52,7 @@ pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
         );
 
         // merge the resolved product ids from group ids into the directly found product ids
-        if let Some(resolved_product_ids) =
-            resolve_product_groups(doc, &found_group_ids)
-        {
+        if let Some(resolved_product_ids) = resolve_product_groups(doc, &found_group_ids) {
             found_product_ids.extend(resolved_product_ids.iter().map(|product_id| product_id.to_owned()));
         }
 

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -53,7 +53,7 @@ pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
 
         // merge the resolved product ids from group ids into the directly found product ids
         if let Some(resolved_product_ids) =
-            resolve_product_groups(doc, &found_group_ids.into_iter().collect::<Vec<_>>())
+            resolve_product_groups(doc, &found_group_ids)
         {
             found_product_ids.extend(resolved_product_ids.iter().map(|product_id| product_id.to_owned()));
         }

--- a/csaf-validator/Cargo.toml
+++ b/csaf-validator/Cargo.toml
@@ -9,6 +9,9 @@ version = "0.4.1"
 edition = "2024"
 rust-version = "1.88.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anstream = "0.6.7"
 anstyle = "1.0.8"

--- a/type-generator/Cargo.toml
+++ b/type-generator/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 rust-version = "1.88.0"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 schemars = "0.8"
 clap = {version =  "4.5.53", features = ["derive"]}


### PR DESCRIPTION
This PR:
* adds a workspace level clippy config
* uses that config in all crates
* adds a first rule to check for unnecessary collects, which does have a negative performance impact (more infos: https://rust-lang.github.io/rust-clippy/master/index.html#needless_collect)