### PR TITLE
build: packageurl requirement 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "packageurl"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35da99768af1ae8830ccf30d295db0e09c24bcfda5a67515191dd4b773f6d82a"
+checksum = "d33fa1a190c3c9024f21b82e6b30f94137d9c1bf25071e2ab2ba13020135fbaf"
 dependencies = [
  "percent-encoding",
  "thiserror 2.0.18",

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 chrono = { version = "0.4", features = ["serde"] }
 regex = "1"
 rust-embed = { version = "8", features = ["include-exclude"] }
-packageurl = "0.6"
+packageurl = "0.7"
 uuid = { version = "1.17.0", features = ["v7", "serde"] }
 semver = { version = "1" }
 jsonschema = { version = "0.45.0", default-features = false }

--- a/csaf-rs/src/csaf/types/purl/purl_error.rs
+++ b/csaf-rs/src/csaf/types/purl/purl_error.rs
@@ -14,11 +14,16 @@ pub enum PurlParseErrorKind {
     InvalidKey(String),
     MissingName,
     TypeProhibitsNamespace(String),
+    TypeRequiresNamespace(String),
+    MissingRequiredQualifier(String, String),
+    InvalidName(String, String),
+    InvalidVersion(String, String),
     InvalidNamespaceComponent(String),
     MissingScheme,
     MissingType,
     InvalidSubpathSegment(String),
     DecodingError,
+    Other(String),
 }
 
 impl PurlParseError {
@@ -66,11 +71,18 @@ impl From<packageurl::Error> for PurlParseErrorKind {
             packageurl::Error::InvalidKey(key) => Self::InvalidKey(key),
             packageurl::Error::MissingName => Self::MissingName,
             packageurl::Error::TypeProhibitsNamespace(package_type) => Self::TypeProhibitsNamespace(package_type),
+            packageurl::Error::TypeRequiresNamespace(package_type) => Self::TypeRequiresNamespace(package_type),
+            packageurl::Error::MissingRequiredQualifier(package_type, qualifier) => {
+                Self::MissingRequiredQualifier(package_type, qualifier)
+            },
+            packageurl::Error::InvalidName(package_type, name) => Self::InvalidName(package_type, name),
+            packageurl::Error::InvalidVersion(package_type, version) => Self::InvalidVersion(package_type, version),
             packageurl::Error::InvalidNamespaceComponent(component) => Self::InvalidNamespaceComponent(component),
             packageurl::Error::MissingScheme => Self::MissingScheme,
             packageurl::Error::MissingType => Self::MissingType,
             packageurl::Error::InvalidSubpathSegment(segment) => Self::InvalidSubpathSegment(segment),
             packageurl::Error::DecodingError(_) => Self::DecodingError,
+            error => Self::Other(error.to_string()),
         }
     }
 }
@@ -85,6 +97,18 @@ impl Display for PurlParseErrorKind {
             Self::TypeProhibitsNamespace(package_type) => {
                 write!(f, "no namespace allowed for type {package_type:?}")
             },
+            Self::TypeRequiresNamespace(package_type) => {
+                write!(f, "namespace required for type {package_type:?}")
+            },
+            Self::MissingRequiredQualifier(package_type, qualifier) => {
+                write!(f, "missing required qualifier {qualifier:?} for type {package_type:?}")
+            },
+            Self::InvalidName(package_type, name) => {
+                write!(f, "invalid name for type {package_type:?}: {name:?}")
+            },
+            Self::InvalidVersion(package_type, version) => {
+                write!(f, "invalid version for type {package_type:?}: {version:?}")
+            },
             Self::InvalidNamespaceComponent(component) => {
                 write!(f, "invalid namespace component: {component:?}")
             },
@@ -94,6 +118,7 @@ impl Display for PurlParseErrorKind {
                 write!(f, "invalid subpath segment: {segment:?}")
             },
             Self::DecodingError => write!(f, "utf-8 decoding failed"),
+            Self::Other(message) => write!(f, "{message}"),
         }
     }
 }


### PR DESCRIPTION
Upgrades packageurl to the just-released 0.7.0, the spec-compliance release (scm-rs/packageurl.rs#33).

The 0.7 `Error` enum is `non_exhaustive` and carries four new variants, so the `PurlParseErrorKind` mapping gains `TypeRequiresNamespace`, `MissingRequiredQualifier`, `InvalidName`, and `InvalidVersion`, plus an `Other(String)` catch-all arm for future variants.
No other code changes were needed; the full test suite passes unchanged.

Measured against the official purl-spec suite (on the csaf-rs/csaf#712 branch, updated to 0.7 for comparison):

- CSAF 2.0 pipeline: 16 known gaps → 3
- CSAF 2.1 pipeline: 24 known gaps → 11

Every remaining divergence is CSAF's own canonical-form profile rather than a parser gap: the `pkg:/` / `pkg://` / `pkg:///` forms the standard declares invalid, and (2.1) non-canonical case in types and qualifier keys (`pkg:GOLANG`, `pkg:Maven`, `repositorY_url`, …), which only the canonical form admits.
