### PR TITLE
chore: remove doc category validation helper from api

### DIFF
--- a/csaf-rs/src/lib.rs
+++ b/csaf-rs/src/lib.rs
@@ -5,7 +5,6 @@ pub mod csaf2_0;
 pub mod csaf2_1;
 pub mod csaf_traits;
 pub(crate) mod cvss;
-pub mod document_category_test_helper;
 pub mod helpers;
 pub(crate) mod macros;
 pub mod schema;

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -1,4 +1,5 @@
 pub mod test_schema;
+pub(crate) mod utils;
 
 pub mod test_6_1_01;
 pub mod test_6_1_02;

--- a/csaf-rs/src/validations/test_6_1_27_01.rs
+++ b/csaf-rs/src/validations/test_6_1_27_01.rs
@@ -1,8 +1,8 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_note_error(doc_category: CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_02.rs
+++ b/csaf-rs/src/validations/test_6_1_27_02.rs
@@ -1,8 +1,8 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentReferenceTrait, DocumentTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::schema::csaf2_1::schema::CategoryOfReference;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_external_reference_error(doc_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_03.rs
+++ b/csaf-rs/src/validations/test_6_1_27_03.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_must_not_have_vuln_element_error(doc_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_04.rs
+++ b/csaf-rs/src/validations/test_6_1_27_04.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.4 Product Tree
 ///

--- a/csaf-rs/src/validations/test_6_1_27_05.rs
+++ b/csaf-rs/src/validations/test_6_1_27_05.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.5 Vulnerability Notes
 ///

--- a/csaf-rs/src/validations/test_6_1_27_06.rs
+++ b/csaf-rs/src/validations/test_6_1_27_06.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.6 Product Status
 ///

--- a/csaf-rs/src/validations/test_6_1_27_07.rs
+++ b/csaf-rs/src/validations/test_6_1_27_07.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.7 VEX Product Status
 ///

--- a/csaf-rs/src/validations/test_6_1_27_08.rs
+++ b/csaf-rs/src/validations/test_6_1_27_08.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.8 Vulnerability ID
 ///

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -3,10 +3,10 @@ use crate::csaf_traits::{
     CsafTrait, DocumentTrait, ProductStatusTrait, ThreatTrait, VulnerabilityTrait, WithOptionalGroupIds,
     WithOptionalProductIds,
 };
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::helpers::resolve_product_groups;
 use crate::schema::csaf2_1::schema::CategoryOfTheThreat;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 use std::collections::{HashMap, HashSet};
 
 /// 6.1.27.9 Impact Statement

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -1,8 +1,8 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::helpers::resolve_product_groups;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 use std::collections::{HashMap, HashSet};
 
 /// 6.1.27.10 Action Statement

--- a/csaf-rs/src/validations/test_6_1_27_11.rs
+++ b/csaf-rs/src/validations/test_6_1_27_11.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_vulnerabilities_error(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_12.rs
+++ b/csaf-rs/src/validations/test_6_1_27_12.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_affected_products_error(
     document_category: &CsafDocumentCategory,

--- a/csaf-rs/src/validations/test_6_1_27_14.rs
+++ b/csaf-rs/src/validations/test_6_1_27_14.rs
@@ -1,8 +1,8 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_description_note(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_15.rs
+++ b/csaf-rs/src/validations/test_6_1_27_15.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_product_tree_exists_error(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_16.rs
+++ b/csaf-rs/src/validations/test_6_1_27_16.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_revision_history_only_one_entry_error(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_17.rs
+++ b/csaf-rs/src/validations/test_6_1_27_17.rs
@@ -1,9 +1,9 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_18.rs
+++ b/csaf-rs/src/validations/test_6_1_27_18.rs
@@ -1,9 +1,9 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -1,9 +1,9 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentReferenceTrait, DocumentTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::schema::csaf2_1::schema::CategoryOfReference;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_reference_error(document_category: &CsafDocumentCategory) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/test_6_2_01.rs
+++ b/csaf-rs/src/validations/test_6_2_01.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductTrait, ProductTreeTrait};
-use crate::document_category_test_helper::DocumentCategoryTestConfig;
 use crate::validation::ValidationError;
+use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_unused_product_id_error(product_id: &str, path: &str) -> ValidationError {
     ValidationError {

--- a/csaf-rs/src/validations/utils/document_category_test_config.rs
+++ b/csaf-rs/src/validations/utils/document_category_test_config.rs
@@ -33,6 +33,8 @@ impl DocumentCategoryTestConfig {
     }
 
     /// Sets additional categories specific to CSAF 2.0.
+    /// This is currently unused, but might be necessary later if CSAF 2.0 and 2.1 drift further.
+    #[allow(dead_code)]
     pub const fn csaf20(mut self, categories: &'static [CsafDocumentCategory]) -> Self {
         self.csaf20_categories = Some(categories);
         self

--- a/csaf-rs/src/validations/utils/mod.rs
+++ b/csaf-rs/src/validations/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod document_category_test_config;


### PR DESCRIPTION
The `document_category_test_helper` was previously exposed via the API.

This is an internal helper, only meant to be used in the context of the `validations` module.

This PR removes the helper from the API and places it in a `validation/utils` module.