### PR TITLE
feat: adds validate _as_json functions for WASM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
 
 [[package]]
 name = "csaf-ffi"
-version = "0.3.1"
+version = "0.4.1"
 dependencies = [
  "csaf-rs",
  "serde_json",

--- a/csaf-ffi/Cargo.toml
+++ b/csaf-ffi/Cargo.toml
@@ -2,7 +2,7 @@
 name = "csaf-ffi"
 description = "UniFFI bindings for the csaf-rs CSAF validation library"
 license = "Apache-2.0"
-version = "0.3.1"
+version = "0.4.1"
 edition = "2021"
 rust-version = "1.88.0"
 publish = false

--- a/csaf-ffi/src/lib.rs
+++ b/csaf-ffi/src/lib.rs
@@ -150,7 +150,7 @@ impl From<csaf::validation::ValidationResult> for ValidationResult {
 /// # Arguments
 ///
 /// * `json_str` - The CSAF document as a JSON string.
-/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+/// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 ///
 /// # Returns
 ///
@@ -195,7 +195,7 @@ pub fn validate_csaf(json_str: String, preset: String) -> Result<ValidationResul
 /// # Arguments
 ///
 /// * `json_str` - The CSAF 2.0 document as a JSON string.
-/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+/// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_0(json_str: String, preset: String) -> Result<ValidationResult, CsafError> {
     let doc = load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
@@ -207,7 +207,7 @@ pub fn validate_csaf_2_0(json_str: String, preset: String) -> Result<ValidationR
 /// # Arguments
 ///
 /// * `json_str` - The CSAF 2.1 document as a JSON string.
-/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+/// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_1(json_str: String, preset: String) -> Result<ValidationResult, CsafError> {
     let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
@@ -224,7 +224,7 @@ pub fn validate_csaf_2_1(json_str: String, preset: String) -> Result<ValidationR
 /// # Arguments
 ///
 /// * `json_str` - The CSAF document as a JSON string.
-/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+/// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
     let json_value: serde_json::Value =
@@ -268,7 +268,7 @@ pub fn validate_csaf_as_json(json_str: String, preset: String) -> Result<String,
 /// # Arguments
 ///
 /// * `json_str` - The CSAF 2.0 document as a JSON string.
-/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+/// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_0_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
     let doc = load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
@@ -284,7 +284,7 @@ pub fn validate_csaf_2_0_as_json(json_str: String, preset: String) -> Result<Str
 /// # Arguments
 ///
 /// * `json_str` - The CSAF 2.1 document as a JSON string.
-/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+/// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_1_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
     let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;

--- a/csaf-ffi/src/lib.rs
+++ b/csaf-ffi/src/lib.rs
@@ -213,3 +213,81 @@ pub fn validate_csaf_2_1(json_str: String, preset: String) -> Result<ValidationR
     let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     Ok(validate_by_preset(&doc, "2.1", &preset).into())
 }
+
+/// Validate a CSAF document from a JSON string and return the result as JSON.
+///
+/// Same as [`validate_csaf`] but returns the [`ValidationResult`] serialized
+/// as a JSON string instead of a typed UniFFI record.  Prefer this in WASM
+/// contexts: `JSON.parse(result)` is much faster than the UniFFI binary
+/// deserializer for the result type.
+///
+/// # Arguments
+///
+/// * `json_str` - The CSAF document as a JSON string.
+/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+#[uniffi::export]
+pub fn validate_csaf_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
+    let json_value: serde_json::Value =
+        serde_json::from_str(&json_str).map_err(|e| CsafError::InvalidJson { message: e.to_string() })?;
+
+    let version = json_value
+        .get("document")
+        .and_then(|doc| doc.get("csaf_version"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CsafError::MissingVersion {
+            message: "document.csaf_version field not found".into(),
+        })?
+        .to_string();
+
+    let result = match version.as_str() {
+        "2.0" => {
+            let doc =
+                load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            validate_by_preset(&doc, "2.0", &preset)
+        },
+        "2.1" => {
+            let doc =
+                load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            validate_by_preset(&doc, "2.1", &preset)
+        },
+        other => {
+            return Err(CsafError::UnsupportedVersion {
+                version: other.to_string(),
+            });
+        },
+    };
+
+    serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })
+}
+
+/// Validate a CSAF 2.0 document and return the result as JSON.
+///
+/// Same as [`validate_csaf_2_0`] but returns the [`ValidationResult`]
+/// serialized as a JSON string.  Prefer in WASM contexts.
+///
+/// # Arguments
+///
+/// * `json_str` - The CSAF 2.0 document as a JSON string.
+/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+#[uniffi::export]
+pub fn validate_csaf_2_0_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
+    let doc = load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+    let result = validate_by_preset(&doc, "2.0", &preset);
+    serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })
+}
+
+/// Validate a CSAF 2.1 document and return the result as JSON.
+///
+/// Same as [`validate_csaf_2_1`] but returns the [`ValidationResult`]
+/// serialized as a JSON string.  Prefer in WASM contexts.
+///
+/// # Arguments
+///
+/// * `json_str` - The CSAF 2.1 document as a JSON string.
+/// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+#[uniffi::export]
+pub fn validate_csaf_2_1_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
+    let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+    let result = validate_by_preset(&doc, "2.1", &preset);
+    serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })
+}

--- a/csaf-ffi/src/lib.rs
+++ b/csaf-ffi/src/lib.rs
@@ -226,7 +226,7 @@ pub fn validate_csaf_2_1(json_str: String, preset: String) -> Result<ValidationR
 /// * `json_str` - The CSAF document as a JSON string.
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
-pub fn validate_csaf_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
+pub fn validate_csaf_to_json_string(json_str: String, preset: String) -> Result<String, CsafError> {
     let json_value: serde_json::Value =
         serde_json::from_str(&json_str).map_err(|e| CsafError::InvalidJson { message: e.to_string() })?;
 
@@ -270,7 +270,7 @@ pub fn validate_csaf_as_json(json_str: String, preset: String) -> Result<String,
 /// * `json_str` - The CSAF 2.0 document as a JSON string.
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
-pub fn validate_csaf_2_0_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
+pub fn validate_csaf_2_0_to_json_string(json_str: String, preset: String) -> Result<String, CsafError> {
     let doc = load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     let result = validate_by_preset(&doc, "2.0", &preset);
     serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })
@@ -286,7 +286,7 @@ pub fn validate_csaf_2_0_as_json(json_str: String, preset: String) -> Result<Str
 /// * `json_str` - The CSAF 2.1 document as a JSON string.
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
-pub fn validate_csaf_2_1_as_json(json_str: String, preset: String) -> Result<String, CsafError> {
+pub fn validate_csaf_2_1_to_json_string(json_str: String, preset: String) -> Result<String, CsafError> {
     let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     let result = validate_by_preset(&doc, "2.1", &preset);
     serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })

--- a/go/csaf_ffi/csaf_ffi.go
+++ b/go/csaf_ffi/csaf_ffi.go
@@ -373,7 +373,7 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_csaf_ffi_checksum_func_validate_csaf()
 		})
-		if checksum != 6588 {
+		if checksum != 52424 {
 			// If this happens try cleaning and rebuilding your project
 			panic("csaf_ffi: uniffi_csaf_ffi_checksum_func_validate_csaf: UniFFI API checksum mismatch")
 		}
@@ -382,18 +382,45 @@ func uniffiCheckChecksums() {
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_csaf_ffi_checksum_func_validate_csaf_2_0()
 		})
-		if checksum != 6842 {
+		if checksum != 4645 {
 			// If this happens try cleaning and rebuilding your project
 			panic("csaf_ffi: uniffi_csaf_ffi_checksum_func_validate_csaf_2_0: UniFFI API checksum mismatch")
 		}
 	}
 	{
 		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_csaf_ffi_checksum_func_validate_csaf_2_0_to_json_string()
+		})
+		if checksum != 27025 {
+			// If this happens try cleaning and rebuilding your project
+			panic("csaf_ffi: uniffi_csaf_ffi_checksum_func_validate_csaf_2_0_to_json_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
 			return C.uniffi_csaf_ffi_checksum_func_validate_csaf_2_1()
 		})
-		if checksum != 22579 {
+		if checksum != 19507 {
 			// If this happens try cleaning and rebuilding your project
 			panic("csaf_ffi: uniffi_csaf_ffi_checksum_func_validate_csaf_2_1: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_csaf_ffi_checksum_func_validate_csaf_2_1_to_json_string()
+		})
+		if checksum != 56379 {
+			// If this happens try cleaning and rebuilding your project
+			panic("csaf_ffi: uniffi_csaf_ffi_checksum_func_validate_csaf_2_1_to_json_string: UniFFI API checksum mismatch")
+		}
+	}
+	{
+		checksum := rustCall(func(_uniffiStatus *C.RustCallStatus) C.uint16_t {
+			return C.uniffi_csaf_ffi_checksum_func_validate_csaf_to_json_string()
+		})
+		if checksum != 22896 {
+			// If this happens try cleaning and rebuilding your project
+			panic("csaf_ffi: uniffi_csaf_ffi_checksum_func_validate_csaf_to_json_string: UniFFI API checksum mismatch")
 		}
 	}
 	{
@@ -1978,7 +2005,7 @@ func (FfiDestroyerSequenceValidationError) Destroy(sequence []ValidationError) {
 // # Arguments
 //
 // * `json_str` - The CSAF document as a JSON string.
-// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 //
 // # Returns
 //
@@ -2002,7 +2029,7 @@ func ValidateCsaf(jsonStr string, preset string) (ValidationResult, error) {
 // # Arguments
 //
 // * `json_str` - The CSAF 2.0 document as a JSON string.
-// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 func ValidateCsaf20(jsonStr string, preset string) (ValidationResult, error) {
 	_uniffiRV, _uniffiErr := rustCallWithError[*CsafError](FfiConverterCsafError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer{
@@ -2017,12 +2044,35 @@ func ValidateCsaf20(jsonStr string, preset string) (ValidationResult, error) {
 	}
 }
 
+// Validate a CSAF 2.0 document and return the result as JSON.
+//
+// Same as [`validate_csaf_2_0`] but returns the [`ValidationResult`]
+// serialized as a JSON string.  Prefer in WASM contexts.
+//
+// # Arguments
+//
+// * `json_str` - The CSAF 2.0 document as a JSON string.
+// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
+func ValidateCsaf20ToJsonString(jsonStr string, preset string) (string, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError[*CsafError](FfiConverterCsafError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer{
+			inner: C.uniffi_csaf_ffi_fn_func_validate_csaf_2_0_to_json_string(FfiConverterStringINSTANCE.Lower(jsonStr), FfiConverterStringINSTANCE.Lower(preset), _uniffiStatus),
+		}
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue string
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterStringINSTANCE.Lift(_uniffiRV), nil
+	}
+}
+
 // Validate a CSAF 2.1 document from a JSON string.
 //
 // # Arguments
 //
 // * `json_str` - The CSAF 2.1 document as a JSON string.
-// * `preset`   - The validation preset: `"basic"`, `"extended"`, or `"full"`.
+// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 func ValidateCsaf21(jsonStr string, preset string) (ValidationResult, error) {
 	_uniffiRV, _uniffiErr := rustCallWithError[*CsafError](FfiConverterCsafError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
 		return GoRustBuffer{
@@ -2034,5 +2084,53 @@ func ValidateCsaf21(jsonStr string, preset string) (ValidationResult, error) {
 		return _uniffiDefaultValue, _uniffiErr
 	} else {
 		return FfiConverterValidationResultINSTANCE.Lift(_uniffiRV), nil
+	}
+}
+
+// Validate a CSAF 2.1 document and return the result as JSON.
+//
+// Same as [`validate_csaf_2_1`] but returns the [`ValidationResult`]
+// serialized as a JSON string.  Prefer in WASM contexts.
+//
+// # Arguments
+//
+// * `json_str` - The CSAF 2.1 document as a JSON string.
+// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
+func ValidateCsaf21ToJsonString(jsonStr string, preset string) (string, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError[*CsafError](FfiConverterCsafError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer{
+			inner: C.uniffi_csaf_ffi_fn_func_validate_csaf_2_1_to_json_string(FfiConverterStringINSTANCE.Lower(jsonStr), FfiConverterStringINSTANCE.Lower(preset), _uniffiStatus),
+		}
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue string
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterStringINSTANCE.Lift(_uniffiRV), nil
+	}
+}
+
+// Validate a CSAF document from a JSON string and return the result as JSON.
+//
+// Same as [`validate_csaf`] but returns the [`ValidationResult`] serialized
+// as a JSON string instead of a typed UniFFI record.  Prefer this in WASM
+// contexts: `JSON.parse(result)` is much faster than the UniFFI binary
+// deserializer for the result type.
+//
+// # Arguments
+//
+// * `json_str` - The CSAF document as a JSON string.
+// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
+func ValidateCsafToJsonString(jsonStr string, preset string) (string, error) {
+	_uniffiRV, _uniffiErr := rustCallWithError[*CsafError](FfiConverterCsafError{}, func(_uniffiStatus *C.RustCallStatus) RustBufferI {
+		return GoRustBuffer{
+			inner: C.uniffi_csaf_ffi_fn_func_validate_csaf_to_json_string(FfiConverterStringINSTANCE.Lower(jsonStr), FfiConverterStringINSTANCE.Lower(preset), _uniffiStatus),
+		}
+	})
+	if _uniffiErr != nil {
+		var _uniffiDefaultValue string
+		return _uniffiDefaultValue, _uniffiErr
+	} else {
+		return FfiConverterStringINSTANCE.Lift(_uniffiRV), nil
 	}
 }

--- a/go/csaf_ffi/csaf_ffi.h
+++ b/go/csaf_ffi/csaf_ffi.h
@@ -435,9 +435,24 @@ RustBuffer uniffi_csaf_ffi_fn_func_validate_csaf(RustBuffer json_str, RustBuffer
 RustBuffer uniffi_csaf_ffi_fn_func_validate_csaf_2_0(RustBuffer json_str, RustBuffer preset, RustCallStatus *out_status
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_2_0_TO_JSON_STRING
+#define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_2_0_TO_JSON_STRING
+RustBuffer uniffi_csaf_ffi_fn_func_validate_csaf_2_0_to_json_string(RustBuffer json_str, RustBuffer preset, RustCallStatus *out_status
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_2_1
 #define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_2_1
 RustBuffer uniffi_csaf_ffi_fn_func_validate_csaf_2_1(RustBuffer json_str, RustBuffer preset, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_2_1_TO_JSON_STRING
+#define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_2_1_TO_JSON_STRING
+RustBuffer uniffi_csaf_ffi_fn_func_validate_csaf_2_1_to_json_string(RustBuffer json_str, RustBuffer preset, RustCallStatus *out_status
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_TO_JSON_STRING
+#define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_FN_FUNC_VALIDATE_CSAF_TO_JSON_STRING
+RustBuffer uniffi_csaf_ffi_fn_func_validate_csaf_to_json_string(RustBuffer json_str, RustBuffer preset, RustCallStatus *out_status
 );
 #endif
 #ifndef UNIFFI_FFIDEF_FFI_CSAF_FFI_RUSTBUFFER_ALLOC
@@ -712,9 +727,27 @@ uint16_t uniffi_csaf_ffi_checksum_func_validate_csaf_2_0(void
     
 );
 #endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_2_0_TO_JSON_STRING
+#define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_2_0_TO_JSON_STRING
+uint16_t uniffi_csaf_ffi_checksum_func_validate_csaf_2_0_to_json_string(void
+    
+);
+#endif
 #ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_2_1
 #define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_2_1
 uint16_t uniffi_csaf_ffi_checksum_func_validate_csaf_2_1(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_2_1_TO_JSON_STRING
+#define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_2_1_TO_JSON_STRING
+uint16_t uniffi_csaf_ffi_checksum_func_validate_csaf_2_1_to_json_string(void
+    
+);
+#endif
+#ifndef UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_TO_JSON_STRING
+#define UNIFFI_FFIDEF_UNIFFI_CSAF_FFI_CHECKSUM_FUNC_VALIDATE_CSAF_TO_JSON_STRING
+uint16_t uniffi_csaf_ffi_checksum_func_validate_csaf_to_json_string(void
     
 );
 #endif


### PR DESCRIPTION
This adds validate functions to UniFFI exports which return the result as a String. In WASM the JSON.from is highly performant and can handle a raw string much better than a typed value, because of how UniFFI is creating an interpreted typescript parser for it's binary protocol.