### PR TITLE
feat: typed CVSS accessors on ContentTrait

### DIFF
--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -25,7 +25,7 @@ converter = []
 cvss-rs = "0.3.0"
 regress = "0.11"
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0.135", features = ["preserve_order"] }
+serde_json = { version = "1.0.131", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 rust-embed = { version = "8", features = ["include-exclude"] }

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -25,7 +25,7 @@ converter = []
 cvss-rs = "0.3.0"
 regress = "0.11"
 serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1.0.135", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 rust-embed = { version = "8", features = ["include-exclude"] }

--- a/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
@@ -4,6 +4,7 @@ use crate::schema::csaf2_1::schema::{Content, Epss, QualitativeSeverityRating};
 use cvss_rs::v2_0::CvssV2;
 use cvss_rs::v3::CvssV3;
 use cvss_rs::v4_0::CvssV4;
+use serde::Deserialize;
 use serde::de::Error as SerdeError;
 use serde_json::{Map, Value};
 use ssvc::selection_list::SelectionList;
@@ -66,8 +67,7 @@ pub trait ContentTrait {
 
     /// Returns the contained CVSS 2.0 metric parsed into its typed representation, if any.
     fn get_cvss_v2_typed(&self) -> Option<Result<CvssV2, serde_json::Error>> {
-        self.get_cvss_v2()
-            .map(|map| serde_json::from_value(Value::Object(map.clone())))
+        self.get_cvss_v2().map(CvssV2::deserialize)
     }
 
     /// Returns a JSON representation of the contained CVSS 3.0/3.1 metric, if any.
@@ -80,8 +80,7 @@ pub trait ContentTrait {
 
     /// Returns the contained CVSS 3.0/3.1 metric parsed into its typed representation, if any.
     fn get_cvss_v3_typed(&self) -> Option<Result<CvssV3, serde_json::Error>> {
-        self.get_cvss_v3()
-            .map(|map| serde_json::from_value(Value::Object(map.clone())))
+        self.get_cvss_v3().map(CvssV3::deserialize)
     }
 
     /// Returns a JSON representation of the contained CVSS 4.0 metric, if any.
@@ -94,8 +93,7 @@ pub trait ContentTrait {
 
     /// Returns the contained CVSS 4.0 metric parsed into its typed representation, if any.
     fn get_cvss_v4_typed(&self) -> Option<Result<CvssV4, serde_json::Error>> {
-        self.get_cvss_v4()
-            .map(|map| serde_json::from_value(Value::Object(map.clone())))
+        self.get_cvss_v4().map(CvssV4::deserialize)
     }
 
     /// Returns whether this content contains any CVSS metric (v2, v3, or v4).

--- a/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
@@ -248,50 +248,109 @@ impl ContentTrait for Content {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
     use serde_json::json;
 
-    #[test]
-    fn score_cvss_v3_typed_parses_the_map() {
-        let score: Score = serde_json::from_value(json!({
-            "products": ["CSAFPID-0001"],
-            "cvss_v3": {
-                "version": "3.1",
-                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
-                "baseScore": 9.8,
-                "baseSeverity": "CRITICAL"
-            }
-        }))
-        .expect("score deserializes");
-        let cvss = score.get_cvss_v3_typed().expect("present").expect("parses");
-        assert_eq!(cvss.vector_string, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
-        assert!(score.get_cvss_v2_typed().is_none());
+    /// Builds a CSAF 2.1 `Content` carrying `metric` under `key`.
+    fn content_with(key: &str, metric: &Value) -> Content {
+        let mut map = Map::new();
+        map.insert(key.to_string(), metric.clone());
+        serde_json::from_value(Value::Object(map)).expect("content deserializes")
     }
 
-    #[test]
-    fn score_cvss_v3_typed_reports_a_nonconforming_map() {
-        let score: Score = serde_json::from_value(json!({
-            "products": ["CSAFPID-0001"],
-            "cvss_v3": { "version": "3.1" }
-        }))
-        .expect("score deserializes");
-        assert!(score.get_cvss_v3_typed().expect("present").is_err());
+    /// Builds a CSAF 2.0 `Score` carrying `metric` under `key`.
+    fn score_with(key: &str, metric: &Value) -> Score {
+        let mut map = Map::new();
+        map.insert("products".to_string(), json!(["CSAFPID-0001"]));
+        map.insert(key.to_string(), metric.clone());
+        serde_json::from_value(Value::Object(map)).expect("score deserializes")
     }
 
-    #[test]
-    fn content_cvss_v4_typed_parses_the_map() {
-        let content: Content = serde_json::from_value(json!({
-            "cvss_v4": {
-                "version": "4.0",
-                "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
-                "baseScore": 9.3,
-                "baseSeverity": "CRITICAL"
-            }
-        }))
-        .expect("content deserializes");
-        let cvss = content.get_cvss_v4_typed().expect("present").expect("parses");
-        assert_eq!(
-            cvss.vector_string,
-            "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+    /// Asserts the typed accessor matching `key` parses to `vector` and the other two
+    /// return `None`.
+    fn assert_only_typed(content: &impl ContentTrait, key: &str, vector: &str) {
+        let (v2, v3, v4) = (
+            content.get_cvss_v2_typed(),
+            content.get_cvss_v3_typed(),
+            content.get_cvss_v4_typed(),
         );
+        match key {
+            "cvss_v2" => {
+                assert_eq!(v2.expect("present").expect("parses").vector_string, vector);
+                assert!(v3.is_none());
+                assert!(v4.is_none());
+            },
+            "cvss_v3" => {
+                assert!(v2.is_none());
+                assert_eq!(v3.expect("present").expect("parses").vector_string, vector);
+                assert!(v4.is_none());
+            },
+            "cvss_v4" => {
+                assert!(v2.is_none());
+                assert!(v3.is_none());
+                assert_eq!(v4.expect("present").expect("parses").vector_string, vector);
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    /// Asserts the typed accessor matching `key` reports a parse error.
+    fn assert_typed_err(content: &impl ContentTrait, key: &str) {
+        match key {
+            "cvss_v2" => assert!(content.get_cvss_v2_typed().expect("present").is_err()),
+            "cvss_v3" => assert!(content.get_cvss_v3_typed().expect("present").is_err()),
+            "cvss_v4" => assert!(content.get_cvss_v4_typed().expect("present").is_err()),
+            _ => unreachable!(),
+        }
+    }
+
+    #[rstest]
+    #[case::v2(
+        "cvss_v2",
+        json!({
+            "version": "2.0",
+            "vectorString": "AV:N/AC:L/Au:N/C:C/I:C/A:C",
+            "baseScore": 10.0
+        }),
+        "AV:N/AC:L/Au:N/C:C/I:C/A:C"
+    )]
+    #[case::v3(
+        "cvss_v3",
+        json!({
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL"
+        }),
+        "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    )]
+    #[case::v4(
+        "cvss_v4",
+        json!({
+            "version": "4.0",
+            "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+            "baseScore": 9.3,
+            "baseSeverity": "CRITICAL"
+        }),
+        "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+    )]
+    fn typed_accessor_parses_and_the_others_are_none(#[case] key: &str, #[case] metric: Value, #[case] vector: &str) {
+        assert_only_typed(&content_with(key, &metric), key, vector);
+        // CSAF 2.0 has no cvss_v4 property; Score::get_cvss_v4 always returns None.
+        if key != "cvss_v4" {
+            assert_only_typed(&score_with(key, &metric), key, vector);
+        }
+    }
+
+    #[rstest]
+    #[case::v2("cvss_v2", "2.0")]
+    #[case::v3("cvss_v3", "3.1")]
+    #[case::v4("cvss_v4", "4.0")]
+    fn typed_accessor_reports_a_nonconforming_map(#[case] key: &str, #[case] version: &str) {
+        let metric = json!({ "version": version });
+        assert_typed_err(&content_with(key, &metric), key);
+        if key != "cvss_v4" {
+            assert_typed_err(&score_with(key, &metric), key);
+        }
     }
 }

--- a/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
@@ -1,6 +1,9 @@
 use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
 use crate::schema::csaf2_0::schema::Score;
 use crate::schema::csaf2_1::schema::{Content, Epss, QualitativeSeverityRating};
+use cvss_rs::v2_0::CvssV2;
+use cvss_rs::v3::CvssV3;
+use cvss_rs::v4_0::CvssV4;
 use serde::de::Error as SerdeError;
 use serde_json::{Map, Value};
 use ssvc::selection_list::SelectionList;
@@ -61,6 +64,12 @@ pub trait ContentTrait {
         self.get_cvss_v2().is_some()
     }
 
+    /// Returns the contained CVSS 2.0 metric parsed into its typed representation, if any.
+    fn get_cvss_v2_typed(&self) -> Option<Result<CvssV2, serde_json::Error>> {
+        self.get_cvss_v2()
+            .map(|map| serde_json::from_value(Value::Object(map.clone())))
+    }
+
     /// Returns a JSON representation of the contained CVSS 3.0/3.1 metric, if any.
     fn get_cvss_v3(&self) -> Option<&Map<String, Value>>;
 
@@ -69,12 +78,24 @@ pub trait ContentTrait {
         self.get_cvss_v3().is_some()
     }
 
+    /// Returns the contained CVSS 3.0/3.1 metric parsed into its typed representation, if any.
+    fn get_cvss_v3_typed(&self) -> Option<Result<CvssV3, serde_json::Error>> {
+        self.get_cvss_v3()
+            .map(|map| serde_json::from_value(Value::Object(map.clone())))
+    }
+
     /// Returns a JSON representation of the contained CVSS 4.0 metric, if any.
     fn get_cvss_v4(&self) -> Option<&Map<String, Value>>;
 
     /// Returns whether this content contains a CVSS 4.0 metric.
     fn has_cvss_v4(&self) -> bool {
         self.get_cvss_v4().is_some()
+    }
+
+    /// Returns the contained CVSS 4.0 metric parsed into its typed representation, if any.
+    fn get_cvss_v4_typed(&self) -> Option<Result<CvssV4, serde_json::Error>> {
+        self.get_cvss_v4()
+            .map(|map| serde_json::from_value(Value::Object(map.clone())))
     }
 
     /// Returns whether this content contains any CVSS metric (v2, v3, or v4).
@@ -221,5 +242,56 @@ impl ContentTrait for Content {
 
     fn get_content_json_path(&self, vulnerability_idx: usize, metric_idx: usize) -> String {
         format!("/vulnerabilities/{vulnerability_idx}/metrics/{metric_idx}/content",)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn score_cvss_v3_typed_parses_the_map() {
+        let score: Score = serde_json::from_value(json!({
+            "products": ["CSAFPID-0001"],
+            "cvss_v3": {
+                "version": "3.1",
+                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                "baseScore": 9.8,
+                "baseSeverity": "CRITICAL"
+            }
+        }))
+        .expect("score deserializes");
+        let cvss = score.get_cvss_v3_typed().expect("present").expect("parses");
+        assert_eq!(cvss.vector_string, "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H");
+        assert!(score.get_cvss_v2_typed().is_none());
+    }
+
+    #[test]
+    fn score_cvss_v3_typed_reports_a_nonconforming_map() {
+        let score: Score = serde_json::from_value(json!({
+            "products": ["CSAFPID-0001"],
+            "cvss_v3": { "version": "3.1" }
+        }))
+        .expect("score deserializes");
+        assert!(score.get_cvss_v3_typed().expect("present").is_err());
+    }
+
+    #[test]
+    fn content_cvss_v4_typed_parses_the_map() {
+        let content: Content = serde_json::from_value(json!({
+            "cvss_v4": {
+                "version": "4.0",
+                "vectorString": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N",
+                "baseScore": 9.3,
+                "baseSeverity": "CRITICAL"
+            }
+        }))
+        .expect("content deserializes");
+        let cvss = content.get_cvss_v4_typed().expect("present").expect("parses");
+        assert_eq!(
+            cvss.vector_string,
+            "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+        );
     }
 }

--- a/csaf-rs/src/lib.rs
+++ b/csaf-rs/src/lib.rs
@@ -17,3 +17,9 @@ pub mod test_validation;
 pub mod validation;
 pub mod validation_result;
 pub mod validations;
+
+/// The CVSS metric types returned by `ContentTrait`'s typed accessors
+/// (`get_cvss_v2_typed`, `get_cvss_v3_typed`, `get_cvss_v4_typed`).
+pub use cvss_rs;
+/// The SSVC selection types returned by `ContentTrait::get_ssvc_v2`.
+pub use ssvc;


### PR DESCRIPTION
The CVSS payloads on `Score` (CSAF 2.0) and `Content` (CSAF 2.1) are raw `serde_json::Map`, so a consumer reading scores works stringly-typed (`.get("vectorString")`, `.get("baseScore")`) or rebuilds the typed objects by hand — while the crate already deserializes the same maps into the cvss-rs types internally (`deserialize_cvss`, tests 6.1.09/6.1.10).

`get_cvss_v2_typed`, `get_cvss_v3_typed`, and `get_cvss_v4_typed` on `ContentTrait` parse the raw maps into `cvss_rs::v2_0::CvssV2` / `v3::CvssV3` / `v4_0::CvssV4`, following the existing `get_ssvc_v2` pattern (which already returns the external `ssvc` type the same way).
`None` when the metric is absent, `Some(Err(_))` when the map does not deserialize.

Note: this makes cvss-rs part of the public API surface, as ssvc already is through `get_ssvc_v2`.
An in-crate wrapper under `csaf/types/` would avoid that, at the cost of mirroring the cvss-rs structs — happy to rework in that direction if preferred.