### PR TITLE
fix: use Path instead of string content for parsing

### DIFF
--- a/csaf-result-json/src/main.rs
+++ b/csaf-result-json/src/main.rs
@@ -77,7 +77,6 @@ fn main() -> Result<(), anyhow::Error> {
             csaf_document: path,
         } => {
             tests.push(test_id.as_str());
-            println!("Running tests: {tests:?}");
 
             let file_path = Path::new(&path);
 
@@ -85,7 +84,6 @@ fn main() -> Result<(), anyhow::Error> {
                 "auto" => detect_version(file_path)?,
                 other => other.to_string(),
             };
-            println!("Detected CSAF version: {version}");
 
             let result = match version.as_str() {
                 "2.0" => {

--- a/csaf-result-json/src/main.rs
+++ b/csaf-result-json/src/main.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), anyhow::Error> {
             csaf_document: path,
         } => {
             tests.push(test_id.as_str());
-            println!("Running tests: {:?}", tests);
+            println!("Running tests: {tests:?}");
 
             let file_path = Path::new(&path);
 

--- a/csaf-result-json/src/main.rs
+++ b/csaf-result-json/src/main.rs
@@ -2,6 +2,8 @@ mod compare;
 mod convert;
 mod result;
 
+use std::path::Path;
+
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 use compare::compare_result_jsons;
@@ -75,19 +77,23 @@ fn main() -> Result<(), anyhow::Error> {
             csaf_document: path,
         } => {
             tests.push(test_id.as_str());
+            println!("Running tests: {:?}", tests);
+
+            let file_path = Path::new(&path);
 
             let version = match args.csaf_version.as_str() {
-                "auto" => detect_version(path.as_str())?,
+                "auto" => detect_version(file_path)?,
                 other => other.to_string(),
             };
+            println!("Detected CSAF version: {version}");
 
             let result = match version.as_str() {
                 "2.0" => {
-                    let document = load_document_2_0(path.as_str())?;
+                    let document = load_document_2_0(file_path)?;
                     validate_document(document, "2.0", &tests)
                 },
                 "2.1" => {
-                    let document = load_document_2_1(path.as_str())?;
+                    let document = load_document_2_1(file_path)?;
                     validate_document(document, "2.1", &tests)
                 },
                 _ => bail!(format!("Invalid CSAF version: {version}")),
@@ -121,18 +127,20 @@ fn main() -> Result<(), anyhow::Error> {
                 }
             }
 
+            let file_path = Path::new(&path);
+
             let version = match args.csaf_version.as_str() {
-                "auto" => detect_version(path.as_str())?,
+                "auto" => detect_version(file_path)?,
                 other => other.to_string(),
             };
 
             let result = match version.as_str() {
                 "2.0" => {
-                    let document = load_document_2_0(path.as_str())?;
+                    let document = load_document_2_0(file_path)?;
                     validate_document(document, "2.0", &tests)
                 },
                 "2.1" => {
-                    let document = load_document_2_1(path.as_str())?;
+                    let document = load_document_2_1(file_path)?;
                     validate_document(document, "2.1", &tests)
                 },
                 _ => bail!(format!("Invalid CSAF version: {version}")),

--- a/csaf-validator/src/main.rs
+++ b/csaf-validator/src/main.rs
@@ -10,7 +10,7 @@ use csaf::validation::{
     TestResultStatus::{Failure, NotFound, Skipped, Success},
     Validatable, ValidationResult, validate_by_tests,
 };
-use std::ops::Deref;
+use std::path::Path;
 
 /// A validator for CSAF documents
 #[derive(Parser, Debug)]
@@ -43,7 +43,7 @@ fn main() -> Result<(), anyhow::Error> {
     if args
         .path
         .iter()
-        .map(|file| validate_file(file.deref(), &args))
+        .map(|file| validate_file(Path::new(&file), &args))
         .filter(|result| match result {
             Ok(result) => !result.success,
             Err(err) => {
@@ -60,9 +60,9 @@ fn main() -> Result<(), anyhow::Error> {
 }
 
 /// Try to validate a file as a CSAF document based on the specified version.
-fn validate_file(path: &str, args: &Args) -> Result<ValidationResult> {
+fn validate_file(path: &Path, args: &Args) -> Result<ValidationResult> {
     let file_color = anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Cyan.into()));
-    println!("Validating file: {file_color}{path}{file_color:#}");
+    println!("Validating file: {file_color}{}{file_color:#}", path.display());
     let version = match args.csaf_version.as_str() {
         "auto" => detect_version(path)?,
         other => other.to_string(),


### PR DESCRIPTION
resolves #683 

The detect_version function was called with the name of the file instead of the content of the file. This was probably introduced with the `JsonSource` functionality. This is a quick fix which uses the file path, so the content passed to the functions is really the json content.