### PR TITLE
feat: abstract the source of the JSON content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,6 +518,7 @@ dependencies = [
  "serde_json",
  "spdx",
  "ssvc",
+ "tempfile",
  "uuid",
 ]
 

--- a/csaf-ffi/src/document.rs
+++ b/csaf-ffi/src/document.rs
@@ -5,8 +5,8 @@
 use std::sync::{Arc, Mutex};
 
 use csaf::csaf::raw::{HasParsed, RawDocument};
-use csaf::csaf2_0::loader::load_document_from_str as load_2_0;
-use csaf::csaf2_1::loader::load_document_from_str as load_2_1;
+use csaf::csaf2_0::loader::load_document as load_2_0;
+use csaf::csaf2_1::loader::load_document as load_2_1;
 use csaf::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework as Csaf20;
 use csaf::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework as Csaf21;
 use csaf::validation::{validate_by_preset, validate_by_test, validate_by_tests};

--- a/csaf-ffi/src/lib.rs
+++ b/csaf-ffi/src/lib.rs
@@ -3,10 +3,8 @@
 //! This crate provides a foreign-function interface (FFI) layer on top of `csaf-rs`,
 //! enabling Go, WASM, and other language bindings via Mozilla UniFFI.
 
-use csaf::csaf2_0::loader::load_document_from_str as load_document_from_str_2_0;
-use csaf::csaf2_0::loader::load_document_from_value as load_document_from_value_2_0;
-use csaf::csaf2_1::loader::load_document_from_str as load_document_from_str_2_1;
-use csaf::csaf2_1::loader::load_document_from_value as load_document_from_value_2_1;
+use csaf::csaf2_0::loader::load_document as load_document_2_0;
+use csaf::csaf2_1::loader::load_document as load_document_2_1;
 use csaf::validation::validate_by_preset;
 
 pub mod document;
@@ -171,13 +169,11 @@ pub fn validate_csaf(json_str: String, preset: String) -> Result<ValidationResul
 
     let result = match version.as_str() {
         "2.0" => {
-            let doc = load_document_from_value_2_0(json_value)
-                .map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            let doc = load_document_2_0(json_value).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
             validate_by_preset(&doc, "2.0", &preset)
         },
         "2.1" => {
-            let doc = load_document_from_value_2_1(json_value)
-                .map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            let doc = load_document_2_1(json_value).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
             validate_by_preset(&doc, "2.1", &preset)
         },
         other => {
@@ -198,7 +194,7 @@ pub fn validate_csaf(json_str: String, preset: String) -> Result<ValidationResul
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_0(json_str: String, preset: String) -> Result<ValidationResult, CsafError> {
-    let doc = load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+    let doc = load_document_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     Ok(validate_by_preset(&doc, "2.0", &preset).into())
 }
 
@@ -210,7 +206,7 @@ pub fn validate_csaf_2_0(json_str: String, preset: String) -> Result<ValidationR
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_1(json_str: String, preset: String) -> Result<ValidationResult, CsafError> {
-    let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+    let doc = load_document_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     Ok(validate_by_preset(&doc, "2.1", &preset).into())
 }
 
@@ -241,13 +237,11 @@ pub fn validate_csaf_to_json_string(json_str: String, preset: String) -> Result<
 
     let result = match version.as_str() {
         "2.0" => {
-            let doc =
-                load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            let doc = load_document_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
             validate_by_preset(&doc, "2.0", &preset)
         },
         "2.1" => {
-            let doc =
-                load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+            let doc = load_document_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
             validate_by_preset(&doc, "2.1", &preset)
         },
         other => {
@@ -271,7 +265,7 @@ pub fn validate_csaf_to_json_string(json_str: String, preset: String) -> Result<
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_0_to_json_string(json_str: String, preset: String) -> Result<String, CsafError> {
-    let doc = load_document_from_str_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+    let doc = load_document_2_0(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     let result = validate_by_preset(&doc, "2.0", &preset);
     serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })
 }
@@ -287,7 +281,7 @@ pub fn validate_csaf_2_0_to_json_string(json_str: String, preset: String) -> Res
 /// * `preset`   - The validation preset: e.g. `"basic"`, `"extended"`, or `"full"`.
 #[uniffi::export]
 pub fn validate_csaf_2_1_to_json_string(json_str: String, preset: String) -> Result<String, CsafError> {
-    let doc = load_document_from_str_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+    let doc = load_document_2_1(&json_str).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
     let result = validate_by_preset(&doc, "2.1", &preset);
     serde_json::to_string(&result).map_err(|e| CsafError::InvalidJson { message: e.to_string() })
 }

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -25,7 +25,7 @@ converter = []
 cvss-rs = "0.3.0"
 regress = "0.11"
 serde = { version = "1", features = ["derive"] }
-serde_json = {  version = "1",  features = ["preserve_order"]}
+serde_json = { version = "1", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 rust-embed = { version = "8", features = ["include-exclude"] }
@@ -47,6 +47,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 [dev-dependencies]
 rstest = "0.26.1"
 criterion = { version = "0.5", features = ["html_reports"] }
+tempfile = "3"
 
 [[bench]]
 name = "validation_benchmark"

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -5,12 +5,12 @@ use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
-use csaf::csaf2_0::loader::load_document_from_str as load_document_2_0;
+use csaf::csaf2_0::loader::load_document as load_document_2_0;
 use csaf::csaf2_0::testcases::{
     informative_tests as informative_tests_2_0, mandatory_tests as mandatory_tests_2_0,
     recommended_tests as recommended_tests_2_0,
 };
-use csaf::csaf2_1::loader::load_document_from_str as load_document_2_1;
+use csaf::csaf2_1::loader::load_document as load_document_2_1;
 use csaf::csaf2_1::testcases::{
     informative_tests as informative_tests_2_1, mandatory_tests as mandatory_tests_2_1,
     recommended_tests as recommended_tests_2_1,

--- a/csaf-rs/src/converter/mod.rs
+++ b/csaf-rs/src/converter/mod.rs
@@ -13,12 +13,13 @@ mod tests {
     use crate::csaf::raw::HasParsed;
     use crate::csaf2_0::loader::load_document as load_document_2_0;
     use crate::csaf2_1::loader::load_document as load_document_2_1;
+    use std::path::Path;
 
     #[test]
     fn test_is_csaf_2_0_returns_true_for_v20() {
-        let doc = load_document_2_0(
+        let doc = load_document_2_0(Path::new(
             "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-01-11.json",
-        )
+        ))
         .expect("Failed to load CSAF 2.0 test document");
         let parsed = doc.get_parsed().as_ref().expect("Failed to parse CSAF 2.0 document");
         assert!(is_csaf_2_0(parsed));
@@ -26,9 +27,9 @@ mod tests {
 
     #[test]
     fn test_is_csaf_2_0_returns_false_for_v21() {
-        let doc = load_document_2_1(
+        let doc = load_document_2_1(Path::new(
             "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-11.json",
-        )
+        ))
         .expect("Failed to load CSAF 2.1 test document");
         let parsed = doc.get_parsed().as_ref().expect("Failed to parse CSAF 2.1 document");
         assert!(!is_csaf_2_0(parsed));

--- a/csaf-rs/src/csaf/loader.rs
+++ b/csaf-rs/src/csaf/loader.rs
@@ -1,14 +1,25 @@
-use std::{fs::File, io::BufReader};
+use crate::json::JsonSource;
 
-pub fn detect_version(path: &str) -> std::io::Result<String> {
-    let f = File::open(path)?;
-    let reader = BufReader::new(f);
+/// Detected version and parsed data.
+pub struct VersionAndData {
+    pub version: String,
+    pub data: serde_json::Value,
+}
 
+/// Detect the version and return only the version.
+pub fn detect_version<T: JsonSource>(source: T) -> std::io::Result<String> {
+    detect_version_with(source).map(|r| r.version)
+}
+
+/// Detect the version and return it with the parsed raw JSON.
+///
+/// This can help improve re-using the already parsed data.
+pub fn detect_version_with<T: JsonSource>(source: T) -> std::io::Result<VersionAndData> {
     // First, try to parse the JSON
-    let json_value: serde_json::Value = serde_json::from_reader(reader)?;
+    let json_value: serde_json::Value = source.parse()?;
 
     // Then, try to get the CSAF version from the document
-    json_value
+    let version = json_value
         .get("document")
         .and_then(|doc| doc.get("csaf_version"))
         .and_then(|v| v.as_str())
@@ -18,5 +29,10 @@ pub fn detect_version(path: &str) -> std::io::Result<String> {
                 std::io::ErrorKind::InvalidData,
                 "Could not detect CSAF version. Make sure the document has a 'document.csaf_version' field",
             )
-        })
+        })?;
+
+    Ok(VersionAndData {
+        version,
+        data: json_value,
+    })
 }

--- a/csaf-rs/src/csaf2_0/loader.rs
+++ b/csaf-rs/src/csaf2_0/loader.rs
@@ -1,27 +1,7 @@
-use crate::{csaf::raw::RawDocument, schema::csaf2_0::schema::CommonSecurityAdvisoryFramework};
-use std::{fs::File, io::BufReader};
+use crate::{csaf::raw::RawDocument, json::JsonSource, schema::csaf2_0::schema::CommonSecurityAdvisoryFramework};
 
-pub fn load_document(path: &str) -> std::io::Result<RawDocument<CommonSecurityAdvisoryFramework>> {
-    let f = File::open(path)?;
-    let reader = BufReader::new(f);
-    let doc: RawDocument<CommonSecurityAdvisoryFramework> = RawDocument::new(serde_json::from_reader(reader)?);
-    Ok(doc)
-}
-
-/// Load a CSAF document from a JSON string
-pub fn load_document_from_str(json_str: &str) -> std::io::Result<RawDocument<CommonSecurityAdvisoryFramework>> {
-    let doc: RawDocument<CommonSecurityAdvisoryFramework> = RawDocument::new(serde_json::from_str(json_str)?);
-    Ok(doc)
-}
-
-/// Load a CSAF document from an already-parsed [`serde_json::Value`].
-///
-/// Use this when the JSON has already been parsed (e.g. to extract the
-/// `document.csaf_version` field) to avoid parsing the same string twice.
-pub fn load_document_from_value(
-    value: serde_json::Value,
-) -> Result<RawDocument<CommonSecurityAdvisoryFramework>, serde_json::Error> {
-    Ok(RawDocument::new(serde_json::from_value(value)?))
+pub fn load_document<T: JsonSource>(source: T) -> std::io::Result<RawDocument<CommonSecurityAdvisoryFramework>> {
+    Ok(RawDocument::new(source.parse()?))
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/csaf2_1/loader.rs
+++ b/csaf-rs/src/csaf2_1/loader.rs
@@ -1,27 +1,7 @@
-use crate::{csaf::raw::RawDocument, schema::csaf2_1::schema::CommonSecurityAdvisoryFramework};
-use std::{fs::File, io::BufReader};
+use crate::{csaf::raw::RawDocument, json::JsonSource, schema::csaf2_1::schema::CommonSecurityAdvisoryFramework};
 
-pub fn load_document(path: &str) -> std::io::Result<RawDocument<CommonSecurityAdvisoryFramework>> {
-    let f = File::open(path)?;
-    let reader = BufReader::new(f);
-    let doc: RawDocument<CommonSecurityAdvisoryFramework> = RawDocument::new(serde_json::from_reader(reader)?);
-    Ok(doc)
-}
-
-/// Load a CSAF document from a JSON string
-pub fn load_document_from_str(json_str: &str) -> std::io::Result<RawDocument<CommonSecurityAdvisoryFramework>> {
-    let doc: RawDocument<CommonSecurityAdvisoryFramework> = RawDocument::new(serde_json::from_str(json_str)?);
-    Ok(doc)
-}
-
-/// Load a CSAF document from an already-parsed [`serde_json::Value`].
-///
-/// Use this when the JSON has already been parsed (e.g. to extract the
-/// `document.csaf_version` field) to avoid parsing the same string twice.
-pub fn load_document_from_value(
-    value: serde_json::Value,
-) -> Result<RawDocument<CommonSecurityAdvisoryFramework>, serde_json::Error> {
-    Ok(RawDocument::new(serde_json::from_value(value)?))
+pub fn load_document<T: JsonSource>(source: T) -> std::io::Result<RawDocument<CommonSecurityAdvisoryFramework>> {
+    Ok(RawDocument::new(source.parse()?))
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/json.rs
+++ b/csaf-rs/src/json.rs
@@ -1,0 +1,174 @@
+//! Helpers to work with JSON
+//!
+//! ## JSON source
+//!
+//! In order to avoid creating multiple combinations of functions reading from different JSON
+//! sources (file, buffer, string, …) and still missing some, we use [`JsonSource`], which
+//! implements whatever has to be done to parse a JSON document from the source.
+//!
+//! ```rust
+//! # use std::fs;
+//! # use std::path::Path;
+//! # use csaf::json::JsonSource;
+//! # use serde_json::json;
+//! #
+//! # #[derive(serde::Deserialize)] struct MyDoc;
+//! fn load_doc(s: impl JsonSource) -> std::io::Result<MyDoc> {
+//!   s.parse()
+//! }
+//!
+//! fn examples() -> std::io::Result<()> {
+//!   let _ = load_doc(r#"{}"#)?; // load from JSON string
+//!   let _ = load_doc(Path::new("file.json"))?; // load from file
+//!   let _ = load_doc(json!({}))?; // load from serde_json::Value
+//!   let _ = load_doc(&fs::read("file.json")?)?; // load from byte array
+//!
+//!   Ok(())
+//! }
+//! ```
+use serde::de::DeserializeOwned;
+use std::path::PathBuf;
+use std::{fs, io::BufReader, path::Path};
+
+/// A source of JSON based information.
+///
+/// This trait allows to parse a JSON document, independent of the source. Avoiding repeated
+/// implementations for "parsing from file", "parsing from string", "parsing from Value", ...
+pub trait JsonSource {
+    /// Parse the source
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error>;
+}
+
+impl JsonSource for &Path {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_reader(BufReader::new(fs::File::open(self)?))?)
+    }
+}
+
+impl JsonSource for &PathBuf {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_reader(BufReader::new(fs::File::open(self)?))?)
+    }
+}
+
+impl JsonSource for fs::File {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_reader(BufReader::new(self))?)
+    }
+}
+
+impl<R: std::io::Read> JsonSource for BufReader<R> {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_reader(self)?)
+    }
+}
+
+impl JsonSource for &Vec<u8> {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_slice(self)?)
+    }
+}
+
+impl JsonSource for &[u8] {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_slice(self)?)
+    }
+}
+
+impl<const N: usize> JsonSource for &[u8; N] {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_slice(self)?)
+    }
+}
+
+impl JsonSource for serde_json::Value {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_value(self)?)
+    }
+}
+
+impl JsonSource for &str {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_str(self)?)
+    }
+}
+
+/// Convenience implementation for directly referencing `String`.
+impl JsonSource for &String {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_str(self)?)
+    }
+}
+
+/// A new-type to allow using [`JsonSource`] with anything that implements [`std::io::Read`].
+pub struct Reader<R: std::io::Read>(pub R);
+
+impl<R: std::io::Read> JsonSource for Reader<R> {
+    fn parse<T: DeserializeOwned>(self) -> Result<T, std::io::Error> {
+        Ok(serde_json::from_reader(self.0)?)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::io::{Cursor, Seek, SeekFrom, Write};
+
+    #[derive(Debug, serde::Deserialize)]
+    struct TestDocument {}
+
+    fn load<T: JsonSource>(source: T) -> std::io::Result<TestDocument> {
+        source.parse()
+    }
+
+    /// Test we can load a string
+    #[test]
+    fn from_str() {
+        let _ = load("{}").expect("must load");
+    }
+
+    /// Test we can load a slice
+    #[test]
+    fn from_slice() {
+        let _ = load(&b"{}"[..]).expect("must load");
+    }
+
+    /// Test an array (with a size) works like a slice
+    #[test]
+    fn from_array() {
+        let _ = load(b"{}").expect("must load");
+    }
+
+    /// Test from a file handle
+    #[test]
+    fn from_file() {
+        let mut t = tempfile::tempfile().expect("must create temp file");
+        t.write_all(br#"{}"#).expect("must write to temp file");
+        t.seek(SeekFrom::Start(0)).expect("must seek");
+
+        let _ = load(t).expect("must load");
+    }
+
+    /// Test from a path to a file
+    #[test]
+    fn from_path() {
+        let t = tempfile::tempdir().expect("must create temp dir");
+
+        let path = t.path().join("test.json");
+        fs::write(&path, br#"{}"#).expect("must write to temp file");
+
+        let _ = load(&path).expect("must load");
+        let _ = load(&path as &Path).expect("must load");
+
+        t.close().expect("must close file");
+    }
+
+    /// Test a simple reader trait
+    #[test]
+    fn from_any_reader() {
+        let s = br#"{}"#;
+        let c = Cursor::new(s);
+
+        let _ = load(Reader(c)).expect("must load");
+    }
+}

--- a/csaf-rs/src/lib.rs
+++ b/csaf-rs/src/lib.rs
@@ -6,6 +6,7 @@ pub mod csaf2_1;
 pub mod csaf_traits;
 pub(crate) mod cvss;
 pub mod helpers;
+pub mod json;
 pub(crate) mod macros;
 pub mod schema;
 #[cfg(test)]


### PR DESCRIPTION
Instead of having multiple variants of "load_abc" functions, create a trait and let it implement what "loading JSON" means. And have the content functions just re-use that.