### PR TITLE
build: drop the docs.rs rustc-args cfg

### DIFF
--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -53,5 +53,3 @@ tempfile = "3"
 name = "validation_benchmark"
 harness = false
 
-[package.metadata.docs.rs]
-rustc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
rustc-args applies --cfg docsrs to every dependency build; generic-array 0.14 reacts with a nightly feature removed in Rust 1.92 and the whole docs.rs build fails (E0557). Nothing in this crate reads the cfg.