### PR TITLE
feat: add load_from_value

### DIFF
--- a/csaf-ffi/src/lib.rs
+++ b/csaf-ffi/src/lib.rs
@@ -4,7 +4,9 @@
 //! enabling Go, WASM, and other language bindings via Mozilla UniFFI.
 
 use csaf::csaf2_0::loader::load_document_from_str as load_document_from_str_2_0;
+use csaf::csaf2_0::loader::load_document_from_value as load_document_from_value_2_0;
 use csaf::csaf2_1::loader::load_document_from_str as load_document_from_str_2_1;
+use csaf::csaf2_1::loader::load_document_from_value as load_document_from_value_2_1;
 use csaf::validation::validate_by_preset;
 
 pub mod document;
@@ -169,13 +171,13 @@ pub fn validate_csaf(json_str: String, preset: String) -> Result<ValidationResul
 
     let result = match version.as_str() {
         "2.0" => {
-            let doc =
-                load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            let doc = load_document_from_value_2_0(json_value)
+                .map_err(|e| CsafError::LoadError { message: e.to_string() })?;
             validate_by_preset(&doc, "2.0", &preset)
         },
         "2.1" => {
-            let doc =
-                load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            let doc = load_document_from_value_2_1(json_value)
+                .map_err(|e| CsafError::LoadError { message: e.to_string() })?;
             validate_by_preset(&doc, "2.1", &preset)
         },
         other => {

--- a/csaf-rs/src/csaf2_0/loader.rs
+++ b/csaf-rs/src/csaf2_0/loader.rs
@@ -14,6 +14,16 @@ pub fn load_document_from_str(json_str: &str) -> std::io::Result<RawDocument<Com
     Ok(doc)
 }
 
+/// Load a CSAF document from an already-parsed [`serde_json::Value`].
+///
+/// Use this when the JSON has already been parsed (e.g. to extract the
+/// `document.csaf_version` field) to avoid parsing the same string twice.
+pub fn load_document_from_value(
+    value: serde_json::Value,
+) -> Result<RawDocument<CommonSecurityAdvisoryFramework>, serde_json::Error> {
+    Ok(RawDocument::new(serde_json::from_value(value)?))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::schema::csaf2_0::schema::{

--- a/csaf-rs/src/csaf2_1/loader.rs
+++ b/csaf-rs/src/csaf2_1/loader.rs
@@ -14,6 +14,16 @@ pub fn load_document_from_str(json_str: &str) -> std::io::Result<RawDocument<Com
     Ok(doc)
 }
 
+/// Load a CSAF document from an already-parsed [`serde_json::Value`].
+///
+/// Use this when the JSON has already been parsed (e.g. to extract the
+/// `document.csaf_version` field) to avoid parsing the same string twice.
+pub fn load_document_from_value(
+    value: serde_json::Value,
+) -> Result<RawDocument<CommonSecurityAdvisoryFramework>, serde_json::Error> {
+    Ok(RawDocument::new(serde_json::from_value(value)?))
+}
+
 #[cfg(test)]
 mod tests {
     use crate::schema::csaf2_1::schema::{


### PR DESCRIPTION
Adds a function to load the document from an already parsed serde_json:Value. This can prevent parsing the document twice.