### PR TITLE
feat: revisit test 6.1.47 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ csaf-validator --csaf-version 2.1 --test-id 6.1.34 my-csaf-2-1-document.json
 | 6.1.44 | :o:                | :white_check_mark: |
 | 6.1.45 | :o:                |                    |
 | 6.1.46 | :o:                |                    |
-| 6.1.47 | :o:                |                    |
+| 6.1.47 | :o:                | :white_check_mark: |
 | 6.1.48 | :o:                |                    |
 | 6.1.49 | :o:                |                    |
 | 6.1.50 | :o:                |                    |

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -154,7 +154,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.1.44" => Some(ValidatorForTest6_1_44.validate(self)),
                 "6.1.45" => Some(ValidatorForTest6_1_45.validate(self)),
                 "6.1.46" => None, // Some(ValidatorForTest6_1_46.validate(self)),
-                "6.1.47" => None, // Some(ValidatorForTest6_1_47.validate(self)),
+                "6.1.47" => Some(ValidatorForTest6_1_47.validate(self)),
                 "6.1.48" => None, // Some(ValidatorForTest6_1_48.validate(self)),
                 "6.1.49" => None, // Some(ValidatorForTest6_1_49.validate(self)),
                 "6.1.50" => None, // Some(ValidatorForTest6_1_50.validate(self)),

--- a/csaf-rs/src/validations/test_6_1_47.rs
+++ b/csaf-rs/src/validations/test_6_1_47.rs
@@ -72,7 +72,7 @@ pub fn test_6_1_47_inconsistent_ssvc_id(doc: &impl CsafTrait) -> Result<(), Vec<
                                                 ),
                                             );
                                         }
-                                        // target ID is valid, continue to next
+                                        // target ID matched document ID
                                         continue;
                                     }
 

--- a/csaf-rs/src/validations/test_6_1_47.rs
+++ b/csaf-rs/src/validations/test_6_1_47.rs
@@ -33,57 +33,76 @@ fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usi
     }
 }
 
+/// 6.1.47 Inconsistent SSVC Target IDs
+///
+/// For each ssvc_v2 object it MUST be tested that each item in target_ids is either
+/// the CVE of the vulnerability given in cve or the text of an item in the ids array of the vulnerability.
+/// The test MUST fail, if the target ID equals the /document/tracking/id and the CSAF document
+/// contains more than one vulnerability.
 pub fn test_6_1_47_inconsistent_ssvc_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+    let mut errors: Option<Vec<ValidationError>> = None;
+
     let vulnerabilities = doc.get_vulnerabilities();
 
+    // for each vulnerability, and its metrics, if they contain ssvc_v2
     for (i_v, v) in vulnerabilities.iter().enumerate() {
         if let Some(metrics) = v.get_metrics() {
             for (i_m, m) in metrics.iter().enumerate() {
                 if m.get_content().has_ssvc() {
+                    // try to parse ssvc_v2 content as SSVC
                     match m.get_content().get_ssvc() {
+                        // parsing succeeded
                         Ok(ssvc) => {
-                            // Get the SSVC target_ids if they exist
+                            // get the SSVC target_ids if they exist
                             if let Some(target_ids) = &ssvc.target_ids {
                                 let document_id = doc.get_document().get_tracking().get_id();
 
-                                // Check each target ID
+                                // check each target ID
                                 for (i_t, target_id) in target_ids.iter().enumerate() {
-                                    // Check if target ID equals document ID
+                                    // check if target ID equals document ID
                                     if target_id == document_id {
-                                        // If there are multiple vulnerabilities, the validation must fail here.
+                                        // if there are multiple vulnerabilities, add an error
                                         if vulnerabilities.len() > 1 {
-                                            return Err(vec![create_document_id_multiple_vulnerabilities_error(
-                                                document_id,
-                                                i_v,
-                                                i_m,
-                                                i_t,
-                                            )]);
+                                            errors.get_or_insert_default().push(
+                                                create_document_id_multiple_vulnerabilities_error(
+                                                    document_id,
+                                                    i_v,
+                                                    i_m,
+                                                    i_t,
+                                                ),
+                                            );
                                         }
-                                        // Target ID is valid, continue to next
+                                        // target ID is valid, continue to next
                                         continue;
                                     }
 
-                                    // Check if it matches CVE
+                                    // check if it matches CVE
                                     if let Some(cve) = v.get_cve()
                                         && target_id == cve
                                     {
                                         continue;
                                     }
 
-                                    // Check if it matches any ID in id array
+                                    // check if it matches any ID in id array
                                     if let Some(ids) = v.get_ids()
                                         && ids.iter().any(|id| id.get_text() == target_id)
                                     {
                                         continue;
                                     }
 
-                                    // Return error if target ID is not valid
-                                    return Err(vec![create_target_id_mismatch_error(target_id, i_v, i_m, i_t)]);
+                                    // none of the above criteria were met, so the target ID is invalid
+                                    errors
+                                        .get_or_insert_default()
+                                        .push(create_target_id_mismatch_error(target_id, i_v, i_m, i_t));
                                 }
                             }
                         },
+                        // parsing failed
                         Err(err) => {
-                            return Err(vec![create_invalid_ssvc_error(err, i_v, i_m)]);
+                            // TODO #409 this will nondeterminable later
+                            errors
+                                .get_or_insert_default()
+                                .push(create_invalid_ssvc_error(err, i_v, i_m));
                         },
                     }
                 }
@@ -91,7 +110,7 @@ pub fn test_6_1_47_inconsistent_ssvc_id(doc: &impl CsafTrait) -> Result<(), Vec<
         }
     }
 
-    Ok(())
+    errors.map_or(Ok(()), Err)
 }
 
 crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_47, test_6_1_47_inconsistent_ssvc_id);
@@ -103,24 +122,47 @@ mod tests {
 
     #[test]
     fn test_test_6_1_47() {
-        // Only CSAF 2.1 has this test with 11 test cases (6 error cases, 5 success cases)
-        TESTS_2_1.test_6_1_47.expect(
-            Err(vec![create_target_id_mismatch_error("CVE-1900-0002", 0, 0, 0)]),
-            Err(vec![create_target_id_mismatch_error("CVE-1900-0001", 0, 0, 0)]),
-            Err(vec![create_target_id_mismatch_error("2723", 0, 0, 0)]),
-            Err(vec![create_target_id_mismatch_error("Bug#2723", 0, 0, 0)]),
-            Err(vec![create_target_id_mismatch_error(
-                "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-47-15",
-                0,
-                0,
-                0,
-            )]),
+        let case_01_target_id_cve_mismatch = Err(vec![create_target_id_mismatch_error("CVE-1900-0002", 0, 0, 0)]);
+        let case_02_target_id_vuln_id_mismatch = Err(vec![create_target_id_mismatch_error("CVE-1900-0001", 0, 0, 0)]);
+        let case_03_target_id_vuln_id_partial_mismatch = Err(vec![create_target_id_mismatch_error("2723", 0, 0, 0)]);
+        let case_04_target_id_vuln_id_swapped_mismatch = Err(vec![
+            create_target_id_mismatch_error("Bug#2723", 0, 0, 0),
+            create_target_id_mismatch_error("Bug#3272", 1, 0, 0),
+        ]);
+        let case_05_target_id_document_id_mismatch = Err(vec![create_target_id_mismatch_error(
+            "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-47-15",
+            0,
+            0,
+            0,
+        )]);
+        let case_06_target_id_document_id_match_multi_vuln =
             Err(vec![create_document_id_multiple_vulnerabilities_error(
                 "OASIS_CSAF_TC-CSAF_2.1-2024-6-1-47-06",
                 1,
                 0,
                 0,
-            )]),
+            )]);
+
+        // Case 01: target ID / CVE mismatch (CVE-1900-0002 vs CVE-1900-0001)
+        // Case 02: target ID / vuln IDs mismatch (CVE-1900-0001 vs [Bug#2723])
+        // Case 03: target ID / vuln IDs partial match, but still mismatch (2723 vs [Bug#2723])
+        // Case 04: 2 vulns, with target ID and vuln IDs, but the IDs are swapped (Bug#2723 vs [Bug#3272])
+        // Case 05: target ID / document ID mismatch (OASIS_CSAF_TC-CSAF_2.1-2024-6-1-47-15 vs OASIS_CSAF_TC-CSAF_2.1-2024-6-1-47-05)
+        // Case 06: target ID matches vuln IDs, but also document ID, and there are multiple vulns
+
+        // Case 11: target ID equals CVE
+        // Case 12: target ID equals CVE, there is also a vuln ID
+        // Case 13: target ID equals a vuln ID
+        // Case 14: 2 vulns, target ID equals vuln ID, there is also a CVE in the second vuln
+        // Case 15: target ID matches both document ID and vuln ID
+
+        TESTS_2_1.test_6_1_47.expect(
+            case_01_target_id_cve_mismatch,
+            case_02_target_id_vuln_id_mismatch,
+            case_03_target_id_vuln_id_partial_mismatch,
+            case_04_target_id_vuln_id_swapped_mismatch,
+            case_05_target_id_document_id_mismatch,
+            case_06_target_id_document_id_match_multi_vuln,
             Ok(()),
             Ok(()),
             Ok(()),


### PR DESCRIPTION
This PR reviews / fixes test 6.1.47. 

Previously, the first error returned the function, which hid a second error case in 6-1-47-04.

Also improved the test function readability with comments and code cleanup.

Resolves #380 