### PR TITLE
chore: remove ssvc entry from checkov.yaml

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,3 +1,2 @@
 skip-path:
   - csaf
-  - ssvc


### PR DESCRIPTION
SSVC is it's own library now. No need to ignore the now non-existent ssvc submodule.