### PR TITLE
fix: 6.3.4 reports correct error path on CSAF 2.1

### DIFF
--- a/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
@@ -124,6 +124,9 @@ pub trait VulnerabilityTrait {
     /// Returns the CWEs associated with the vulnerability.
     fn get_cwes(&self) -> Option<Vec<Cwe>>;
 
+    /// Returns the JSON property name used for CWE data in this CSAF version
+    fn get_cwe_property_name(&self) -> &'static str;
+
     /// Returns the vulnerability IDs associated with this vulnerability.
     fn get_ids(&self) -> Option<&Vec<Self::VulnerabilityIdType>>;
 
@@ -206,6 +209,10 @@ impl VulnerabilityTrait for Vulnerability20 {
         self.cwe.as_ref().map(|cwe| vec![Cwe::from(cwe)])
     }
 
+    fn get_cwe_property_name(&self) -> &'static str {
+        "cwe"
+    }
+
     fn get_ids(&self) -> Option<&Vec<Self::VulnerabilityIdType>> {
         self.ids.as_ref()
     }
@@ -270,6 +277,10 @@ impl VulnerabilityTrait for Vulnerability21 {
 
     fn get_cwes(&self) -> Option<Vec<Cwe>> {
         self.cwes.as_ref().map(|cwes| cwes.iter().map(Cwe::from).collect())
+    }
+
+    fn get_cwe_property_name(&self) -> &'static str {
+        "cwes"
     }
 
     fn get_ids(&self) -> Option<&Vec<Self::VulnerabilityIdType>> {

--- a/csaf-rs/src/validations/test_6_3_04.rs
+++ b/csaf-rs/src/validations/test_6_3_04.rs
@@ -1,22 +1,25 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
 use crate::validation::ValidationError;
 
-fn create_missing_cwe_error(vulnerability_index: usize) -> ValidationError {
+fn create_missing_cwe_error(vulnerability_index: usize, field_name: &str) -> ValidationError {
     ValidationError {
-        message: "Vulnerability is missing 'cwe' property".to_string(),
+        message: format!("Vulnerability is missing '{field_name}' property"),
         instance_path: format!("/vulnerabilities/{vulnerability_index}"),
     }
 }
 
 /// 6.3.4 Missing CWE
 ///
-/// Tests if all vulnerabilities have their `/vulnerabilities[]/cwe` field filled.
+/// Tests if all vulnerabilities have a `/vulnerabilities[]/cwe` (CSAF 2.0) /
+/// `/vulnerabilities[]/cwes` (CSAF 2.1) field present.
 pub fn test_6_3_4_missing_cwe(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     let mut errors: Option<Vec<ValidationError>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if vuln.get_cwes().is_none() {
-            errors.get_or_insert_default().push(create_missing_cwe_error(v_i));
+            errors
+                .get_or_insert_default()
+                .push(create_missing_cwe_error(v_i, vuln.get_cwe_property_name()));
         }
     }
 
@@ -33,13 +36,15 @@ mod tests {
 
     #[test]
     fn test_test_6_3_4() {
-        let case_01 = Err(vec![create_missing_cwe_error(0)]);
-        let case_02 = Err(vec![create_missing_cwe_error(0), create_missing_cwe_error(2)]);
+        let case_01_20 = Err(vec![create_missing_cwe_error(0, "cwe")]);
+        let case_02_20 = Err(vec![create_missing_cwe_error(0, "cwe"), create_missing_cwe_error(2, "cwe")]);
+        let case_01_21 = Err(vec![create_missing_cwe_error(0, "cwes")]);
+        let case_02_21 = Err(vec![create_missing_cwe_error(0, "cwes"), create_missing_cwe_error(2, "cwes")]);
 
         // Both CSAF 2.0 and 2.1 have 4 test cases
         TESTS_2_0
             .test_6_3_4
-            .expect(case_01.clone(), case_02.clone(), Ok(()), Ok(()));
-        TESTS_2_1.test_6_3_4.expect(case_01, case_02, Ok(()), Ok(()));
+            .expect(case_01_20, case_02_20, Ok(()), Ok(()));
+        TESTS_2_1.test_6_3_4.expect(case_01_21, case_02_21, Ok(()), Ok(()));
     }
 }

--- a/csaf-rs/src/validations/test_6_3_04.rs
+++ b/csaf-rs/src/validations/test_6_3_04.rs
@@ -37,14 +37,18 @@ mod tests {
     #[test]
     fn test_test_6_3_4() {
         let case_01_20 = Err(vec![create_missing_cwe_error(0, "cwe")]);
-        let case_02_20 = Err(vec![create_missing_cwe_error(0, "cwe"), create_missing_cwe_error(2, "cwe")]);
+        let case_02_20 = Err(vec![
+            create_missing_cwe_error(0, "cwe"),
+            create_missing_cwe_error(2, "cwe"),
+        ]);
         let case_01_21 = Err(vec![create_missing_cwe_error(0, "cwes")]);
-        let case_02_21 = Err(vec![create_missing_cwe_error(0, "cwes"), create_missing_cwe_error(2, "cwes")]);
+        let case_02_21 = Err(vec![
+            create_missing_cwe_error(0, "cwes"),
+            create_missing_cwe_error(2, "cwes"),
+        ]);
 
         // Both CSAF 2.0 and 2.1 have 4 test cases
-        TESTS_2_0
-            .test_6_3_4
-            .expect(case_01_20, case_02_20, Ok(()), Ok(()));
+        TESTS_2_0.test_6_3_4.expect(case_01_20, case_02_20, Ok(()), Ok(()));
         TESTS_2_1.test_6_3_4.expect(case_01_21, case_02_21, Ok(()), Ok(()));
     }
 }


### PR DESCRIPTION
This PR: 
* resolves #705 
* adds get_cwe_property_name, which returns `cwe` for CSAF 2.0 and `cwes` for CSAF 2.1
* uses new method in test 6.3.4
* update comments
* update tests