### PR TITLE
chore: fix doc warnings

### DIFF
--- a/csaf-rs/src/csaf/traits/vulnerabilities/hash_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/hash_trait.rs
@@ -19,7 +19,7 @@ pub trait HashTrait {
     /// The `algorithm` parameter is **NOT** normalized, as this is so far being run for known
     /// algorithms, which are normalized by definition.
     ///
-    /// TODO: This might change based on https://github.com/oasis-tcs/csaf/issues/1264
+    /// TODO: This might change based on <https://github.com/oasis-tcs/csaf/issues/1264>
     fn contains_only_hash_algorithm(&self, algorithm: CsafHashAlgorithm) -> bool {
         let file_hashes = self.get_file_hashes();
         if file_hashes.is_empty() {

--- a/csaf-rs/src/csaf/traits/vulnerabilities/product_status_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/product_status_trait.rs
@@ -41,7 +41,7 @@ pub trait ProductStatusTrait {
     fn get_unknown(&self) -> Option<impl Iterator<Item = &String> + '_>;
 
     /// Returns all product IDs grouped by their [`ProductStatus`]. The original index is
-    /// implicit in the Vec<String> index.
+    /// implicit in the `Vec<String>` index.
     fn get_products_by_status(&self) -> Vec<(ProductStatus, Vec<String>)> {
         fn collect(products: Option<impl Iterator<Item = impl AsRef<str>>>) -> Vec<String> {
             products

--- a/csaf-rs/src/csaf/types/csaf_hash_algo.rs
+++ b/csaf-rs/src/csaf/types/csaf_hash_algo.rs
@@ -73,7 +73,7 @@ impl CsafHashAlgorithm {
 
     /// Normalize a hash algorithm for matching purposes.
     ///
-    /// TODO: Update this once https://github.com/oasis-tcs/csaf/issues/1264 has been answered.
+    /// TODO: Update this once <https://github.com/oasis-tcs/csaf/issues/1264> has been answered.
     /// For now, we are only lowercasing the potentially cased HashAlgorithm::Other variants from
     /// CSAF 2.0. Further normalization could include trimming, removing hyphens, etc.
     pub fn normalize(&self) -> CsafHashAlgorithm {

--- a/csaf-rs/src/schema/csaf2_0/schema.rs
+++ b/csaf-rs/src/schema/csaf2_0/schema.rs
@@ -5,6 +5,7 @@
  */
 #![allow(clippy::all)]
 #![cfg_attr(any(), rustfmt::skip)]
+#![allow(rustdoc::all)]
 /// Error types.
 pub mod error {
     /// Error from a `TryFrom` or `FromStr` implementation.

--- a/csaf-rs/src/schema/csaf2_0/testcases_schema.rs
+++ b/csaf-rs/src/schema/csaf2_0/testcases_schema.rs
@@ -5,6 +5,7 @@
  */
 #![allow(clippy::all)]
 #![cfg_attr(any(), rustfmt::skip)]
+#![allow(rustdoc::all)]
 /// Error types.
 pub mod error {
     /// Error from a `TryFrom` or `FromStr` implementation.

--- a/csaf-rs/src/schema/csaf2_1/schema.rs
+++ b/csaf-rs/src/schema/csaf2_1/schema.rs
@@ -5,6 +5,7 @@
  */
 #![allow(clippy::all)]
 #![cfg_attr(any(), rustfmt::skip)]
+#![allow(rustdoc::all)]
 /// Error types.
 pub mod error {
     /// Error from a `TryFrom` or `FromStr` implementation.

--- a/csaf-rs/src/schema/csaf2_1/testcases_schema.rs
+++ b/csaf-rs/src/schema/csaf2_1/testcases_schema.rs
@@ -5,6 +5,7 @@
  */
 #![allow(clippy::all)]
 #![cfg_attr(any(), rustfmt::skip)]
+#![allow(rustdoc::all)]
 /// Error types.
 pub mod error {
     /// Error from a `TryFrom` or `FromStr` implementation.

--- a/csaf-rs/src/validations/test_6_1_35.rs
+++ b/csaf-rs/src/validations/test_6_1_35.rs
@@ -170,7 +170,7 @@ impl ProductIdRemediationCategoriesMap {
 /// is not member of contradicting remediation categories.
 /// This takes indirect relations through product groups into account.
 ///
-/// For more details on how the checks work, see [`ProductIdRemediationCategoriesMap].
+/// For more details on how the checks work, see `ProductIdRemediationCategoriesMap`.
 pub fn test_6_1_35_contradicting_remediations(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     let vulnerabilities = doc.get_vulnerabilities();
     if vulnerabilities.is_empty() {

--- a/csaf-rs/src/validations/test_6_1_54.rs
+++ b/csaf-rs/src/validations/test_6_1_54.rs
@@ -56,7 +56,7 @@ fn parse_license_as_allowed_in_csaf(license: &LicenseExpression) -> Result<Expre
 ///
 /// It MUST be tested that the license expression is valid.
 /// To implement this test, it is deemed sufficient to check for the ABNF defined
-/// in annex B of [SPDX](https://spdx.github.io/spdx-spec/) and the restriction 
+/// in annex B of [SPDX](https://spdx.github.io/spdx-spec/) and the restriction
 /// on the DocumentRef part given in 3.2.2.7.
 pub fn test_6_1_54_invalid_license_expression(
     doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,

--- a/csaf-rs/src/validations/test_6_1_54.rs
+++ b/csaf-rs/src/validations/test_6_1_54.rs
@@ -55,7 +55,9 @@ fn parse_license_as_allowed_in_csaf(license: &LicenseExpression) -> Result<Expre
 /// 6.1.54 License Expression
 ///
 /// It MUST be tested that the license expression is valid.
-/// To implement this test, it it deemed sufficient to check for the ABNF defined in annex B of [SPDX301] and the restriction on the DocumentRef part given in 3.2.2.7.
+/// To implement this test, it is deemed sufficient to check for the ABNF defined
+/// in annex B of [SPDX](https://spdx.github.io/spdx-spec/) and the restriction 
+/// on the DocumentRef part given in 3.2.2.7.
 pub fn test_6_1_54_invalid_license_expression(
     doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
 ) -> Result<(), Vec<ValidationError>> {

--- a/type-generator/src/schema/generate.rs
+++ b/type-generator/src/schema/generate.rs
@@ -1,5 +1,7 @@
 use crate::build_errors::BuildError;
-use crate::utils::codegen_snippets::{add_generated_code_header, add_ignore_clippy, add_ignore_rustdoc, add_ignore_rustfmt};
+use crate::utils::codegen_snippets::{
+    add_generated_code_header, add_ignore_clippy, add_ignore_rustdoc, add_ignore_rustfmt,
+};
 use crate::utils::read_write_fs::write_generated_file;
 use typify::{TypeSpace, TypeSpaceSettings};
 

--- a/type-generator/src/schema/generate.rs
+++ b/type-generator/src/schema/generate.rs
@@ -1,5 +1,5 @@
 use crate::build_errors::BuildError;
-use crate::utils::codegen_snippets::{add_generated_code_header, add_ignore_clippy, add_ignore_rustfmt};
+use crate::utils::codegen_snippets::{add_generated_code_header, add_ignore_clippy, add_ignore_rustdoc, add_ignore_rustfmt};
 use crate::utils::read_write_fs::write_generated_file;
 use typify::{TypeSpace, TypeSpaceSettings};
 
@@ -19,6 +19,7 @@ pub fn generate_from_schema(
     // Convert the TypeSpace token stream into a syn::File so we can inject a file-level doc attribute
     let mut file = syn::parse2::<syn::File>(type_space.to_stream())?;
 
+    add_ignore_rustdoc(&mut file);
     add_ignore_rustfmt(&mut file);
     add_ignore_clippy(&mut file);
     add_generated_code_header(&mut file);

--- a/type-generator/src/utils/codegen_snippets.rs
+++ b/type-generator/src/utils/codegen_snippets.rs
@@ -19,6 +19,11 @@ pub fn add_ignore_dead_code(file: &mut syn::File) {
     file.attrs.insert(0, doc_attr);
 }
 
+pub fn add_ignore_rustdoc(file: &mut syn::File) {
+    let doc_attr = syn::parse_quote! { #![allow(rustdoc::all)] };
+    file.attrs.insert(0, doc_attr);
+}
+
 pub fn add_generated_code_header(file: &mut syn::File) {
     let doc_attr: syn::Attribute = syn::parse_quote! { #![doc = #GENERATED_CODE_HEADER] };
     file.attrs.insert(0, doc_attr);


### PR DESCRIPTION
This PR:

Fixes warnings produced by `cargo doc --no-deps --document-private-items`, ensuring a well-formatted documentation.

Mostly links being wrapped in <>, also an ignore for unwrapped links for our generated schemas (fixing this in the schemas would be overkill IMO)

Resolves #648 