### PR TITLE
Fix no-default-features build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,9 @@ jobs:
       - name: Run tests
         run: cargo test --locked --target=${{ matrix.target.arch }} --verbose
         if: ${{ matrix.target.skip-test != true }}
+      - name: Build with --no-default-features
+        run: cargo build --locked --target=${{ matrix.target.arch }} --no-default-features --verbose
+        if: ${{ matrix.target.skip-test != true }}
       - name: Archive csaf-validator (${{ matrix.target.arch }})
         uses: actions/upload-artifact@v4
         with:

--- a/csaf-rs/src/validation.rs
+++ b/csaf-rs/src/validation.rs
@@ -1,8 +1,11 @@
 use TestResultStatus::*;
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "wasm")]
 use tsify::Tsify;
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, Tsify)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 #[serde(rename_all = "camelCase")]
 pub struct ValidationError {
     pub message: String,
@@ -21,7 +24,8 @@ pub trait IntoValidationError {
 }
 
 /// Result of executing a single test
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 #[serde(rename_all = "camelCase")]
 pub struct TestResult {
     /// The test ID that was executed
@@ -31,7 +35,8 @@ pub struct TestResult {
     pub status: TestResultStatus,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Tsify)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
 #[serde(rename_all = "camelCase")]
 pub enum TestResultStatus {
     Success,
@@ -45,9 +50,10 @@ pub enum TestResultStatus {
 }
 
 /// Result of a CSAF validation
-#[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 pub struct ValidationResult {
     /// Whether the validation was successful (no errors)
     pub success: bool,


### PR DESCRIPTION
The tsify dependency is (correctly) marked as optional, because it is only required by the "wasm" feature. However, it is unconditionally used in validation.rs. Since the "wasm" feature flag is enabled by default, this only becomes relevant if default features are disabled.

This PR adds a verification test for the build without default features and guards the usage of tsify behind a feature flag.