### PR TITLE
feat: add regression benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,53 @@
+name: benchmark
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: benchmark-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: "true"
+
+      - name: Use cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: benchmark
+
+      - name: Update rustup
+        run: rustup update stable --no-self-update
+
+      - name: Run benchmarks
+        run: cargo bench --bench validation_benchmark -- --output-format bencher | tee output.txt
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: CSAF Validation Benchmark
+          tool: "cargo"
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          alert-threshold: "150%"
+          comment-on-alert: true
+          summary-always: true
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +280,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,6 +313,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -365,6 +404,73 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +504,7 @@ name = "csaf-rs"
 version = "0.4.1"
 dependencies = [
  "chrono",
+ "criterion",
  "cvss-rs",
  "jsonschema",
  "oxilangtag",
@@ -468,6 +575,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "email_address"
@@ -669,6 +782,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,6 +823,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iana-time-zone"
@@ -846,10 +976,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1067,6 +1217,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1289,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1373,26 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1733,6 +1937,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "toml"
 version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2164,6 +2378,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -46,6 +46,11 @@ serde_json = { version = "1", features = ["preserve_order"] }
 
 [dev-dependencies]
 rstest = "0.26.1"
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "validation_benchmark"
+harness = false
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "docsrs"]

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -156,12 +156,11 @@ fn bench_full_validation(c: &mut Criterion) {
             .filter_map(|(_name, content)| load_document_2_0(content).ok())
             .collect();
 
-        let test_ids_2_0: Vec<&str> =
-            [mandatory_tests_2_0(), recommended_tests_2_0(), informative_tests_2_0()]
-                .concat()
-                .into_iter()
-                .filter(|id| !SKIPPED_TESTS.contains(id))
-                .collect();
+        let test_ids_2_0: Vec<&str> = [mandatory_tests_2_0(), recommended_tests_2_0(), informative_tests_2_0()]
+            .concat()
+            .into_iter()
+            .filter(|id| !SKIPPED_TESTS.contains(id))
+            .collect();
 
         group.bench_function("csaf_2_0_full_preset", |b| {
             b.iter(|| {
@@ -180,12 +179,11 @@ fn bench_full_validation(c: &mut Criterion) {
             .filter_map(|(_name, content)| load_document_2_1(content).ok())
             .collect();
 
-        let test_ids_2_1: Vec<&str> =
-            [mandatory_tests_2_1(), recommended_tests_2_1(), informative_tests_2_1()]
-                .concat()
-                .into_iter()
-                .filter(|id| !SKIPPED_TESTS.contains(id))
-                .collect();
+        let test_ids_2_1: Vec<&str> = [mandatory_tests_2_1(), recommended_tests_2_1(), informative_tests_2_1()]
+            .concat()
+            .into_iter()
+            .filter(|id| !SKIPPED_TESTS.contains(id))
+            .collect();
 
         group.bench_function("csaf_2_1_full_preset", |b| {
             b.iter(|| {

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::hint::black_box;
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -90,7 +91,7 @@ fn bench_individual_tests_csaf_2_0(c: &mut Criterion) {
             b.iter(|| {
                 for doc in &documents {
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        validate_by_test(doc, test_id);
+                        black_box(validate_by_test(doc, test_id));
                     }));
                 }
             });
@@ -126,7 +127,7 @@ fn bench_individual_tests_csaf_2_1(c: &mut Criterion) {
             b.iter(|| {
                 for doc in &documents {
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        validate_by_test(doc, test_id);
+                        black_box(validate_by_test(doc, test_id));
                     }));
                 }
             });
@@ -156,7 +157,7 @@ fn bench_full_validation(c: &mut Criterion) {
             b.iter(|| {
                 for doc in &documents_2_0 {
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        validate_by_preset(doc, "2.0", "full");
+                        black_box(validate_by_preset(doc, "2.0", "full"));
                     }));
                 }
             });
@@ -173,7 +174,7 @@ fn bench_full_validation(c: &mut Criterion) {
             b.iter(|| {
                 for doc in &documents_2_1 {
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        validate_by_preset(doc, "2.1", "full");
+                        black_box(validate_by_preset(doc, "2.1", "full"));
                     }));
                 }
             });
@@ -197,7 +198,7 @@ fn bench_parse_only(c: &mut Criterion) {
     group.bench_function("csaf_2_0", |b| {
         b.iter(|| {
             for (_name, content) in &contents {
-                let _ = load_document_2_0(content);
+                let _ = black_box(load_document_2_0(content));
             }
         });
     });

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -5,8 +5,15 @@ use std::time::Duration;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 use csaf::csaf2_0::loader::load_document_from_str as load_document_2_0;
-use csaf::csaf2_0::testcases::{informative_tests, mandatory_tests, recommended_tests};
+use csaf::csaf2_0::testcases::{
+    informative_tests as informative_tests_2_0, mandatory_tests as mandatory_tests_2_0,
+    recommended_tests as recommended_tests_2_0,
+};
 use csaf::csaf2_1::loader::load_document_from_str as load_document_2_1;
+use csaf::csaf2_1::testcases::{
+    informative_tests as informative_tests_2_1, mandatory_tests as mandatory_tests_2_1,
+    recommended_tests as recommended_tests_2_1,
+};
 use csaf::validation::{validate_by_preset, validate_by_test};
 
 /// Collect all JSON test fixture files from a directory recursively.
@@ -74,10 +81,10 @@ fn bench_individual_tests_csaf_2_0(c: &mut Criterion) {
         .filter_map(|(_name, content)| load_document_2_0(content).ok())
         .collect();
 
-    let all_test_ids: Vec<&str> = [mandatory_tests(), recommended_tests(), informative_tests()].concat();
+    let all_test_ids: Vec<&str> = [mandatory_tests_2_0(), recommended_tests_2_0(), informative_tests_2_0()].concat();
 
     let mut group = c.benchmark_group("csaf_2_0_tests");
-    group.sample_size(10);
+    group.sample_size(50);
     group.warm_up_time(Duration::from_secs(2));
     group.measurement_time(Duration::from_secs(5));
 
@@ -113,10 +120,10 @@ fn bench_individual_tests_csaf_2_1(c: &mut Criterion) {
         .collect();
 
     // CSAF 2.1 uses the same test ID scheme
-    let all_test_ids: Vec<&str> = [mandatory_tests(), recommended_tests(), informative_tests()].concat();
+    let all_test_ids: Vec<&str> = [mandatory_tests_2_1(), recommended_tests_2_1(), informative_tests_2_1()].concat();
 
     let mut group = c.benchmark_group("csaf_2_1_tests");
-    group.sample_size(10);
+    group.sample_size(50);
     group.warm_up_time(Duration::from_secs(2));
     group.measurement_time(Duration::from_secs(5));
 
@@ -144,9 +151,9 @@ fn bench_full_validation(c: &mut Criterion) {
     let contents_2_1 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_1));
 
     let mut group = c.benchmark_group("full_validation");
-    group.sample_size(10);
-    group.warm_up_time(Duration::from_secs(3));
-    group.measurement_time(Duration::from_secs(10));
+    group.sample_size(50);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
 
     if !contents_2_0.is_empty() {
         let documents_2_0: Vec<_> = contents_2_0
@@ -195,7 +202,7 @@ fn bench_parse_only(c: &mut Criterion) {
     }
 
     let mut group = c.benchmark_group("parse_only");
-    group.sample_size(10);
+    group.sample_size(50);
     group.warm_up_time(Duration::from_secs(2));
     group.measurement_time(Duration::from_secs(5));
 

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -65,6 +65,9 @@ fn load_fixture_contents(files: &[PathBuf]) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Tests to skip in individual benchmarks (e.g., too slow or not yet implemented).
+const SKIPPED_TESTS: &[&str] = &["6.1.14"];
+
 /// Benchmark each individual CSAF 2.0 test function across all fixtures.
 fn bench_individual_tests_csaf_2_0(c: &mut Criterion) {
     let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
@@ -86,7 +89,7 @@ fn bench_individual_tests_csaf_2_0(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("csaf_2_0_tests");
 
-    for test_id in &all_test_ids {
+    for test_id in all_test_ids.iter().filter(|id| !SKIPPED_TESTS.contains(id)) {
         group.bench_function(*test_id, |b| {
             b.iter(|| {
                 for doc in &documents {
@@ -122,7 +125,7 @@ fn bench_individual_tests_csaf_2_1(c: &mut Criterion) {
 
     let mut group = c.benchmark_group("csaf_2_1_tests");
 
-    for test_id in &all_test_ids {
+    for test_id in all_test_ids.iter().filter(|id| !SKIPPED_TESTS.contains(id)) {
         group.bench_function(*test_id, |b| {
             b.iter(|| {
                 for doc in &documents {

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -1,0 +1,220 @@
+use std::fs;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use criterion::{Criterion, criterion_group, criterion_main};
+
+use csaf::csaf2_0::loader::load_document_from_str as load_document_2_0;
+use csaf::csaf2_0::testcases::{informative_tests, mandatory_tests, recommended_tests};
+use csaf::csaf2_1::loader::load_document_from_str as load_document_2_1;
+use csaf::validation::{validate_by_preset, validate_by_test};
+
+/// Collect all JSON test fixture files from a directory recursively.
+fn collect_fixture_files(dir: &str) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let path = PathBuf::from(dir);
+    if !path.exists() {
+        return files;
+    }
+    for entry in walkdir(&path) {
+        if entry.extension().is_some_and(|ext| ext == "json") {
+            let filename = entry.file_name().unwrap_or_default().to_string_lossy();
+            if filename.starts_with("testcases") || filename.contains("TEMPLATE") {
+                continue;
+            }
+            files.push(entry);
+        }
+    }
+    files.sort();
+    files
+}
+
+/// Simple recursive directory walker.
+fn walkdir(path: &PathBuf) -> Vec<PathBuf> {
+    let mut results = Vec::new();
+    if let Ok(entries) = fs::read_dir(path) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                results.extend(walkdir(&p));
+            } else {
+                results.push(p);
+            }
+        }
+    }
+    results
+}
+
+/// Pre-load all fixture file contents to exclude I/O from benchmark timing.
+fn load_fixture_contents(files: &[PathBuf]) -> Vec<(String, String)> {
+    files
+        .iter()
+        .filter_map(|f| {
+            let content = fs::read_to_string(f).ok()?;
+            let name = f.file_name()?.to_string_lossy().to_string();
+            Some((name, content))
+        })
+        .collect()
+}
+
+/// Benchmark each individual CSAF 2.0 test function across all fixtures.
+fn bench_individual_tests_csaf_2_0(c: &mut Criterion) {
+    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
+    let files = collect_fixture_files(fixtures_dir);
+    let contents = load_fixture_contents(&files);
+
+    if contents.is_empty() {
+        eprintln!("Warning: No CSAF 2.0 test fixtures found at {fixtures_dir}");
+        return;
+    }
+
+    // Pre-parse all documents once (parsing is not what we're benchmarking here)
+    let documents: Vec<_> = contents
+        .iter()
+        .filter_map(|(_name, content)| load_document_2_0(content).ok())
+        .collect();
+
+    let all_test_ids: Vec<&str> = [mandatory_tests(), recommended_tests(), informative_tests()].concat();
+
+    let mut group = c.benchmark_group("csaf_2_0_tests");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+
+    for test_id in &all_test_ids {
+        group.bench_function(*test_id, |b| {
+            b.iter(|| {
+                for doc in &documents {
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        validate_by_test(doc, test_id);
+                    }));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark each individual CSAF 2.1 test function across all fixtures.
+fn bench_individual_tests_csaf_2_1(c: &mut Criterion) {
+    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.1/test/validator/data");
+    let files = collect_fixture_files(fixtures_dir);
+    let contents = load_fixture_contents(&files);
+
+    if contents.is_empty() {
+        eprintln!("Warning: No CSAF 2.1 test fixtures found at {fixtures_dir}");
+        return;
+    }
+
+    let documents: Vec<_> = contents
+        .iter()
+        .filter_map(|(_name, content)| load_document_2_1(content).ok())
+        .collect();
+
+    // CSAF 2.1 uses the same test ID scheme
+    let all_test_ids: Vec<&str> = [mandatory_tests(), recommended_tests(), informative_tests()].concat();
+
+    let mut group = c.benchmark_group("csaf_2_1_tests");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+
+    for test_id in &all_test_ids {
+        group.bench_function(*test_id, |b| {
+            b.iter(|| {
+                for doc in &documents {
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        validate_by_test(doc, test_id);
+                    }));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark full preset validation (all tests combined) for overall throughput.
+fn bench_full_validation(c: &mut Criterion) {
+    let fixtures_dir_2_0 = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
+    let fixtures_dir_2_1 = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.1/test/validator/data");
+
+    let contents_2_0 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_0));
+    let contents_2_1 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_1));
+
+    let mut group = c.benchmark_group("full_validation");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(3));
+    group.measurement_time(Duration::from_secs(10));
+
+    if !contents_2_0.is_empty() {
+        let documents_2_0: Vec<_> = contents_2_0
+            .iter()
+            .filter_map(|(_name, content)| load_document_2_0(content).ok())
+            .collect();
+
+        group.bench_function("csaf_2_0_full_preset", |b| {
+            b.iter(|| {
+                for doc in &documents_2_0 {
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        validate_by_preset(doc, "2.0", "full");
+                    }));
+                }
+            });
+        });
+    }
+
+    if !contents_2_1.is_empty() {
+        let documents_2_1: Vec<_> = contents_2_1
+            .iter()
+            .filter_map(|(_name, content)| load_document_2_1(content).ok())
+            .collect();
+
+        group.bench_function("csaf_2_1_full_preset", |b| {
+            b.iter(|| {
+                for doc in &documents_2_1 {
+                    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        validate_by_preset(doc, "2.1", "full");
+                    }));
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+/// Benchmark parsing only (no validation).
+fn bench_parse_only(c: &mut Criterion) {
+    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
+    let contents = load_fixture_contents(&collect_fixture_files(fixtures_dir));
+
+    if contents.is_empty() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("parse_only");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(2));
+    group.measurement_time(Duration::from_secs(5));
+
+    group.bench_function("csaf_2_0", |b| {
+        b.iter(|| {
+            for (_name, content) in &contents {
+                let _ = load_document_2_0(content);
+            }
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_individual_tests_csaf_2_0,
+    bench_individual_tests_csaf_2_1,
+    bench_full_validation,
+    bench_parse_only,
+);
+criterion_main!(benches);

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -84,9 +84,6 @@ fn bench_individual_tests_csaf_2_0(c: &mut Criterion) {
     let all_test_ids: Vec<&str> = [mandatory_tests_2_0(), recommended_tests_2_0(), informative_tests_2_0()].concat();
 
     let mut group = c.benchmark_group("csaf_2_0_tests");
-    group.sample_size(50);
-    group.warm_up_time(Duration::from_secs(2));
-    group.measurement_time(Duration::from_secs(5));
 
     for test_id in &all_test_ids {
         group.bench_function(*test_id, |b| {
@@ -123,9 +120,6 @@ fn bench_individual_tests_csaf_2_1(c: &mut Criterion) {
     let all_test_ids: Vec<&str> = [mandatory_tests_2_1(), recommended_tests_2_1(), informative_tests_2_1()].concat();
 
     let mut group = c.benchmark_group("csaf_2_1_tests");
-    group.sample_size(50);
-    group.warm_up_time(Duration::from_secs(2));
-    group.measurement_time(Duration::from_secs(5));
 
     for test_id in &all_test_ids {
         group.bench_function(*test_id, |b| {
@@ -151,9 +145,6 @@ fn bench_full_validation(c: &mut Criterion) {
     let contents_2_1 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_1));
 
     let mut group = c.benchmark_group("full_validation");
-    group.sample_size(50);
-    group.warm_up_time(Duration::from_secs(2));
-    group.measurement_time(Duration::from_secs(5));
 
     if !contents_2_0.is_empty() {
         let documents_2_0: Vec<_> = contents_2_0
@@ -202,9 +193,6 @@ fn bench_parse_only(c: &mut Criterion) {
     }
 
     let mut group = c.benchmark_group("parse_only");
-    group.sample_size(50);
-    group.warm_up_time(Duration::from_secs(2));
-    group.measurement_time(Duration::from_secs(5));
 
     group.bench_function("csaf_2_0", |b| {
         b.iter(|| {
@@ -217,11 +205,16 @@ fn bench_parse_only(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(
-    benches,
-    bench_individual_tests_csaf_2_0,
-    bench_individual_tests_csaf_2_1,
-    bench_full_validation,
-    bench_parse_only,
-);
+fn configured_criterion() -> Criterion {
+    Criterion::default()
+        .warm_up_time(Duration::from_secs(2))
+        .measurement_time(Duration::from_secs(5))
+        .sample_size(50)
+}
+
+criterion_group! {
+   name = benches;
+   config = configured_criterion();
+   targets = bench_individual_tests_csaf_2_0, bench_individual_tests_csaf_2_1, bench_full_validation, bench_parse_only
+}
 criterion_main!(benches);

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -223,9 +223,9 @@ fn bench_parse_only(c: &mut Criterion) {
 
 fn configured_criterion() -> Criterion {
     Criterion::default()
-        .warm_up_time(Duration::from_secs(2))
-        .measurement_time(Duration::from_secs(5))
-        .sample_size(50)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(1))
+        .sample_size(10)
 }
 
 criterion_group! {

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -15,7 +15,7 @@ use csaf::csaf2_1::testcases::{
     informative_tests as informative_tests_2_1, mandatory_tests as mandatory_tests_2_1,
     recommended_tests as recommended_tests_2_1,
 };
-use csaf::validation::{validate_by_preset, validate_by_test};
+use csaf::validation::{validate_by_test, validate_by_tests};
 
 /// Collect all JSON test fixture files from a directory recursively.
 fn collect_fixture_files(dir: &str) -> Vec<PathBuf> {
@@ -156,11 +156,18 @@ fn bench_full_validation(c: &mut Criterion) {
             .filter_map(|(_name, content)| load_document_2_0(content).ok())
             .collect();
 
+        let test_ids_2_0: Vec<&str> =
+            [mandatory_tests_2_0(), recommended_tests_2_0(), informative_tests_2_0()]
+                .concat()
+                .into_iter()
+                .filter(|id| !SKIPPED_TESTS.contains(id))
+                .collect();
+
         group.bench_function("csaf_2_0_full_preset", |b| {
             b.iter(|| {
                 for doc in &documents_2_0 {
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        black_box(validate_by_preset(doc, "2.0", "full"));
+                        black_box(validate_by_tests(doc, "2.0", &test_ids_2_0));
                     }));
                 }
             });
@@ -173,11 +180,18 @@ fn bench_full_validation(c: &mut Criterion) {
             .filter_map(|(_name, content)| load_document_2_1(content).ok())
             .collect();
 
+        let test_ids_2_1: Vec<&str> =
+            [mandatory_tests_2_1(), recommended_tests_2_1(), informative_tests_2_1()]
+                .concat()
+                .into_iter()
+                .filter(|id| !SKIPPED_TESTS.contains(id))
+                .collect();
+
         group.bench_function("csaf_2_1_full_preset", |b| {
             b.iter(|| {
                 for doc in &documents_2_1 {
                     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        black_box(validate_by_preset(doc, "2.1", "full"));
+                        black_box(validate_by_tests(doc, "2.1", &test_ids_2_1));
                     }));
                 }
             });


### PR DESCRIPTION
The configuration 
```rust
fn configured_criterion() -> Criterion {
    Criterion::default()
        .warm_up_time(Duration::from_secs(2))
        .measurement_time(Duration::from_secs(5))
        .sample_size(50)
}
```
can be tweaked for all benchmarks. We'll see if we have any weird behavior with the current settings.