### PR TITLE
perf: deserialize typed documents and metrics from borrowed JSON

### DIFF
--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 
+use csaf::csaf::raw::HasParsed;
 use csaf::csaf2_0::loader::load_document as load_document_2_0;
 use csaf::csaf2_0::testcases::{
     informative_tests as informative_tests_2_0, mandatory_tests as mandatory_tests_2_0,
@@ -221,6 +222,33 @@ fn bench_parse_only(c: &mut Criterion) {
     group.finish();
 }
 
+/// Benchmark parsing plus the typed deserialization (no validation).
+///
+/// `parse_only` stops at the JSON `Value`; the delta between the two groups isolates the
+/// cost of materializing the typed document that every validation run pays once per document.
+fn bench_typed_parse(c: &mut Criterion) {
+    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
+    let contents = load_fixture_contents(&collect_fixture_files(fixtures_dir));
+
+    if contents.is_empty() {
+        return;
+    }
+
+    let mut group = c.benchmark_group("typed_parse");
+
+    group.bench_function("csaf_2_0", |b| {
+        b.iter(|| {
+            for (_name, content) in &contents {
+                if let Ok(doc) = load_document_2_0(content) {
+                    let _ = black_box(doc.get_parsed());
+                }
+            }
+        });
+    });
+
+    group.finish();
+}
+
 fn configured_criterion() -> Criterion {
     Criterion::default()
         .warm_up_time(Duration::from_secs(1))
@@ -231,6 +259,6 @@ fn configured_criterion() -> Criterion {
 criterion_group! {
    name = benches;
    config = configured_criterion();
-   targets = bench_individual_tests_csaf_2_0, bench_individual_tests_csaf_2_1, bench_full_validation, bench_parse_only
+   targets = bench_individual_tests_csaf_2_0, bench_individual_tests_csaf_2_1, bench_full_validation, bench_parse_only, bench_typed_parse
 }
 criterion_main!(benches);

--- a/csaf-rs/benches/validation_benchmark.rs
+++ b/csaf-rs/benches/validation_benchmark.rs
@@ -202,22 +202,33 @@ fn bench_full_validation(c: &mut Criterion) {
 
 /// Benchmark parsing only (no validation).
 fn bench_parse_only(c: &mut Criterion) {
-    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
-    let contents = load_fixture_contents(&collect_fixture_files(fixtures_dir));
+    let fixtures_dir_2_0 = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
+    let fixtures_dir_2_1 = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.1/test/validator/data");
 
-    if contents.is_empty() {
-        return;
-    }
+    let contents_2_0 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_0));
+    let contents_2_1 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_1));
 
     let mut group = c.benchmark_group("parse_only");
 
-    group.bench_function("csaf_2_0", |b| {
-        b.iter(|| {
-            for (_name, content) in &contents {
-                let _ = black_box(load_document_2_0(content));
-            }
+    if !contents_2_0.is_empty() {
+        group.bench_function("csaf_2_0", |b| {
+            b.iter(|| {
+                for (_name, content) in &contents_2_0 {
+                    let _ = black_box(load_document_2_0(content));
+                }
+            });
         });
-    });
+    }
+
+    if !contents_2_1.is_empty() {
+        group.bench_function("csaf_2_1", |b| {
+            b.iter(|| {
+                for (_name, content) in &contents_2_1 {
+                    let _ = black_box(load_document_2_1(content));
+                }
+            });
+        });
+    }
 
     group.finish();
 }
@@ -227,24 +238,37 @@ fn bench_parse_only(c: &mut Criterion) {
 /// `parse_only` stops at the JSON `Value`; the delta between the two groups isolates the
 /// cost of materializing the typed document that every validation run pays once per document.
 fn bench_typed_parse(c: &mut Criterion) {
-    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
-    let contents = load_fixture_contents(&collect_fixture_files(fixtures_dir));
+    let fixtures_dir_2_0 = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.0/test/validator/data");
+    let fixtures_dir_2_1 = concat!(env!("CARGO_MANIFEST_DIR"), "/../csaf/csaf_2.1/test/validator/data");
 
-    if contents.is_empty() {
-        return;
-    }
+    let contents_2_0 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_0));
+    let contents_2_1 = load_fixture_contents(&collect_fixture_files(fixtures_dir_2_1));
 
     let mut group = c.benchmark_group("typed_parse");
 
-    group.bench_function("csaf_2_0", |b| {
-        b.iter(|| {
-            for (_name, content) in &contents {
-                if let Ok(doc) = load_document_2_0(content) {
-                    let _ = black_box(doc.get_parsed());
+    if !contents_2_0.is_empty() {
+        group.bench_function("csaf_2_0", |b| {
+            b.iter(|| {
+                for (_name, content) in &contents_2_0 {
+                    if let Ok(doc) = load_document_2_0(content) {
+                        let _ = black_box(doc.get_parsed());
+                    }
                 }
-            }
+            });
         });
-    });
+    }
+
+    if !contents_2_1.is_empty() {
+        group.bench_function("csaf_2_1", |b| {
+            b.iter(|| {
+                for (_name, content) in &contents_2_1 {
+                    if let Ok(doc) = load_document_2_1(content) {
+                        let _ = black_box(doc.get_parsed());
+                    }
+                }
+            });
+        });
+    }
 
     group.finish();
 }

--- a/csaf-rs/src/csaf/raw.rs
+++ b/csaf-rs/src/csaf/raw.rs
@@ -36,7 +36,7 @@ where
 
     fn get_parsed(&self) -> &Result<Self::Parsed, String> {
         self.parsed
-            .get_or_init(|| serde_json::from_value::<T>(self.raw.clone()).map_err(|e| e.to_string()))
+            .get_or_init(|| T::deserialize(&self.raw).map_err(|e| e.to_string()))
     }
 }
 

--- a/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities/content_trait.rs
@@ -195,7 +195,7 @@ impl ContentTrait for Content {
     }
 
     fn get_ssvc_v2(&self) -> Result<SelectionList, serde_json::Error> {
-        serde_json::from_value::<SelectionList>(Value::Object(self.ssvc_v2.clone()))
+        SelectionList::deserialize(&self.ssvc_v2)
     }
 
     fn get_ssvc_v2_raw(&self) -> Option<&Map<String, Value>> {

--- a/csaf-rs/src/cvss/mod.rs
+++ b/csaf-rs/src/cvss/mod.rs
@@ -9,6 +9,7 @@ use crate::validation::ValidationError;
 use cvss_rs::Cvss;
 use cvss_rs::Severity;
 use cvss_rs::Version;
+use serde::Deserialize;
 use serde_json::Value;
 
 /// Validates CVSS scores for all CVSS versions present.
@@ -165,7 +166,7 @@ pub fn deserialize_cvss(
     instance_path: &str,
     errors: &mut Option<Vec<ValidationError>>,
 ) -> Option<Cvss> {
-    match serde_json::from_value(Value::Object(cvss_map.to_owned())) {
+    match Cvss::deserialize(cvss_map) {
         Ok(cvss) => Some(cvss),
         Err(e) => {
             errors


### PR DESCRIPTION
Addresses #742. Found three clone-then-deserialize sites, all in csaf-rs, all covered by the `Deserializer` impls for `&Value`/`&Map` that #715 already set the serde_json floor for.

- `RawDocument::get_parsed` cloned the entire document `Value` before `from_value`, once per document on every validation, FFI, and converter path — now `T::deserialize(&self.raw)`.
- `deserialize_cvss` cloned each CVSS metric map into a `Value::Object` per call — now `Cvss::deserialize(cvss_map)`; the map is reused after the call, so the borrow is exactly right.
- `Content::get_ssvc_v2` cloned the ssvc map per call — now `SelectionList::deserialize(&self.ssvc_v2)`, body only; the `Option<Result<…>>` signature refactor stays with upstream #736.

The first commit adds a `typed_parse` bench: every existing bench pre-parses documents outside `b.iter`, so the whole-document clone was invisible to the suite and its regression alert.
