### PR TITLE
build: packageurl requirement 0.6

### DIFF
--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 rust-embed = { version = "8", features = ["include-exclude"] }
-packageurl = "0.6.0-rc.1"
+packageurl = "0.6"
 uuid = { version = "1.17.0", features = ["v7", "serde"] }
 semver = { version = "1" }
 jsonschema = { version = "0.45.0", default-features = false }


### PR DESCRIPTION
The pre-release requirement string resolves to the stable 0.6.0 either way; the caret range states it directly and stops advertising a pre-release in the published metadata.