### PR TITLE
refactor: simplify trait return types

### DIFF
--- a/csaf-rs/src/converter/mod.rs
+++ b/csaf-rs/src/converter/mod.rs
@@ -4,7 +4,7 @@ use crate::csaf_traits::{CsafTrait, CsafVersion, DocumentTrait};
 ///
 /// Works with any type implementing CsafTrait
 pub fn is_csaf_2_0<Doc: CsafTrait>(doc: &Doc) -> bool {
-    doc.get_document().get_csaf_version() == &CsafVersion::X20
+    doc.get_document().get_csaf_version() == CsafVersion::X20
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/csaf/enums/category_of_the_branch.rs
+++ b/csaf-rs/src/csaf/enums/category_of_the_branch.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter};
 /// We need a shared type on the trait, as CSAF version 2.0 have fully divergent definitions.
 /// CSAF 2.0 has legacy, which 2.1 has not.
 /// CSAF 2.1 has platform, which 2.0 has not.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum CategoryOfTheBranch {
     Architecture,
     HostName,

--- a/csaf-rs/src/csaf/enums/csaf_version.rs
+++ b/csaf-rs/src/csaf/enums/csaf_version.rs
@@ -3,7 +3,7 @@
 /// Contrary to other enums that are based on enums in the generated schemas, we are re-defining
 /// this enum in the trait. Each schema only contains an enum with "their" version, and merging them
 /// would be more complex than defining them here and mapping to them in each implementation.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CsafVersion {
     X20,
     X21,

--- a/csaf-rs/src/csaf/traits/document/document_references_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/document_references_trait.rs
@@ -4,40 +4,40 @@ use crate::schema::csaf2_1::schema::{CategoryOfReference as CategoryOfReference2
 /// Trait representing document references
 pub trait DocumentReferenceTrait {
     /// Returns the category of the document reference as enum
-    fn get_category(&self) -> &CategoryOfReference21;
+    fn get_category(&self) -> CategoryOfReference21;
     /// Returns the summary of the document reference
-    fn get_summary(&self) -> &String;
+    fn get_summary(&self) -> &str;
     /// Returns the URL of the document reference
-    fn get_url(&self) -> &String;
+    fn get_url(&self) -> &str;
 }
 
 impl DocumentReferenceTrait for Reference20 {
-    fn get_category(&self) -> &CategoryOfReference21 {
+    fn get_category(&self) -> CategoryOfReference21 {
         match &self.category {
-            CategoryOfReference20::External => &CategoryOfReference21::External,
-            CategoryOfReference20::Self_ => &CategoryOfReference21::Self_,
+            CategoryOfReference20::External => CategoryOfReference21::External,
+            CategoryOfReference20::Self_ => CategoryOfReference21::Self_,
         }
     }
 
-    fn get_summary(&self) -> &String {
+    fn get_summary(&self) -> &str {
         &self.summary
     }
 
-    fn get_url(&self) -> &String {
+    fn get_url(&self) -> &str {
         &self.url
     }
 }
 
 impl DocumentReferenceTrait for Reference21 {
-    fn get_category(&self) -> &CategoryOfReference21 {
-        &self.category
+    fn get_category(&self) -> CategoryOfReference21 {
+        self.category
     }
 
-    fn get_summary(&self) -> &String {
+    fn get_summary(&self) -> &str {
         &self.summary
     }
 
-    fn get_url(&self) -> &String {
+    fn get_url(&self) -> &str {
         &self.url
     }
 }

--- a/csaf-rs/src/csaf/traits/document/revision_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/revision_trait.rs
@@ -10,7 +10,7 @@ pub trait RevisionTrait: WithDate {
     fn get_number(&self) -> CsafVersionNumber;
 
     /// Returns the summary of changes in this revision
-    fn get_summary(&self) -> &String;
+    fn get_summary(&self) -> &str;
 }
 
 impl RevisionTrait for Revision20 {
@@ -18,7 +18,7 @@ impl RevisionTrait for Revision20 {
         CsafVersionNumber::from(&self.number)
     }
 
-    fn get_summary(&self) -> &String {
+    fn get_summary(&self) -> &str {
         &self.summary
     }
 }
@@ -28,7 +28,7 @@ impl RevisionTrait for Revision21 {
         CsafVersionNumber::from(&self.number)
     }
 
-    fn get_summary(&self) -> &String {
+    fn get_summary(&self) -> &str {
         &self.summary
     }
 }

--- a/csaf-rs/src/csaf/traits/document/sharing_group_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/sharing_group_trait.rs
@@ -13,7 +13,7 @@ pub trait SharingGroupTrait {
     fn get_id(&self) -> &Uuid;
 
     /// Returns the optional name of the sharing group
-    fn get_name(&self) -> Option<&String>;
+    fn get_name(&self) -> Option<&str>;
 
     /// Utility function to check if the sharing group name is "Public"
     fn is_name_public(&self) -> bool {
@@ -31,7 +31,7 @@ impl SharingGroupTrait for NotPresentInCsaf20 {
         self.into_any()
     }
 
-    fn get_name(&self) -> Option<&String> {
+    fn get_name(&self) -> Option<&str> {
         self.into_any()
     }
 }
@@ -41,7 +41,7 @@ impl SharingGroupTrait for SharingGroup21 {
         &self.id
     }
 
-    fn get_name(&self) -> Option<&String> {
-        self.name.as_deref()
+    fn get_name(&self) -> Option<&str> {
+        self.name.as_deref().map(String::as_str)
     }
 }

--- a/csaf-rs/src/csaf/traits/document/tracking_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/tracking_trait.rs
@@ -11,7 +11,6 @@ use crate::schema::csaf2_1::schema::{
     Tracking as Tracking21,
 };
 use chrono::{DateTime, Utc};
-use std::ops::Deref;
 
 /// Type alias for a vector of revision history items
 pub type RevisionHistory = Vec<RevisionHistoryItem>;
@@ -98,7 +97,7 @@ pub trait TrackingTrait {
     fn get_status(&self) -> DocumentStatus21;
 
     /// Returns the tracking ID of this document
-    fn get_id(&self) -> &String;
+    fn get_id(&self) -> &str;
 
     fn get_version(&self) -> CsafVersionNumber;
 }
@@ -131,8 +130,8 @@ impl TrackingTrait for Tracking20 {
         }
     }
 
-    fn get_id(&self) -> &String {
-        self.id.deref()
+    fn get_id(&self) -> &str {
+        &self.id
     }
 
     fn get_version(&self) -> CsafVersionNumber {
@@ -164,8 +163,8 @@ impl TrackingTrait for Tracking21 {
         self.status
     }
 
-    fn get_id(&self) -> &String {
-        self.id.deref()
+    fn get_id(&self) -> &str {
+        &self.id
     }
 
     fn get_version(&self) -> CsafVersionNumber {

--- a/csaf-rs/src/csaf/traits/document_trait.rs
+++ b/csaf-rs/src/csaf/traits/document_trait.rs
@@ -68,7 +68,7 @@ pub trait DocumentTrait {
     /// Returns the references of this document
     fn get_references(&self) -> Option<&Vec<Self::DocumentReferenceType>>;
 
-    fn get_csaf_version(&self) -> &CsafVersion;
+    fn get_csaf_version(&self) -> CsafVersion;
 
     /// Returns the title of this document
     fn get_title(&self) -> &str;
@@ -125,9 +125,9 @@ impl DocumentTrait for DocumentLevelMetaData20 {
         self.references.as_deref()
     }
 
-    fn get_csaf_version(&self) -> &CsafVersion {
-        match self.csaf_version {
-            CsafVersion20::X20 => &CsafVersion::X20,
+    fn get_csaf_version(&self) -> CsafVersion {
+        match &self.csaf_version {
+            CsafVersion20::X20 => CsafVersion::X20,
         }
     }
 
@@ -181,9 +181,9 @@ impl DocumentTrait for DocumentLevelMetaData21 {
         self.references.as_deref()
     }
 
-    fn get_csaf_version(&self) -> &CsafVersion {
-        match self.csaf_version {
-            CsafVersion21::X21 => &CsafVersion::X21,
+    fn get_csaf_version(&self) -> CsafVersion {
+        match &self.csaf_version {
+            CsafVersion21::X21 => CsafVersion::X21,
         }
     }
 

--- a/csaf-rs/src/csaf/traits/product_tree/product_group_trait.rs
+++ b/csaf-rs/src/csaf/traits/product_tree/product_group_trait.rs
@@ -8,15 +8,15 @@ use std::ops::Deref;
 /// its IDs and associated product IDs.
 pub trait ProductGroupTrait {
     /// Returns the unique identifier of the product group.
-    fn get_group_id(&self) -> &String;
+    fn get_group_id(&self) -> &str;
 
     /// Retrieves a vector of product IDs contained within the product group.
     fn get_product_ids(&self) -> impl Iterator<Item = &String> + '_;
 }
 
 impl ProductGroupTrait for ProductGroup20 {
-    fn get_group_id(&self) -> &String {
-        self.group_id.deref()
+    fn get_group_id(&self) -> &str {
+        &self.group_id
     }
 
     fn get_product_ids(&self) -> impl Iterator<Item = &String> + '_ {
@@ -25,8 +25,8 @@ impl ProductGroupTrait for ProductGroup20 {
 }
 
 impl ProductGroupTrait for ProductGroup21 {
-    fn get_group_id(&self) -> &String {
-        self.group_id.deref()
+    fn get_group_id(&self) -> &str {
+        &self.group_id
     }
 
     fn get_product_ids(&self) -> impl Iterator<Item = &String> + '_ {

--- a/csaf-rs/src/csaf/traits/product_tree/product_path_trait.rs
+++ b/csaf-rs/src/csaf/traits/product_tree/product_path_trait.rs
@@ -1,15 +1,14 @@
 use crate::csaf_traits::ProductTrait;
 use crate::schema::csaf2_0::schema::Relationship;
 use crate::schema::csaf2_1::schema::{FullProductNameT, ProductPath};
-use std::ops::Deref;
 
 /// Trait representing an abstract relationship or product path in a product tree.
 pub trait ProductPathTrait<FPN: ProductTrait> {
     /// Retrieves the product reference identifier.
-    fn get_beginning_product_reference(&self) -> &String;
+    fn get_beginning_product_reference(&self) -> &str;
 
     /// Retrieves the identifier of the related product.
-    fn get_subpath_product_references(&self) -> Vec<&String>;
+    fn get_subpath_product_references(&self) -> Vec<&str>;
 
     /// Retrieves the full product name associated with the relationship.
     fn get_full_product_name(&self) -> &FPN;
@@ -29,12 +28,12 @@ pub trait ProductPathTrait<FPN: ProductTrait> {
 }
 
 impl ProductPathTrait<crate::schema::csaf2_0::schema::FullProductNameT> for Relationship {
-    fn get_beginning_product_reference(&self) -> &String {
-        self.product_reference.deref()
+    fn get_beginning_product_reference(&self) -> &str {
+        &self.product_reference
     }
 
-    fn get_subpath_product_references(&self) -> Vec<&String> {
-        vec![self.relates_to_product_reference.deref()]
+    fn get_subpath_product_references(&self) -> Vec<&str> {
+        vec![&self.relates_to_product_reference]
     }
 
     fn get_full_product_name(&self) -> &crate::schema::csaf2_0::schema::FullProductNameT {
@@ -55,14 +54,14 @@ impl ProductPathTrait<crate::schema::csaf2_0::schema::FullProductNameT> for Rela
 }
 
 impl ProductPathTrait<FullProductNameT> for ProductPath {
-    fn get_beginning_product_reference(&self) -> &String {
+    fn get_beginning_product_reference(&self) -> &str {
         &self.beginning_product_reference
     }
 
-    fn get_subpath_product_references(&self) -> Vec<&String> {
+    fn get_subpath_product_references(&self) -> Vec<&str> {
         self.subpaths
             .iter()
-            .map(|subpath| subpath.next_product_reference.deref())
+            .map(|subpath| subpath.next_product_reference.as_str())
             .collect()
     }
 

--- a/csaf-rs/src/csaf/traits/product_tree/product_trait.rs
+++ b/csaf-rs/src/csaf/traits/product_tree/product_trait.rs
@@ -5,7 +5,6 @@ use crate::schema::csaf2_0::schema::{
 use crate::schema::csaf2_1::schema::{
     FullProductNameT as FullProductNameT21, HelperToIdentifyTheProduct as HelperToIdentifyTheProduct21,
 };
-use std::ops::Deref;
 
 /// Trait representing an abstract full product name in a CSAF document.
 pub trait ProductTrait {
@@ -13,7 +12,7 @@ pub trait ProductTrait {
     type ProductIdentificationHelperType: ProductIdentificationHelperTrait;
 
     /// Returns the product ID from the full product name.
-    fn get_product_id(&self) -> &String;
+    fn get_product_id(&self) -> &str;
 
     /// Returns the textual description of the product
     fn get_name(&self) -> &str;
@@ -25,12 +24,12 @@ pub trait ProductTrait {
 impl ProductTrait for FullProductNameT20 {
     type ProductIdentificationHelperType = HelperToIdentifyTheProduct20;
 
-    fn get_product_id(&self) -> &String {
-        self.product_id.deref()
+    fn get_product_id(&self) -> &str {
+        &self.product_id
     }
 
     fn get_name(&self) -> &str {
-        self.name.deref()
+        &self.name
     }
 
     fn get_product_identification_helper(&self) -> Option<&Self::ProductIdentificationHelperType> {
@@ -41,12 +40,12 @@ impl ProductTrait for FullProductNameT20 {
 impl ProductTrait for FullProductNameT21 {
     type ProductIdentificationHelperType = HelperToIdentifyTheProduct21;
 
-    fn get_product_id(&self) -> &String {
-        self.product_id.deref()
+    fn get_product_id(&self) -> &str {
+        &self.product_id
     }
 
     fn get_name(&self) -> &str {
-        self.name.deref()
+        &self.name
     }
 
     fn get_product_identification_helper(&self) -> Option<&Self::ProductIdentificationHelperType> {

--- a/csaf-rs/src/csaf/traits/product_tree_trait.rs
+++ b/csaf-rs/src/csaf/traits/product_tree_trait.rs
@@ -218,7 +218,7 @@ pub trait BranchTrait<FPN: ProductTrait>: Sized {
     /// Returns an optional reference to the child branches of this branch.
     fn get_branches(&self) -> Option<&Vec<Self>>;
 
-    fn get_category(&self) -> &CategoryOfTheBranch;
+    fn get_category(&self) -> CategoryOfTheBranch;
 
     fn get_name(&self) -> &str;
 
@@ -375,20 +375,20 @@ impl BranchTrait<FullProductNameT20> for Branch20 {
         self.branches.as_deref()
     }
 
-    fn get_category(&self) -> &CategoryOfTheBranch {
-        match self.category {
-            CategoryOfTheBranch20::Architecture => &CategoryOfTheBranch::Architecture,
-            CategoryOfTheBranch20::HostName => &CategoryOfTheBranch::HostName,
-            CategoryOfTheBranch20::Language => &CategoryOfTheBranch::Language,
-            CategoryOfTheBranch20::Legacy => &CategoryOfTheBranch::Legacy,
-            CategoryOfTheBranch20::PatchLevel => &CategoryOfTheBranch::PatchLevel,
-            CategoryOfTheBranch20::ProductFamily => &CategoryOfTheBranch::ProductFamily,
-            CategoryOfTheBranch20::ProductName => &CategoryOfTheBranch::ProductName,
-            CategoryOfTheBranch20::ProductVersion => &CategoryOfTheBranch::ProductVersion,
-            CategoryOfTheBranch20::ProductVersionRange => &CategoryOfTheBranch::ProductVersionRange,
-            CategoryOfTheBranch20::ServicePack => &CategoryOfTheBranch::ServicePack,
-            CategoryOfTheBranch20::Specification => &CategoryOfTheBranch::Specification,
-            CategoryOfTheBranch20::Vendor => &CategoryOfTheBranch::Vendor,
+    fn get_category(&self) -> CategoryOfTheBranch {
+        match &self.category {
+            CategoryOfTheBranch20::Architecture => CategoryOfTheBranch::Architecture,
+            CategoryOfTheBranch20::HostName => CategoryOfTheBranch::HostName,
+            CategoryOfTheBranch20::Language => CategoryOfTheBranch::Language,
+            CategoryOfTheBranch20::Legacy => CategoryOfTheBranch::Legacy,
+            CategoryOfTheBranch20::PatchLevel => CategoryOfTheBranch::PatchLevel,
+            CategoryOfTheBranch20::ProductFamily => CategoryOfTheBranch::ProductFamily,
+            CategoryOfTheBranch20::ProductName => CategoryOfTheBranch::ProductName,
+            CategoryOfTheBranch20::ProductVersion => CategoryOfTheBranch::ProductVersion,
+            CategoryOfTheBranch20::ProductVersionRange => CategoryOfTheBranch::ProductVersionRange,
+            CategoryOfTheBranch20::ServicePack => CategoryOfTheBranch::ServicePack,
+            CategoryOfTheBranch20::Specification => CategoryOfTheBranch::Specification,
+            CategoryOfTheBranch20::Vendor => CategoryOfTheBranch::Vendor,
         }
     }
 
@@ -406,20 +406,20 @@ impl BranchTrait<FullProductNameT21> for Branch21 {
         self.branches.as_deref()
     }
 
-    fn get_category(&self) -> &CategoryOfTheBranch {
-        match self.category {
-            CategoryOfTheBranch21::Architecture => &CategoryOfTheBranch::Architecture,
-            CategoryOfTheBranch21::HostName => &CategoryOfTheBranch::HostName,
-            CategoryOfTheBranch21::Language => &CategoryOfTheBranch::Language,
-            CategoryOfTheBranch21::PatchLevel => &CategoryOfTheBranch::PatchLevel,
-            CategoryOfTheBranch21::ProductFamily => &CategoryOfTheBranch::ProductFamily,
-            CategoryOfTheBranch21::ProductName => &CategoryOfTheBranch::ProductName,
-            CategoryOfTheBranch21::ProductVersion => &CategoryOfTheBranch::ProductVersion,
-            CategoryOfTheBranch21::ProductVersionRange => &CategoryOfTheBranch::ProductVersionRange,
-            CategoryOfTheBranch21::ServicePack => &CategoryOfTheBranch::ServicePack,
-            CategoryOfTheBranch21::Specification => &CategoryOfTheBranch::Specification,
-            CategoryOfTheBranch21::Vendor => &CategoryOfTheBranch::Vendor,
-            CategoryOfTheBranch21::Platform => &CategoryOfTheBranch::Platform,
+    fn get_category(&self) -> CategoryOfTheBranch {
+        match &self.category {
+            CategoryOfTheBranch21::Architecture => CategoryOfTheBranch::Architecture,
+            CategoryOfTheBranch21::HostName => CategoryOfTheBranch::HostName,
+            CategoryOfTheBranch21::Language => CategoryOfTheBranch::Language,
+            CategoryOfTheBranch21::PatchLevel => CategoryOfTheBranch::PatchLevel,
+            CategoryOfTheBranch21::ProductFamily => CategoryOfTheBranch::ProductFamily,
+            CategoryOfTheBranch21::ProductName => CategoryOfTheBranch::ProductName,
+            CategoryOfTheBranch21::ProductVersion => CategoryOfTheBranch::ProductVersion,
+            CategoryOfTheBranch21::ProductVersionRange => CategoryOfTheBranch::ProductVersionRange,
+            CategoryOfTheBranch21::ServicePack => CategoryOfTheBranch::ServicePack,
+            CategoryOfTheBranch21::Specification => CategoryOfTheBranch::Specification,
+            CategoryOfTheBranch21::Vendor => CategoryOfTheBranch::Vendor,
+            CategoryOfTheBranch21::Platform => CategoryOfTheBranch::Platform,
         }
     }
 

--- a/csaf-rs/src/csaf/traits/shared/note_trait.rs
+++ b/csaf-rs/src/csaf/traits/shared/note_trait.rs
@@ -5,7 +5,7 @@ use std::ops::Deref;
 
 pub trait NoteTrait: WithOptionalGroupIds + WithOptionalProductIds {
     fn get_category(&self) -> NoteCategory21;
-    fn get_title(&self) -> Option<&String>;
+    fn get_title(&self) -> Option<&str>;
 }
 
 // CSAF 2.0 implementation
@@ -23,7 +23,7 @@ impl WithOptionalProductIds for Note20 {
 
 impl NoteTrait for Note20 {
     fn get_category(&self) -> NoteCategory21 {
-        match self.category {
+        match &self.category {
             NoteCategory20::Summary => NoteCategory21::Summary,
             NoteCategory20::Details => NoteCategory21::Details,
             NoteCategory20::Other => NoteCategory21::Other,
@@ -34,8 +34,8 @@ impl NoteTrait for Note20 {
         }
     }
 
-    fn get_title(&self) -> Option<&String> {
-        self.title.as_deref()
+    fn get_title(&self) -> Option<&str> {
+        self.title.as_deref().map(String::as_str)
     }
 }
 
@@ -57,7 +57,7 @@ impl NoteTrait for Note21 {
         self.category
     }
 
-    fn get_title(&self) -> Option<&String> {
-        self.title.as_deref()
+    fn get_title(&self) -> Option<&str> {
+        self.title.as_deref().map(String::as_str)
     }
 }

--- a/csaf-rs/src/csaf/traits/util/resolve_product_groups.rs
+++ b/csaf-rs/src/csaf/traits/util/resolve_product_groups.rs
@@ -23,7 +23,7 @@ where
     let product_tree = doc.get_product_tree()?;
 
     // collect requested group IDs into a hashset for O(1) lookup
-    let product_groups: HashSet<&String> = product_groups.into_iter().collect();
+    let product_groups: HashSet<&str> = product_groups.into_iter().map(|s| s.as_str()).collect();
 
     let product_ids: BTreeSet<String> = product_tree
         .get_product_groups()

--- a/csaf-rs/src/csaf/traits/vulnerabilities/metric_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/metric_trait.rs
@@ -14,7 +14,7 @@ pub trait MetricTrait {
     fn get_content(&self) -> &Self::ContentType;
 
     /// Retrieves the "source" (i.e., description of the metrics' origin) of this metric.
-    fn get_source(&self) -> Option<&String>;
+    fn get_source(&self) -> Option<&str>;
 }
 
 impl MetricTrait for Score20 {
@@ -28,7 +28,7 @@ impl MetricTrait for Score20 {
         self
     }
 
-    fn get_source(&self) -> Option<&String> {
+    fn get_source(&self) -> Option<&str> {
         None
     }
 }
@@ -44,7 +44,7 @@ impl MetricTrait for Metric21 {
         &self.content
     }
 
-    fn get_source(&self) -> Option<&String> {
-        self.source.as_ref()
+    fn get_source(&self) -> Option<&str> {
+        self.source.as_deref()
     }
 }

--- a/csaf-rs/src/csaf/traits/vulnerabilities/vulnerability_id_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/vulnerability_id_trait.rs
@@ -1,29 +1,28 @@
 use crate::schema::csaf2_0::schema::Id as Id20;
 use crate::schema::csaf2_1::schema::Id as Id21;
-use std::ops::Deref;
 
 pub trait VulnerabilityIdTrait {
-    fn get_system_name(&self) -> &String;
+    fn get_system_name(&self) -> &str;
 
-    fn get_text(&self) -> &String;
+    fn get_text(&self) -> &str;
 }
 
 impl VulnerabilityIdTrait for Id20 {
-    fn get_system_name(&self) -> &String {
-        self.system_name.deref()
+    fn get_system_name(&self) -> &str {
+        &self.system_name
     }
 
-    fn get_text(&self) -> &String {
-        self.text.deref()
+    fn get_text(&self) -> &str {
+        &self.text
     }
 }
 
 impl VulnerabilityIdTrait for Id21 {
-    fn get_system_name(&self) -> &String {
-        self.system_name.deref()
+    fn get_system_name(&self) -> &str {
+        &self.system_name
     }
 
-    fn get_text(&self) -> &String {
-        self.text.deref()
+    fn get_text(&self) -> &str {
+        &self.text
     }
 }

--- a/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
@@ -118,7 +118,7 @@ pub trait VulnerabilityTrait {
     fn get_involvements(&self) -> Option<&Vec<Self::InvolvementType>>;
 
     /// Returns the CVE associated with the vulnerability.
-    fn get_cve(&self) -> Option<&String>;
+    fn get_cve(&self) -> Option<&str>;
 
     /// Returns the CWE associated with the vulnerability.
     fn get_cwe(&self) -> Option<Vec<Cwe>>;
@@ -198,8 +198,8 @@ impl VulnerabilityTrait for Vulnerability20 {
         self.involvements.as_ref()
     }
 
-    fn get_cve(&self) -> Option<&String> {
-        self.cve.as_deref()
+    fn get_cve(&self) -> Option<&str> {
+        self.cve.as_deref().map(String::as_str)
     }
 
     fn get_cwe(&self) -> Option<Vec<Cwe>> {
@@ -266,8 +266,8 @@ impl VulnerabilityTrait for Vulnerability21 {
         self.involvements.as_ref()
     }
 
-    fn get_cve(&self) -> Option<&String> {
-        self.cve.as_deref()
+    fn get_cve(&self) -> Option<&str> {
+        self.cve.as_deref().map(String::as_str)
     }
 
     fn get_cwe(&self) -> Option<Vec<Cwe>> {

--- a/csaf-rs/src/csaf/types/csaf_document_category.rs
+++ b/csaf-rs/src/csaf/types/csaf_document_category.rs
@@ -90,7 +90,7 @@ impl CsafDocumentCategory {
     }
 
     /// Checks if the document category is a known profile for the given CSAF version
-    pub fn is_known_profile(&self, version: &CsafVersion) -> bool {
+    pub fn is_known_profile(&self, version: CsafVersion) -> bool {
         match version {
             CsafVersion::X20 => Self::CSAF_20_KNOWN_PROFILES.contains(self),
             CsafVersion::X21 => Self::CSAF_21_KNOWN_PROFILES.contains(self),
@@ -98,7 +98,7 @@ impl CsafDocumentCategory {
     }
 
     /// Returns a `, ` concatenated string of known profiles for the given CSAF version
-    pub fn known_profile_concat(version: &CsafVersion) -> String {
+    pub fn known_profile_concat(version: CsafVersion) -> String {
         let profiles: &[CsafDocumentCategory] = match version {
             CsafVersion::X20 => &Self::CSAF_20_KNOWN_PROFILES,
             CsafVersion::X21 => &Self::CSAF_21_KNOWN_PROFILES,
@@ -111,7 +111,7 @@ impl CsafDocumentCategory {
     }
 
     /// Returns a vector of tuples containing normalized known profile strings and their original enum values
-    pub fn known_profiles_normalized(version: &CsafVersion) -> Vec<(String, CsafDocumentCategory)> {
+    pub fn known_profiles_normalized(version: CsafVersion) -> Vec<(String, CsafDocumentCategory)> {
         let profiles: &[CsafDocumentCategory] = match version {
             CsafVersion::X20 => &Self::CSAF_20_KNOWN_PROFILES,
             CsafVersion::X21 => &Self::CSAF_21_KNOWN_PROFILES,

--- a/csaf-rs/src/csaf/types/purl/csaf_purl.rs
+++ b/csaf-rs/src/csaf/types/purl/csaf_purl.rs
@@ -54,7 +54,7 @@ mod test_purl_regex_parsing {
 
     /// Helper function for the CSAF 2.0 / CSAF 2.1 matrix test. We don't care about the values,
     /// just if the from_str passed / failed.
-    fn parse_purl_regex(input: &str, version: &CsafVersion) -> Result<(), ()> {
+    fn parse_purl_regex(input: &str, version: CsafVersion) -> Result<(), ()> {
         match version {
             CsafVersion::X20 => PackageUrlRepresentation20::from_str(input).map(drop).map_err(drop),
             CsafVersion::X21 => PackageUrlRepresentation21::from_str(input).map(drop).map_err(drop),
@@ -75,7 +75,7 @@ mod test_purl_regex_parsing {
         #[case] input: &str,
         #[values(CsafVersion::X20, CsafVersion::X21)] version: CsafVersion,
     ) {
-        assert!(parse_purl_regex(input, &version).is_err());
+        assert!(parse_purl_regex(input, version).is_err());
     }
 
     #[rstest]
@@ -86,8 +86,8 @@ mod test_purl_regex_parsing {
     /// TODO: Same as above, these are schema validation tests implemented here due to lack of schema
     /// validation testing "capability" so far.
     fn test_valid_20_invalid_21_purl_regex(#[case] input: &str) {
-        assert!(parse_purl_regex(input, &CsafVersion::X20).is_ok());
-        assert!(parse_purl_regex(input, &CsafVersion::X21).is_err());
+        assert!(parse_purl_regex(input, CsafVersion::X20).is_ok());
+        assert!(parse_purl_regex(input, CsafVersion::X21).is_err());
     }
 }
 
@@ -104,7 +104,7 @@ mod test_purl_full_pipeline {
     use super::*;
 
     /// Helper function for the CSAF 2.0 / 2.1 matrix test.
-    fn to_csaf_purl(purl_str: &str, version: &CsafVersion) -> CsafPurl {
+    fn to_csaf_purl(purl_str: &str, version: CsafVersion) -> CsafPurl {
         match version {
             CsafVersion::X20 => {
                 let repr = PackageUrlRepresentation20::from_str(purl_str)
@@ -140,7 +140,7 @@ mod test_purl_full_pipeline {
         #[case] expected_error: PurlParseErrorKind,
         #[values(CsafVersion::X20, CsafVersion::X21)] version: CsafVersion,
     ) {
-        let csaf_purl = to_csaf_purl(purl_str, &version);
+        let csaf_purl = to_csaf_purl(purl_str, version);
 
         let expected = PurlParseError::new_for_test(purl_str, expected_error).into_validation_error("");
 
@@ -168,7 +168,7 @@ mod test_purl_full_pipeline {
     #[case::deb_without_namespace("pkg:deb/curl@8.13.0-5~bpo12+1?arch=i386")]
     /// Test the happy path with some additional valid purls from the test data.
     fn test_valid_purl(#[case] input: &str, #[values(CsafVersion::X20, CsafVersion::X21)] version: CsafVersion) {
-        let csaf_purl = to_csaf_purl(input, &version);
+        let csaf_purl = to_csaf_purl(input, version);
         match csaf_purl {
             CsafPurl::Valid(_) => {},
             CsafPurl::Invalid(err) => panic!(

--- a/csaf-rs/src/validations/test_6_1_03.rs
+++ b/csaf-rs/src/validations/test_6_1_03.rs
@@ -2,9 +2,9 @@ use crate::csaf_traits::{CsafTrait, CsafVersion, DocumentTrait, ProductPathTrait
 use crate::validation::ValidationError;
 use std::collections::{HashMap, HashSet};
 
-fn generate_self_reference_product_error(version: &CsafVersion, path: &str) -> ValidationError {
+fn generate_self_reference_product_error(version: CsafVersion, path: &str) -> ValidationError {
     ValidationError {
-        message: if version == &CsafVersion::X21 {
+        message: if version == CsafVersion::X21 {
             "Product path references itself via 'beginning product reference'".to_string()
         } else {
             "Relationship references itself via 'product reference'".to_string()
@@ -13,9 +13,9 @@ fn generate_self_reference_product_error(version: &CsafVersion, path: &str) -> V
     }
 }
 
-fn generate_self_reference_relates_to_error(version: &CsafVersion, path: &str) -> ValidationError {
+fn generate_self_reference_relates_to_error(version: CsafVersion, path: &str) -> ValidationError {
     ValidationError {
-        message: if version == &CsafVersion::X21 {
+        message: if version == CsafVersion::X21 {
             "Product path references itself via 'next product reference'".to_string()
         } else {
             "Relationship references itself via 'relates to product reference'".to_string()
@@ -24,9 +24,9 @@ fn generate_self_reference_relates_to_error(version: &CsafVersion, path: &str) -
     }
 }
 
-fn generate_cycle_error(version: &CsafVersion, cycle: &[String], path: String) -> ValidationError {
+fn generate_cycle_error(version: CsafVersion, cycle: &[String], path: String) -> ValidationError {
     ValidationError {
-        message: if version == &CsafVersion::X21 {
+        message: if version == CsafVersion::X21 {
             format!("Found cycle in product path definitions: {}", cycle.join(" -> "))
         } else {
             format!("Found cycle in relationship definitions: {}", cycle.join(" -> "))
@@ -102,23 +102,23 @@ pub fn test_6_1_03_circular_definition_of_product_id(doc: &impl CsafTrait) -> Re
                 match relation_map.get_mut(rel_prod_id) {
                     Some(v) => {
                         v.insert(
-                            pp.get_beginning_product_reference().clone(),
+                            pp.get_beginning_product_reference().to_owned(),
                             pp.get_json_path_for_product_path(pp_i),
                         );
                         pp.get_subpath_product_references().iter().for_each(|next| {
-                            v.insert((*next).clone(), pp.get_json_path_for_product_path(pp_i));
+                            v.insert(next.to_string(), pp.get_json_path_for_product_path(pp_i));
                         });
                     },
                     None => {
                         let mut v = HashMap::new();
                         v.insert(
-                            pp.get_beginning_product_reference().clone(),
+                            pp.get_beginning_product_reference().to_owned(),
                             pp.get_json_path_for_product_path(pp_i),
                         );
                         pp.get_subpath_product_references().iter().for_each(|next| {
-                            v.insert((*next).clone(), pp.get_json_path_for_product_path(pp_i));
+                            v.insert(next.to_string(), pp.get_json_path_for_product_path(pp_i));
                         });
-                        relation_map.insert(rel_prod_id.clone(), v);
+                        relation_map.insert(rel_prod_id.to_owned(), v);
                     },
                 }
             }
@@ -154,16 +154,16 @@ mod tests {
     fn test_test_6_1_03() {
         TESTS_2_0.test_6_1_3.expect(
             Err(vec![generate_self_reference_relates_to_error(
-                &CsafVersion::X20,
+                CsafVersion::X20,
                 "/product_tree/relationships/0/relates_to_product_reference",
             )]),
             Err(vec![generate_self_reference_product_error(
-                &CsafVersion::X20,
+                CsafVersion::X20,
                 "/product_tree/relationships/0/product_reference",
             )]),
             Err(vec![
                 generate_cycle_error(
-                    &CsafVersion::X20,
+                    CsafVersion::X20,
                     &[
                         "CSAFPID-9080701".to_string(),
                         "CSAFPID-9080702".to_string(),
@@ -172,7 +172,7 @@ mod tests {
                     "/product_tree/relationships/0".to_string(),
                 ),
                 generate_cycle_error(
-                    &CsafVersion::X20,
+                    CsafVersion::X20,
                     &[
                         "CSAFPID-9080702".to_string(),
                         "CSAFPID-9080701".to_string(),
@@ -184,16 +184,16 @@ mod tests {
         );
         TESTS_2_1.test_6_1_3.expect(
             Err(vec![generate_self_reference_relates_to_error(
-                &CsafVersion::X21,
+                CsafVersion::X21,
                 "/product_tree/product_paths/0/subpaths/0/next_product_reference",
             )]),
             Err(vec![generate_self_reference_product_error(
-                &CsafVersion::X21,
+                CsafVersion::X21,
                 "/product_tree/product_paths/0/beginning_product_reference",
             )]),
             Err(vec![
                 generate_cycle_error(
-                    &CsafVersion::X21,
+                    CsafVersion::X21,
                     &[
                         "CSAFPID-9080701".to_string(),
                         "CSAFPID-9080702".to_string(),
@@ -202,7 +202,7 @@ mod tests {
                     "/product_tree/product_paths/0".to_string(),
                 ),
                 generate_cycle_error(
-                    &CsafVersion::X21,
+                    CsafVersion::X21,
                     &[
                         "CSAFPID-9080702".to_string(),
                         "CSAFPID-9080701".to_string(),

--- a/csaf-rs/src/validations/test_6_1_07.rs
+++ b/csaf-rs/src/validations/test_6_1_07.rs
@@ -28,7 +28,7 @@ fn aggregate_product_cvss_metrics(
         let content = metric.get_content();
         let metric_json_path = content.get_content_json_path(vulnerability_index, metric_index);
         let present_cvss_metric_types = content.get_cvss_metric_types();
-        let source = metric.get_source().cloned();
+        let source = metric.get_source().map(|s| s.to_owned());
         for product_id in metric.get_products() {
             for metric_type in &present_cvss_metric_types {
                 product_metrics

--- a/csaf-rs/src/validations/test_6_1_23.rs
+++ b/csaf-rs/src/validations/test_6_1_23.rs
@@ -26,7 +26,7 @@ pub fn test_6_1_23_multiple_use_of_same_cve(doc: &impl CsafTrait) -> Result<(), 
     for (i_r, vulnerability) in vulnerabilities.iter().enumerate() {
         let cve = vulnerability.get_cve();
         if let Some(cve) = cve {
-            let path = cve_paths.entry(cve.clone()).or_default();
+            let path = cve_paths.entry(cve.to_owned()).or_default();
             path.push(i_r);
         }
     }

--- a/csaf-rs/src/validations/test_6_1_26.rs
+++ b/csaf-rs/src/validations/test_6_1_26.rs
@@ -13,7 +13,7 @@ pub fn test_6_1_26_prohibited_document_category(doc: &impl CsafTrait) -> Result<
 #[inline]
 fn validate_document_category(
     doc_category: &CsafDocumentCategory,
-    doc_version: &CsafVersion,
+    doc_version: CsafVersion,
 ) -> Result<(), Vec<ValidationError>> {
     // skip test for known profiles and categories
     if doc_category.is_known_profile(doc_version) {
@@ -44,7 +44,7 @@ fn validate_document_category(
 
 fn test_6_1_26_err_generator_starts_with_csaf(
     doc_category: &CsafDocumentCategory,
-    version: &CsafVersion,
+    version: CsafVersion,
 ) -> ValidationError {
     ValidationError {
         message: format!(
@@ -86,11 +86,11 @@ mod tests {
         // CSAF 2.0 specific test cases
         let case_02_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("csaf_BASE"),
-            &CsafVersion::X20,
+            CsafVersion::X20,
         )]);
         let case_03_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("Csaf_VeX"),
-            &CsafVersion::X20,
+            CsafVersion::X20,
         )]);
         let case_04_csaf20 = Err(vec![test_6_1_26_err_generator_too_similar(
             &CsafDocumentCategory::from("csafsecurityadvisory"),
@@ -120,26 +120,26 @@ mod tests {
         )]);
         let case_07_csaf21 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("CsaF_VeX"),
-            &CsafVersion::X21,
+            CsafVersion::X21,
         )]);
         let case_08_csaf21 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("csaf_BASE"),
-            &CsafVersion::X21,
+            CsafVersion::X21,
         )]);
 
         // Supplementary test cases
         // CSAF 2.1 categories that should fail on CSAF 2.0
         let deprecated_sec_advisory_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("csaf_deprecated_security_advisory"),
-            &CsafVersion::X20,
+            CsafVersion::X20,
         )]);
         let withdrawn_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("csaf_withdrawn"),
-            &CsafVersion::X20,
+            CsafVersion::X20,
         )]);
         let superseded_csaf20 = Err(vec![test_6_1_26_err_generator_starts_with_csaf(
             &CsafDocumentCategory::from("csaf_superseded"),
-            &CsafVersion::X20,
+            CsafVersion::X20,
         )]);
 
         TESTS_2_0.test_6_1_26.expect(
@@ -173,15 +173,15 @@ mod tests {
     #[test]
     fn test_validate_document_category_v21() {
         let version = CsafVersion::X21;
-        assert!(validate_document_category(&CsafDocumentCategory::from("Csaf_a"), &version).is_err());
-        assert!(validate_document_category(&CsafDocumentCategory::from("csafvex"), &version).is_err());
-        assert!(validate_document_category(&CsafDocumentCategory::from("Informational Advisory"), &version).is_err());
-        assert!(validate_document_category(&CsafDocumentCategory::from("Security      Advisory"), &version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("Csaf_a"), version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("csafvex"), version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("Informational Advisory"), version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("Security      Advisory"), version).is_err());
         assert!(
-            validate_document_category(&CsafDocumentCategory::from("security-incident-response"), &version).is_err()
+            validate_document_category(&CsafDocumentCategory::from("security-incident-response"), version).is_err()
         );
-        assert!(validate_document_category(&CsafDocumentCategory::from("Superseded"), &version).is_err());
-        assert!(validate_document_category(&CsafDocumentCategory::from("V_eX"), &version).is_err());
-        assert!(validate_document_category(&CsafDocumentCategory::from("veX"), &version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("Superseded"), version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("V_eX"), version).is_err());
+        assert!(validate_document_category(&CsafDocumentCategory::from("veX"), version).is_err());
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_02.rs
+++ b/csaf-rs/src/validations/test_6_1_27_02.rs
@@ -35,7 +35,7 @@ pub fn test_6_1_27_02_document_references(doc: &impl CsafTrait) -> Result<(), Ve
     let mut found_external_reference = false;
     if let Some(references) = doc.get_document().get_references() {
         for reference in references {
-            if CategoryOfReference::External == *reference.get_category() {
+            if CategoryOfReference::External == reference.get_category() {
                 found_external_reference = true;
                 break;
             };

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -46,7 +46,7 @@ pub fn test_6_1_27_19_reference_to_superseding_document(doc: &impl CsafTrait) ->
     if let Some(references) = doc.get_document().get_references() {
         for (r_i, reference) in references.iter().enumerate() {
             if reference.get_summary().starts_with("Superseding Document") {
-                if *reference.get_category() != CategoryOfReference::External {
+                if reference.get_category() != CategoryOfReference::External {
                     errors
                         .get_or_insert_default()
                         .push(create_incorrect_category_error(r_i));

--- a/csaf-rs/src/validations/test_6_1_31.rs
+++ b/csaf-rs/src/validations/test_6_1_31.rs
@@ -89,7 +89,7 @@ pub fn test_6_1_31_version_range_in_product_version_branch_name(
     let mut errors: Option<Vec<ValidationError>> = None;
 
     product_tree.visit_all_branches(&mut |branch, path| {
-        if branch.get_category() == &CategoryOfTheBranch::ProductVersion {
+        if branch.get_category() == CategoryOfTheBranch::ProductVersion {
             // if there are any forbidden substrings found, create an error
             if let Some(forbidden_substrings) = check_branch_name_for_forbidden_substrings(branch.get_name()) {
                 errors

--- a/csaf-rs/src/validations/test_6_1_57.rs
+++ b/csaf-rs/src/validations/test_6_1_57.rs
@@ -3,7 +3,7 @@ use crate::validation::ValidationError;
 use std::collections::HashMap;
 
 fn create_stacked_categories_error(
-    stacked_categories: &[(&CategoryOfTheBranch, &u64)],
+    stacked_categories: &[(CategoryOfTheBranch, &u64)],
     instance_path: String,
 ) -> ValidationError {
     // singular / plural of category
@@ -41,9 +41,9 @@ pub fn test_6_1_57_stacked_branch_categories(doc: &impl CsafTrait) -> Result<(),
     // for every path
     for (path, indices) in leaf_paths {
         // generate a hashmap of category occurrences
-        let mut categories_in_path_map: HashMap<&CategoryOfTheBranch, u64> = HashMap::new();
+        let mut categories_in_path_map: HashMap<CategoryOfTheBranch, u64> = HashMap::new();
         for branch in &path {
-            if branch.get_category() == &CategoryOfTheBranch::ProductFamily {
+            if branch.get_category() == CategoryOfTheBranch::ProductFamily {
                 continue;
             }
             categories_in_path_map
@@ -53,7 +53,7 @@ pub fn test_6_1_57_stacked_branch_categories(doc: &impl CsafTrait) -> Result<(),
         }
 
         // filter hashmap to only categories that occur more than once
-        let mut stacked_categories: Vec<(&CategoryOfTheBranch, &u64)> = categories_in_path_map
+        let mut stacked_categories: Vec<(CategoryOfTheBranch, &u64)> = categories_in_path_map
             .iter()
             .filter(|(_, count)| **count > 1)
             .map(|(cat, count)| (*cat, count))
@@ -84,49 +84,49 @@ mod tests {
     #[test]
     fn test_6_1_57() {
         let case_01_simple = Err(vec![create_stacked_categories_error(
-            &[(&CategoryOfTheBranch::Vendor, &2)],
+            &[(CategoryOfTheBranch::Vendor, &2)],
             "/product_tree/branches/0/branches/0/branches/0/branches/0/product".to_string(),
         )]);
 
         let case_02_depth = Err(vec![
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::ProductName, &2)],
+                &[(CategoryOfTheBranch::ProductName, &2)],
                 "/product_tree/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/product".to_string()
             ),
         ]);
 
         let case_03_breadth = Err(vec![
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/0/branches/0/branches/0/branches/0/product"
                     .to_string(),
             ),
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/0/branches/0/branches/0/branches/1/product"
                     .to_string(),
             ),
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/0/branches/0/branches/1/branches/0/product"
                     .to_string(),
             ),
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/0/branches/1/branches/0/branches/0/product"
                     .to_string(),
             ),
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/0/branches/1/branches/1/branches/0/product"
                     .to_string(),
             ),
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/1/branches/0/branches/0/product".to_string(),
             ),
             create_stacked_categories_error(
-                &[(&CategoryOfTheBranch::Architecture, &3)],
+                &[(CategoryOfTheBranch::Architecture, &3)],
                 "/product_tree/branches/0/branches/0/branches/1/branches/1/branches/1/branches/0/product".to_string(),
             ),
         ]);

--- a/csaf-rs/src/validations/test_6_1_58.rs
+++ b/csaf-rs/src/validations/test_6_1_58.rs
@@ -29,10 +29,10 @@ pub fn test_6_1_58_product_version_and_product_version_range_in_one_path(
         // check if it contains one of the relevant categories
         let contains_product_version = path
             .iter()
-            .any(|b| b.get_category() == &CategoryOfTheBranch::ProductVersion);
+            .any(|b| b.get_category() == CategoryOfTheBranch::ProductVersion);
         let contains_product_version_range = path
             .iter()
-            .any(|b| b.get_category() == &CategoryOfTheBranch::ProductVersionRange);
+            .any(|b| b.get_category() == CategoryOfTheBranch::ProductVersionRange);
 
         // if it contains both, add an error
         if contains_product_version && contains_product_version_range {

--- a/csaf-rs/src/validations/test_6_2_01.rs
+++ b/csaf-rs/src/validations/test_6_2_01.rs
@@ -25,7 +25,7 @@ pub fn test_6_2_01_unused_definition_of_product_id(doc: &impl CsafTrait) -> Resu
     }
 
     // Get all references to product IDs in the document
-    let references = doc.get_all_product_references_ids();
+    let references: std::collections::HashSet<String> = doc.get_all_product_references_ids().into_iter().collect();
 
     // Visit all product id definitions and check if they are referenced
     if let Some(tree) = doc.get_product_tree() {

--- a/csaf-rs/src/validations/test_6_2_10.rs
+++ b/csaf-rs/src/validations/test_6_2_10.rs
@@ -12,7 +12,7 @@ use std::sync::LazyLock;
 /// Ok(()). (later wasSkipped TODO)
 pub fn test_6_2_10_missing_tlp_label(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     // In CSAF 2.1 this field is mandatory and validated via the schema, so we skip this test
-    if doc.get_document().get_csaf_version() == &CsafVersion::X21 {
+    if doc.get_document().get_csaf_version() == CsafVersion::X21 {
         return Ok(()); // TODO #409 wasSkipped
     }
     // We just need to consider get_distribution_20 / get_tlp_20 here. If either is missing, return an error

--- a/csaf-rs/src/validations/test_6_2_11.rs
+++ b/csaf-rs/src/validations/test_6_2_11.rs
@@ -17,7 +17,7 @@ pub fn test_6_2_11_missing_canonical_url(doc: &impl CsafTrait) -> Result<(), Vec
     // Check if any reference meets the criteria
     if let Some(references) = doc.get_document().get_references() {
         for reference in references {
-            if CategoryOfReference::Self_ == *reference.get_category()
+            if CategoryOfReference::Self_ == reference.get_category()
                 && reference.get_url().starts_with("https://")
                 && reference.get_url().ends_with(&expected_filename)
             {

--- a/csaf-rs/src/validations/test_6_2_18.rs
+++ b/csaf-rs/src/validations/test_6_2_18.rs
@@ -21,7 +21,7 @@ pub fn test_6_2_18_product_version_range_without_vers(doc: &impl CsafTrait) -> R
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_branches(&mut |branch, path| {
-            if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange
+            if branch.get_category() == CategoryOfTheBranch::ProductVersionRange
                 && !VERS_REGEX.is_match(branch.get_name())
             {
                 errors

--- a/csaf-rs/src/validations/test_6_2_22.rs
+++ b/csaf-rs/src/validations/test_6_2_22.rs
@@ -16,7 +16,7 @@ pub fn test_6_2_22_document_tracking_id_in_title(doc: &impl CsafTrait) -> Result
     let title = document.get_title();
     let tracking_id = document.get_tracking().get_id();
 
-    if title.contains(tracking_id.as_str()) {
+    if title.contains(tracking_id) {
         return Err(vec![create_tracking_id_in_title_error(title, tracking_id)]);
     }
 

--- a/csaf-rs/src/validations/test_6_2_48.rs
+++ b/csaf-rs/src/validations/test_6_2_48.rs
@@ -37,7 +37,7 @@ pub fn test_6_2_48_misuse_at_vendor_name(doc: &impl CsafTrait) -> Result<(), Vec
     let mut errors: Option<Vec<ValidationError>> = None;
 
     product_tree.visit_all_branches(&mut |branch, path| {
-        if branch.get_category() == &CategoryOfTheBranch::Vendor && is_open_source(branch.get_name()) {
+        if branch.get_category() == CategoryOfTheBranch::Vendor && is_open_source(branch.get_name()) {
             errors
                 .get_or_insert_default()
                 .push(create_misuse_at_vendor_name_error(branch.get_name(), path));

--- a/csaf-rs/src/validations/test_6_3_09.rs
+++ b/csaf-rs/src/validations/test_6_3_09.rs
@@ -1,7 +1,7 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait, build_leaf_instance_path};
 use crate::validation::ValidationError;
 
-fn format_category_path(categories: &[&CategoryOfTheBranch]) -> String {
+fn format_category_path(categories: &[CategoryOfTheBranch]) -> String {
     categories
         .iter()
         .map(|c| c.to_string())
@@ -10,8 +10,8 @@ fn format_category_path(categories: &[&CategoryOfTheBranch]) -> String {
 }
 
 fn create_branch_categories_error(
-    full_path: &[&CategoryOfTheBranch],
-    relevant_categories: &[&CategoryOfTheBranch],
+    full_path: &[CategoryOfTheBranch],
+    relevant_categories: &[CategoryOfTheBranch],
     instance_path: String,
 ) -> ValidationError {
     let full_display = format_category_path(full_path);
@@ -29,10 +29,10 @@ fn create_branch_categories_error(
 }
 
 /// Required category sequence for branch paths.
-const REQUIRED_CATEGORIES_ORDER: [&CategoryOfTheBranch; 3] = [
-    &CategoryOfTheBranch::Vendor,
-    &CategoryOfTheBranch::ProductName,
-    &CategoryOfTheBranch::ProductVersion,
+const REQUIRED_CATEGORIES_ORDER: [CategoryOfTheBranch; 3] = [
+    CategoryOfTheBranch::Vendor,
+    CategoryOfTheBranch::ProductName,
+    CategoryOfTheBranch::ProductVersion,
 ];
 
 /// 6.3.9 Branch Categories
@@ -56,7 +56,7 @@ pub fn test_6_3_9_branch_categories(doc: &impl CsafTrait) -> Result<(), Vec<Vali
     // for every path to a leaf node
     for (path, indices) in leaf_paths {
         // filter to only the categories relevant to this rule, preserving order
-        let mut relevant: Vec<&CategoryOfTheBranch> = path
+        let mut relevant: Vec<CategoryOfTheBranch> = path
             .iter()
             .map(|b| b.get_category())
             .filter(|c| REQUIRED_CATEGORIES_ORDER.contains(c))
@@ -68,7 +68,7 @@ pub fn test_6_3_9_branch_categories(doc: &impl CsafTrait) -> Result<(), Vec<Vali
         // Check whether the filtered list matches the required sequence exactly
         if !relevant.iter().eq(REQUIRED_CATEGORIES_ORDER.iter()) {
             // collect all categories only when needed for the error message
-            let all_categories: Vec<&CategoryOfTheBranch> = path.iter().map(|b| b.get_category()).collect();
+            let all_categories: Vec<CategoryOfTheBranch> = path.iter().map(|b| b.get_category()).collect();
             errors.get_or_insert_default().push(create_branch_categories_error(
                 &all_categories,
                 &relevant,
@@ -92,31 +92,31 @@ mod tests {
     fn test_test_6_3_9() {
         let case_01_missing_product_version = Err(vec![create_branch_categories_error(
             &[
-                &CategoryOfTheBranch::Vendor,
-                &CategoryOfTheBranch::ProductName,
-                &CategoryOfTheBranch::PatchLevel,
+                CategoryOfTheBranch::Vendor,
+                CategoryOfTheBranch::ProductName,
+                CategoryOfTheBranch::PatchLevel,
             ],
-            &[&CategoryOfTheBranch::Vendor, &CategoryOfTheBranch::ProductName],
+            &[CategoryOfTheBranch::Vendor, CategoryOfTheBranch::ProductName],
             "/product_tree/branches/0/branches/0/branches/0/product".to_string(),
         )]);
 
         let case_02_missing_vendor = Err(vec![
             create_branch_categories_error(
                 &[
-                    &CategoryOfTheBranch::ProductFamily,
-                    &CategoryOfTheBranch::ProductName,
-                    &CategoryOfTheBranch::ProductVersion,
+                    CategoryOfTheBranch::ProductFamily,
+                    CategoryOfTheBranch::ProductName,
+                    CategoryOfTheBranch::ProductVersion,
                 ],
-                &[&CategoryOfTheBranch::ProductName, &CategoryOfTheBranch::ProductVersion],
+                &[CategoryOfTheBranch::ProductName, CategoryOfTheBranch::ProductVersion],
                 "/product_tree/branches/0/branches/0/branches/0/product".to_string(),
             ),
             create_branch_categories_error(
                 &[
-                    &CategoryOfTheBranch::ProductFamily,
-                    &CategoryOfTheBranch::ProductName,
-                    &CategoryOfTheBranch::ProductVersion,
+                    CategoryOfTheBranch::ProductFamily,
+                    CategoryOfTheBranch::ProductName,
+                    CategoryOfTheBranch::ProductVersion,
                 ],
-                &[&CategoryOfTheBranch::ProductName, &CategoryOfTheBranch::ProductVersion],
+                &[CategoryOfTheBranch::ProductName, CategoryOfTheBranch::ProductVersion],
                 "/product_tree/branches/0/branches/0/branches/1/product".to_string(),
             ),
         ]);
@@ -124,28 +124,28 @@ mod tests {
         let case_03_missing_vendor_wrong_order = Err(vec![
             create_branch_categories_error(
                 &[
-                    &CategoryOfTheBranch::ProductFamily,
-                    &CategoryOfTheBranch::ProductVersion,
-                    &CategoryOfTheBranch::ProductName,
+                    CategoryOfTheBranch::ProductFamily,
+                    CategoryOfTheBranch::ProductVersion,
+                    CategoryOfTheBranch::ProductName,
                 ],
-                &[&CategoryOfTheBranch::ProductVersion, &CategoryOfTheBranch::ProductName],
+                &[CategoryOfTheBranch::ProductVersion, CategoryOfTheBranch::ProductName],
                 "/product_tree/branches/0/branches/0/branches/0/product".to_string(),
             ),
             create_branch_categories_error(
                 &[
-                    &CategoryOfTheBranch::ProductFamily,
-                    &CategoryOfTheBranch::ProductVersion,
-                    &CategoryOfTheBranch::ProductName,
+                    CategoryOfTheBranch::ProductFamily,
+                    CategoryOfTheBranch::ProductVersion,
+                    CategoryOfTheBranch::ProductName,
                 ],
-                &[&CategoryOfTheBranch::ProductVersion, &CategoryOfTheBranch::ProductName],
+                &[CategoryOfTheBranch::ProductVersion, CategoryOfTheBranch::ProductName],
                 "/product_tree/branches/0/branches/0/branches/1/product".to_string(),
             ),
         ]);
 
-        let case_04_categories: &[&CategoryOfTheBranch] = &[
-            &CategoryOfTheBranch::Vendor,
-            &CategoryOfTheBranch::ProductVersion,
-            &CategoryOfTheBranch::ProductName,
+        let case_04_categories: &[CategoryOfTheBranch] = &[
+            CategoryOfTheBranch::Vendor,
+            CategoryOfTheBranch::ProductVersion,
+            CategoryOfTheBranch::ProductName,
         ];
         let case_04_wrong_order = Err(vec![
             create_branch_categories_error(
@@ -160,20 +160,20 @@ mod tests {
             ),
         ]);
 
-        let case_05_full: &[&CategoryOfTheBranch] = &[
-            &CategoryOfTheBranch::HostName,
-            &CategoryOfTheBranch::Vendor,
-            &CategoryOfTheBranch::ProductVersion,
-            &CategoryOfTheBranch::Language,
-            &CategoryOfTheBranch::ProductName,
-            &CategoryOfTheBranch::Architecture,
-            &CategoryOfTheBranch::ServicePack,
-            &CategoryOfTheBranch::PatchLevel,
+        let case_05_full: &[CategoryOfTheBranch] = &[
+            CategoryOfTheBranch::HostName,
+            CategoryOfTheBranch::Vendor,
+            CategoryOfTheBranch::ProductVersion,
+            CategoryOfTheBranch::Language,
+            CategoryOfTheBranch::ProductName,
+            CategoryOfTheBranch::Architecture,
+            CategoryOfTheBranch::ServicePack,
+            CategoryOfTheBranch::PatchLevel,
         ];
         let case_05_relevant = &[
-            &CategoryOfTheBranch::Vendor,
-            &CategoryOfTheBranch::ProductVersion,
-            &CategoryOfTheBranch::ProductName,
+            CategoryOfTheBranch::Vendor,
+            CategoryOfTheBranch::ProductVersion,
+            CategoryOfTheBranch::ProductName,
         ];
         let case_05_wrong_order_deep_tree = Err(vec![
             create_branch_categories_error(
@@ -191,19 +191,19 @@ mod tests {
         let case_06_missing_vendor_name_version = Err(vec![
             create_branch_categories_error(
                 &[
-                    &CategoryOfTheBranch::HostName,
-                    &CategoryOfTheBranch::Architecture,
-                    &CategoryOfTheBranch::Language,
+                    CategoryOfTheBranch::HostName,
+                    CategoryOfTheBranch::Architecture,
+                    CategoryOfTheBranch::Language,
                 ],
                 &[],
                 "/product_tree/branches/0/branches/0/branches/0/product".to_string(),
             ),
             create_branch_categories_error(
                 &[
-                    &CategoryOfTheBranch::HostName,
-                    &CategoryOfTheBranch::Architecture,
-                    &CategoryOfTheBranch::ServicePack,
-                    &CategoryOfTheBranch::PatchLevel,
+                    CategoryOfTheBranch::HostName,
+                    CategoryOfTheBranch::Architecture,
+                    CategoryOfTheBranch::ServicePack,
+                    CategoryOfTheBranch::PatchLevel,
                 ],
                 &[],
                 "/product_tree/branches/0/branches/1/branches/0/branches/0/product".to_string(),
@@ -212,16 +212,16 @@ mod tests {
 
         let case_s01_stacked_wrong_order = Err(vec![create_branch_categories_error(
             &[
-                &CategoryOfTheBranch::Vendor,
-                &CategoryOfTheBranch::ProductName,
-                &CategoryOfTheBranch::Vendor,
-                &CategoryOfTheBranch::ProductVersion,
+                CategoryOfTheBranch::Vendor,
+                CategoryOfTheBranch::ProductName,
+                CategoryOfTheBranch::Vendor,
+                CategoryOfTheBranch::ProductVersion,
             ],
             &[
-                &CategoryOfTheBranch::Vendor,
-                &CategoryOfTheBranch::ProductName,
-                &CategoryOfTheBranch::Vendor,
-                &CategoryOfTheBranch::ProductVersion,
+                CategoryOfTheBranch::Vendor,
+                CategoryOfTheBranch::ProductName,
+                CategoryOfTheBranch::Vendor,
+                CategoryOfTheBranch::ProductVersion,
             ],
             "/product_tree/branches/0/branches/0/branches/0/branches/0/product".to_string(),
         )]);

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -16,7 +16,7 @@ pub fn test_6_3_10_usage_of_product_version_range(doc: &impl CsafTrait) -> Resul
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_branches(&mut |branch, path| {
-            if branch.get_category() == &CategoryOfTheBranch::ProductVersionRange {
+            if branch.get_category() == CategoryOfTheBranch::ProductVersionRange {
                 errors
                     .get_or_insert_default()
                     .push(create_product_version_range_error(path));

--- a/csaf-rs/src/validations/test_6_3_11.rs
+++ b/csaf-rs/src/validations/test_6_3_11.rs
@@ -23,7 +23,7 @@ pub fn test_6_3_11_usage_of_v_as_version_indicator(doc: &impl CsafTrait) -> Resu
 
     if let Some(product_tree) = doc.get_product_tree().as_ref() {
         product_tree.visit_all_branches(&mut |branch, path| {
-            if branch.get_category() == &CategoryOfTheBranch::ProductVersion
+            if branch.get_category() == CategoryOfTheBranch::ProductVersion
                 && V_AS_VERSION_INDICATOR_REGEX.is_match(branch.get_name())
             {
                 errors

--- a/csaf-rs/src/validations/utils/document_category_test_config.rs
+++ b/csaf-rs/src/validations/utils/document_category_test_config.rs
@@ -54,7 +54,7 @@ impl DocumentCategoryTestConfig {
     /// The check includes both shared categories and version-specific categories.
     pub fn matches_category_with_csaf_version(
         &self,
-        csaf_version: &CsafVersion,
+        csaf_version: CsafVersion,
         document_category: &CsafDocumentCategory,
     ) -> bool {
         // First check shared categories
@@ -113,37 +113,31 @@ mod tests {
         // Shared applies to both
         assert!(
             TEST_CONFIG
-                .matches_category_with_csaf_version(&CsafVersion::X20, &CsafDocumentCategory::CsafSecurityAdvisory)
+                .matches_category_with_csaf_version(CsafVersion::X20, &CsafDocumentCategory::CsafSecurityAdvisory)
         );
         assert!(
             TEST_CONFIG
-                .matches_category_with_csaf_version(&CsafVersion::X21, &CsafDocumentCategory::CsafSecurityAdvisory)
+                .matches_category_with_csaf_version(CsafVersion::X21, &CsafDocumentCategory::CsafSecurityAdvisory)
         );
 
         // CSAF 2.0-specific applies only to 2.0
-        assert!(TEST_CONFIG.matches_category_with_csaf_version(&CsafVersion::X20, &CsafDocumentCategory::CsafVex));
-        assert!(!TEST_CONFIG.matches_category_with_csaf_version(&CsafVersion::X21, &CsafDocumentCategory::CsafVex));
+        assert!(TEST_CONFIG.matches_category_with_csaf_version(CsafVersion::X20, &CsafDocumentCategory::CsafVex));
+        assert!(!TEST_CONFIG.matches_category_with_csaf_version(CsafVersion::X21, &CsafDocumentCategory::CsafVex));
 
         // CSAF 2.1-specific applies only to 2.1
         assert!(
-            !TEST_CONFIG.matches_category_with_csaf_version(&CsafVersion::X20, &CsafDocumentCategory::CsafWithdrawn)
+            !TEST_CONFIG.matches_category_with_csaf_version(CsafVersion::X20, &CsafDocumentCategory::CsafWithdrawn)
         );
-        assert!(
-            TEST_CONFIG.matches_category_with_csaf_version(&CsafVersion::X21, &CsafDocumentCategory::CsafWithdrawn)
-        );
+        assert!(TEST_CONFIG.matches_category_with_csaf_version(CsafVersion::X21, &CsafDocumentCategory::CsafWithdrawn));
 
         // Other categories do not apply
         assert!(
-            !TEST_CONFIG.matches_category_with_csaf_version(
-                &CsafVersion::X20,
-                &CsafDocumentCategory::CsafInformationalAdvisory
-            )
+            !TEST_CONFIG
+                .matches_category_with_csaf_version(CsafVersion::X20, &CsafDocumentCategory::CsafInformationalAdvisory)
         );
         assert!(
-            !TEST_CONFIG.matches_category_with_csaf_version(
-                &CsafVersion::X21,
-                &CsafDocumentCategory::CsafInformationalAdvisory
-            )
+            !TEST_CONFIG
+                .matches_category_with_csaf_version(CsafVersion::X21, &CsafDocumentCategory::CsafInformationalAdvisory)
         );
     }
 
@@ -181,7 +175,7 @@ mod tests {
             DocumentCategoryTestConfig::new().csaf21(&[CsafDocumentCategory::CsafWithdrawn]);
 
         let result = std::panic::catch_unwind(|| {
-            TEST_CONFIG.matches_category_with_csaf_version(&CsafVersion::X20, &CsafDocumentCategory::CsafVex);
+            TEST_CONFIG.matches_category_with_csaf_version(CsafVersion::X20, &CsafDocumentCategory::CsafVex);
         });
         assert!(result.is_err());
     }
@@ -192,7 +186,7 @@ mod tests {
             DocumentCategoryTestConfig::new().csaf20(&[CsafDocumentCategory::CsafVex]);
 
         let result = std::panic::catch_unwind(|| {
-            TEST_CONFIG.matches_category_with_csaf_version(&CsafVersion::X21, &CsafDocumentCategory::CsafWithdrawn);
+            TEST_CONFIG.matches_category_with_csaf_version(CsafVersion::X21, &CsafDocumentCategory::CsafWithdrawn);
         });
         assert!(result.is_err());
     }


### PR DESCRIPTION
Relates to #205 

This PR: 
* moves &String to &str
* puts Copy on some small enums / types and uses it in the codebase

This improves readability and minimally improves performance for the types that are more efficiently passed by value.