### PR TITLE
feat: add cargo docs lint on pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
         run: |
           rustup component add rustfmt
           cargo fmt --all -- --check -l
+      - name: Doc check
+        run: cargo doc --no-deps --document-private-items --locked
+        env:
+          RUSTDOCFLAGS: "-D warnings"
       - name: Run type-generator
         run: cargo run --locked -p type-generator
       - name: Check for uncommitted changes in generated files


### PR DESCRIPTION
This PR changes the pipeline to look for cargo doc issues on stable. This treats all warnings as errors, including in non-public items.

Resolves #646 