### PR TITLE
feat: extend cwe xslt with `Mapping_Notes/Usage` field

### DIFF
--- a/csaf-rs/assets/cwe/cwe_1.0.1_2008-10-14.csv
+++ b/csaf-rs/assets/cwe/cwe_1.0.1_2008-10-14.csv
@@ -1,616 +1,616 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Error Handling
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Insufficient Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Failure to Resolve Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Failure to Handle File Names that Identify Virtual Resources
-67	Incomplete	Failure to Handle Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Apple HFS+ Alternate Data Stream
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')
-78	Incomplete	Failure to Sanitize Data into an OS Command (aka 'OS Command Injection')
-79	Draft	Failure to Sanitize Directives in a Web Page (aka 'Cross-site scripting' (XSS))
-80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page
-82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Incomplete	Failure to Sanitize Data within SQL Queries (aka 'SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Incomplete	Insufficient Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')
-94	Draft	Code Injection
-95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')
-96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Insufficient Output Sanitization
-117	Draft	Incorrect Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of an Allocated Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Failure to Handle Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Failure to Sanitize Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Failure to Sanitize Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Failure to Sanitize Comment Element
-152	Draft	Failure to Sanitize Macro Symbol
-153	Draft	Failure to Sanitize Substitution Character
-154	Incomplete	Failure to Sanitize Variable Name Delimiter
-155	Draft	Failure to Sanitize Wildcard or Matching Symbol
-156	Draft	Failure to Sanitize Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Failure to Sanitize Leading Special Element
-161	Incomplete	Failure to Sanitize Multiple Leading Special Elements
-162	Incomplete	Failure to Sanitize Trailing Special Element
-163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements
-164	Incomplete	Failure to Sanitize Internal Special Element
-165	Incomplete	Failure to Sanitize Multiple Internal Special Elements
-166	Draft	Failure to Handle Missing Special Element
-167	Draft	Failure to Handle Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow (Wrap or Wraparound)
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Incorrect Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leaks
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Incomplete	Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')
-228	Incomplete	Failure to Handle Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Failure to Handle Missing Value
-231	Draft	Failure to Handle Extra Value
-232	Draft	Failure to Handle Undefined Value
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Failure to Handle Extra Parameter
-236	Draft	Failure to Handle Undefined Parameter
-237	Incomplete	Element Problems
-238	Draft	Failure to Handle Missing Element
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Failure to Resolve Inconsistent Elements
-241	Draft	Failure to Handle Wrong Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Incomplete	Often Misused: Path Manipulation
-250	Draft	Design Principle Violation: Failure to Use Least Privilege
-252	Draft	Unchecked Return Value
-253	Incomplete	Misinterpreted Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Incomplete	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Insecure Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully
-274	Draft	Failure to Handle Insufficient Privileges
-276	Draft	Insecure Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Insecure Execution-assigned Permissions
-280	Draft	Failure to Handle Insufficient Permissions or Privileges
-281	Draft	Permission Preservation Failure
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Missing or Inconsistent Access Control
-286	Incomplete	Incorrect User Management
-287	Draft	Insufficient Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Failure to Follow Chain of Trust in Certificate Validation
-297	Incomplete	Failure to Validate Host-specific Certificate Data
-298	Draft	Failure to Validate Certificate Expiration
-299	Draft	Failure to Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Improper Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Plaintext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Plaintext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Weak Encryption
-327	Incomplete	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Failure to Handle Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improperly Verified Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Failure to Check Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Race Condition in Checking for Certificate Revocation
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Lock on Critical Resource
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Incomplete	Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Failure to Use Default Case in Switch
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Untrusted Mobile Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Missing Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Use of Cookies in Security Decision
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Invalid Pointer Not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Incorrect Syntactic Object Comparison
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions (Missing Catch Block)
-601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')
-602	Draft	Design Principle Violation: Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Design Principle Violation: Not Failing Securely (aka 'Failing Open')
-637	Draft	Design Principle Violation: Not Using Economy of Mechanism
-638	Draft	Design Principle Violation: Not Using Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Incomplete	External Control of User State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')
-644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Improper Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')
-653	Draft	Design Principle Violation: Insufficient Compartmentalization
-654	Draft	Design Principle Violation: Reliance on a Single Factor in a Security Decision
-655	Draft	Design Principle Violation: Failure to Satisfy Psychological Acceptability
-656	Draft	Design Principle Violation: Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Insufficient Control of a Resource Through its Lifetime
-665	Draft	Incorrect or Incomplete Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Design Principle Violation: Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Incomplete	Insecure Permission Assignment for Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Error Handling	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Insufficient Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Failure to Resolve Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Failure to Handle File Names that Identify Virtual Resources	0	
+67	Incomplete	Failure to Handle Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Apple HFS+ Alternate Data Stream	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')	0	
+78	Incomplete	Failure to Sanitize Data into an OS Command (aka 'OS Command Injection')	0	
+79	Draft	Failure to Sanitize Directives in a Web Page (aka 'Cross-site scripting' (XSS))	0	
+80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page	0	
+82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Incomplete	Failure to Sanitize Data within SQL Queries (aka 'SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Incomplete	Insufficient Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')	0	
+94	Draft	Code Injection	0	
+95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')	0	
+96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Insufficient Output Sanitization	0	
+117	Draft	Incorrect Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of an Allocated Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Failure to Handle Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Failure to Sanitize Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Failure to Sanitize Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Failure to Sanitize Comment Element	0	
+152	Draft	Failure to Sanitize Macro Symbol	0	
+153	Draft	Failure to Sanitize Substitution Character	0	
+154	Incomplete	Failure to Sanitize Variable Name Delimiter	0	
+155	Draft	Failure to Sanitize Wildcard or Matching Symbol	0	
+156	Draft	Failure to Sanitize Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Failure to Sanitize Leading Special Element	0	
+161	Incomplete	Failure to Sanitize Multiple Leading Special Elements	0	
+162	Incomplete	Failure to Sanitize Trailing Special Element	0	
+163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements	0	
+164	Incomplete	Failure to Sanitize Internal Special Element	0	
+165	Incomplete	Failure to Sanitize Multiple Internal Special Elements	0	
+166	Draft	Failure to Handle Missing Special Element	0	
+167	Draft	Failure to Handle Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow (Wrap or Wraparound)	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Incorrect Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leaks	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Incomplete	Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')	0	
+228	Incomplete	Failure to Handle Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Failure to Handle Missing Value	0	
+231	Draft	Failure to Handle Extra Value	0	
+232	Draft	Failure to Handle Undefined Value	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Failure to Handle Extra Parameter	0	
+236	Draft	Failure to Handle Undefined Parameter	0	
+237	Incomplete	Element Problems	0	
+238	Draft	Failure to Handle Missing Element	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Failure to Resolve Inconsistent Elements	0	
+241	Draft	Failure to Handle Wrong Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Incomplete	Often Misused: Path Manipulation	0	
+250	Draft	Design Principle Violation: Failure to Use Least Privilege	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Misinterpreted Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Incomplete	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Insecure Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully	0	
+274	Draft	Failure to Handle Insufficient Privileges	0	
+276	Draft	Insecure Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Insecure Execution-assigned Permissions	0	
+280	Draft	Failure to Handle Insufficient Permissions or Privileges	0	
+281	Draft	Permission Preservation Failure	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Missing or Inconsistent Access Control	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Insufficient Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Failure to Follow Chain of Trust in Certificate Validation	0	
+297	Incomplete	Failure to Validate Host-specific Certificate Data	0	
+298	Draft	Failure to Validate Certificate Expiration	0	
+299	Draft	Failure to Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Improper Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Plaintext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Plaintext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Weak Encryption	0	
+327	Incomplete	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Failure to Handle Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improperly Verified Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Failure to Check Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Race Condition in Checking for Certificate Revocation	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Lock on Critical Resource	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Incomplete	Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Failure to Use Default Case in Switch	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Untrusted Mobile Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Missing Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Use of Cookies in Security Decision	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Invalid Pointer Not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Incorrect Syntactic Object Comparison	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions (Missing Catch Block)	0	
+601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')	0	
+602	Draft	Design Principle Violation: Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Design Principle Violation: Not Failing Securely (aka 'Failing Open')	0	
+637	Draft	Design Principle Violation: Not Using Economy of Mechanism	0	
+638	Draft	Design Principle Violation: Not Using Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Incomplete	External Control of User State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')	0	
+644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Improper Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')	0	
+653	Draft	Design Principle Violation: Insufficient Compartmentalization	0	
+654	Draft	Design Principle Violation: Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Design Principle Violation: Failure to Satisfy Psychological Acceptability	0	
+656	Draft	Design Principle Violation: Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Insufficient Control of a Resource Through its Lifetime	0	
+665	Draft	Incorrect or Incomplete Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Design Principle Violation: Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Incomplete	Insecure Permission Assignment for Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	

--- a/csaf-rs/assets/cwe/cwe_1.0_.csv
+++ b/csaf-rs/assets/cwe/cwe_1.0_.csv
@@ -1,615 +1,615 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Error Handling
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Insufficient Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filename'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Failure to Resolve Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'dirname/fakechild/../realchild/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Failure to Handle File Names that Identify Virtual Resources
-67	Incomplete	Failure to Handle Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Apple HFS+ Alternate Data Stream
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')
-78	Incomplete	Failure to Sanitize Data into an OS Command (aka 'OS Command Injection')
-79	Draft	Failure to Sanitize Directives in a Web Page (aka 'Cross-site scripting' (XSS))
-80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page
-82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Incomplete	Failure to Sanitize Data within SQL Queries (aka 'SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Incomplete	Custom Special Character Injection
-93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')
-94	Draft	Code Injection
-95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')
-96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Insufficient Output Sanitization
-117	Draft	Incorrect Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of an Allocated Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Failure to Handle Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Failure to Sanitize Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Failure to Sanitize Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Failure to Sanitize Comment Element
-152	Draft	Failure to Sanitize Macro Symbol
-153	Draft	Failure to Sanitize Substitution Character
-154	Incomplete	Failure to Sanitize Variable Name Delimiter
-155	Draft	Failure to Sanitize Wildcard or Matching Symbol
-156	Draft	Failure to Sanitize Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Failure to Sanitize Leading Special Element
-161	Incomplete	Failure to Sanitize Multiple Leading Special Elements
-162	Incomplete	Failure to Sanitize Trailing Special Element
-163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements
-164	Incomplete	Failure to Sanitize Internal Special Element
-165	Incomplete	Failure to Sanitize Multiple Internal Special Elements
-166	Draft	Failure to Handle Missing Special Element
-167	Draft	Failure to Handle Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow (Wrap or Wraparound)
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Incorrect Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leaks
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Incomplete	Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')
-228	Incomplete	Failure to Handle Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Failure to Handle Missing Value
-231	Draft	Failure to Handle Extra Value
-232	Draft	Failure to Handle Undefined Value
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Failure to Handle Extra Parameter
-236	Draft	Failure to Handle Undefined Parameter
-237	Incomplete	Element Problems
-238	Draft	Failure to Handle Missing Element
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Failure to Resolve Inconsistent Elements
-241	Draft	Failure to Handle Wrong Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Incomplete	Often Misused: Path Manipulation
-250	Draft	Design Principle Violation: Failure to Use Least Privilege
-252	Draft	Unchecked Return Value
-253	Incomplete	Misinterpreted Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Incomplete	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Insecure Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully
-274	Draft	Failure to Handle Insufficient Privileges
-276	Draft	Insecure Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Insecure Execution-assigned Permissions
-280	Draft	Failure to Handle Insufficient Permissions or Privileges
-281	Draft	Permission Preservation Failure
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Missing or Inconsistent Access Control
-286	Incomplete	Incorrect User Management
-287	Draft	Insufficient Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Failure to Follow Chain of Trust in Certificate Validation
-297	Incomplete	Failure to Validate Host-specific Certificate Data
-298	Draft	Failure to Validate Certificate Expiration
-299	Draft	Failure to Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Improper Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Plaintext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Plaintext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Weak Encryption
-327	Incomplete	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Failure to Handle Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improperly Verified Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Failure to Check Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Race Condition in Checking for Certificate Revocation
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Resource Exhaustion
-401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Network Amplification
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Lock on Critical Resource
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Incomplete	Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Failure to Use Default Case in Switch
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Untrusted Mobile Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Missing Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Use of Cookies in Security Decision
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Invalid Pointer Not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Incorrect Syntactic Object Comparison
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions (Missing Catch Block)
-601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')
-602	Draft	Design Principle Violation: Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Design Principle Violation: Not Failing Securely (aka 'Failing Open')
-637	Draft	Design Principle Violation: Not Using Economy of Mechanism
-638	Draft	Design Principle Violation: Not Using Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Incomplete	External Control of User State Data
-643	Incomplete	Unsafe Treatment of XPath Input
-644	Incomplete	Insufficient Filtering of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Taking Actions based on File Name or Extension of a User Supplied File
-647	Incomplete	Using Non-Canonical Paths for Authorization Decisions
-648	Incomplete	Improper Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Unsafe Treatment of XQuery Input
-653	Draft	Design Principle Violation: Insufficient Compartmentalization
-654	Draft	Design Principle Violation: Reliance on a Single Factor in a Security Decision
-655	Draft	Design Principle Violation: Failure to Satisfy Psychological Acceptability
-656	Draft	Design Principle Violation: Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Insufficient Control of a Resource Through its Lifetime
-665	Draft	Incorrect or Incomplete Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Design Principle Violation: Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Incomplete	Insecure Permission Assignment for Resource
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Error Handling	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Insufficient Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filename'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Failure to Resolve Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'dirname/fakechild/../realchild/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Failure to Handle File Names that Identify Virtual Resources	0	
+67	Incomplete	Failure to Handle Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Apple HFS+ Alternate Data Stream	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')	0	
+78	Incomplete	Failure to Sanitize Data into an OS Command (aka 'OS Command Injection')	0	
+79	Draft	Failure to Sanitize Directives in a Web Page (aka 'Cross-site scripting' (XSS))	0	
+80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page	0	
+82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Incomplete	Failure to Sanitize Data within SQL Queries (aka 'SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Incomplete	Custom Special Character Injection	0	
+93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')	0	
+94	Draft	Code Injection	0	
+95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')	0	
+96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Insufficient Output Sanitization	0	
+117	Draft	Incorrect Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of an Allocated Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Failure to Handle Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Failure to Sanitize Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Failure to Sanitize Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Failure to Sanitize Comment Element	0	
+152	Draft	Failure to Sanitize Macro Symbol	0	
+153	Draft	Failure to Sanitize Substitution Character	0	
+154	Incomplete	Failure to Sanitize Variable Name Delimiter	0	
+155	Draft	Failure to Sanitize Wildcard or Matching Symbol	0	
+156	Draft	Failure to Sanitize Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Failure to Sanitize Leading Special Element	0	
+161	Incomplete	Failure to Sanitize Multiple Leading Special Elements	0	
+162	Incomplete	Failure to Sanitize Trailing Special Element	0	
+163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements	0	
+164	Incomplete	Failure to Sanitize Internal Special Element	0	
+165	Incomplete	Failure to Sanitize Multiple Internal Special Elements	0	
+166	Draft	Failure to Handle Missing Special Element	0	
+167	Draft	Failure to Handle Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow (Wrap or Wraparound)	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Incorrect Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leaks	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Incomplete	Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')	0	
+228	Incomplete	Failure to Handle Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Failure to Handle Missing Value	0	
+231	Draft	Failure to Handle Extra Value	0	
+232	Draft	Failure to Handle Undefined Value	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Failure to Handle Extra Parameter	0	
+236	Draft	Failure to Handle Undefined Parameter	0	
+237	Incomplete	Element Problems	0	
+238	Draft	Failure to Handle Missing Element	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Failure to Resolve Inconsistent Elements	0	
+241	Draft	Failure to Handle Wrong Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Incomplete	Often Misused: Path Manipulation	0	
+250	Draft	Design Principle Violation: Failure to Use Least Privilege	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Misinterpreted Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Incomplete	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Insecure Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully	0	
+274	Draft	Failure to Handle Insufficient Privileges	0	
+276	Draft	Insecure Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Insecure Execution-assigned Permissions	0	
+280	Draft	Failure to Handle Insufficient Permissions or Privileges	0	
+281	Draft	Permission Preservation Failure	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Missing or Inconsistent Access Control	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Insufficient Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Failure to Follow Chain of Trust in Certificate Validation	0	
+297	Incomplete	Failure to Validate Host-specific Certificate Data	0	
+298	Draft	Failure to Validate Certificate Expiration	0	
+299	Draft	Failure to Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Improper Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Plaintext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Plaintext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Weak Encryption	0	
+327	Incomplete	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Failure to Handle Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improperly Verified Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Failure to Check Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Race Condition in Checking for Certificate Revocation	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Resource Exhaustion	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Network Amplification	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Lock on Critical Resource	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Incomplete	Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Failure to Use Default Case in Switch	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Untrusted Mobile Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Missing Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Use of Cookies in Security Decision	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Invalid Pointer Not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Incorrect Syntactic Object Comparison	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions (Missing Catch Block)	0	
+601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')	0	
+602	Draft	Design Principle Violation: Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Design Principle Violation: Not Failing Securely (aka 'Failing Open')	0	
+637	Draft	Design Principle Violation: Not Using Economy of Mechanism	0	
+638	Draft	Design Principle Violation: Not Using Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Incomplete	External Control of User State Data	0	
+643	Incomplete	Unsafe Treatment of XPath Input	0	
+644	Incomplete	Insufficient Filtering of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Taking Actions based on File Name or Extension of a User Supplied File	0	
+647	Incomplete	Using Non-Canonical Paths for Authorization Decisions	0	
+648	Incomplete	Improper Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Unsafe Treatment of XQuery Input	0	
+653	Draft	Design Principle Violation: Insufficient Compartmentalization	0	
+654	Draft	Design Principle Violation: Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Design Principle Violation: Failure to Satisfy Psychological Acceptability	0	
+656	Draft	Design Principle Violation: Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Insufficient Control of a Resource Through its Lifetime	0	
+665	Draft	Incorrect or Incomplete Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Design Principle Violation: Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Incomplete	Insecure Permission Assignment for Resource	0	

--- a/csaf-rs/assets/cwe/cwe_1.10_2010-09-27.csv
+++ b/csaf-rs/assets/cwe/cwe_1.10_2010-09-27.csv
@@ -1,675 +1,675 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Multithreaded Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Multithreaded Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	

--- a/csaf-rs/assets/cwe/cwe_1.11_2010-12-13.csv
+++ b/csaf-rs/assets/cwe/cwe_1.11_2010-12-13.csv
@@ -1,682 +1,682 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	

--- a/csaf-rs/assets/cwe/cwe_1.12_2011-03-30.csv
+++ b/csaf-rs/assets/cwe/cwe_1.12_2011-03-30.csv
@@ -1,690 +1,690 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Generated Error Message
-211	Incomplete	Information Exposure Through External Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Exposure Through XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Generated Error Message	0	
+211	Incomplete	Information Exposure Through External Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Exposure Through XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	

--- a/csaf-rs/assets/cwe/cwe_1.13_2011-06-01.csv
+++ b/csaf-rs/assets/cwe/cwe_1.13_2011-06-01.csv
@@ -1,693 +1,693 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Generated Error Message
-211	Incomplete	Information Exposure Through External Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Exposure Through XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Generated Error Message	0	
+211	Incomplete	Information Exposure Through External Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Exposure Through XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	

--- a/csaf-rs/assets/cwe/cwe_1.1_2008-11-24.csv
+++ b/csaf-rs/assets/cwe/cwe_1.1_2008-11-24.csv
@@ -1,617 +1,617 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Error Handling
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Insufficient Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Failure to Resolve Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Failure to Handle File Names that Identify Virtual Resources
-67	Incomplete	Failure to Handle Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Failure to Handle Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')
-78	Incomplete	Failure to Sanitize Data into an OS Command (aka 'OS Command Injection')
-79	Draft	Failure to Sanitize Directives in a Web Page (aka 'Cross-site scripting' (XSS))
-80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page
-82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Incomplete	Failure to Sanitize Data within SQL Queries (aka 'SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Incomplete	Insufficient Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')
-94	Draft	Code Injection
-95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')
-96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Insufficient Output Sanitization
-117	Draft	Incorrect Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of an Allocated Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Failure to Handle Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Failure to Sanitize Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Failure to Sanitize Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Failure to Sanitize Comment Element
-152	Draft	Failure to Sanitize Macro Symbol
-153	Draft	Failure to Sanitize Substitution Character
-154	Incomplete	Failure to Sanitize Variable Name Delimiter
-155	Draft	Failure to Sanitize Wildcard or Matching Symbol
-156	Draft	Failure to Sanitize Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Failure to Sanitize Leading Special Element
-161	Incomplete	Failure to Sanitize Multiple Leading Special Elements
-162	Incomplete	Failure to Sanitize Trailing Special Element
-163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements
-164	Incomplete	Failure to Sanitize Internal Special Element
-165	Incomplete	Failure to Sanitize Multiple Internal Special Elements
-166	Draft	Failure to Handle Missing Special Element
-167	Draft	Failure to Handle Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow (Wrap or Wraparound)
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leaks
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Incomplete	Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')
-228	Incomplete	Failure to Handle Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Failure to Handle Missing Value
-231	Draft	Failure to Handle Extra Value
-232	Draft	Failure to Handle Undefined Value
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Failure to Handle Extra Parameter
-236	Draft	Failure to Handle Undefined Parameter
-237	Incomplete	Element Problems
-238	Draft	Failure to Handle Missing Element
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Failure to Resolve Inconsistent Elements
-241	Draft	Failure to Handle Wrong Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Incomplete	Often Misused: Path Manipulation
-250	Draft	Design Principle Violation: Failure to Use Least Privilege
-252	Draft	Unchecked Return Value
-253	Incomplete	Misinterpreted Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Incomplete	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Insecure Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully
-274	Draft	Failure to Handle Insufficient Privileges
-276	Draft	Insecure Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Insecure Execution-assigned Permissions
-280	Draft	Failure to Handle Insufficient Permissions or Privileges
-281	Draft	Permission Preservation Failure
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Missing or Inconsistent Access Control
-286	Incomplete	Incorrect User Management
-287	Draft	Insufficient Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Failure to Follow Chain of Trust in Certificate Validation
-297	Incomplete	Failure to Validate Host-specific Certificate Data
-298	Draft	Failure to Validate Certificate Expiration
-299	Draft	Failure to Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Improper Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Plaintext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Plaintext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Weak Encryption
-327	Incomplete	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Failure to Handle Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improperly Verified Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Failure to Check Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Race Condition in Checking for Certificate Revocation
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Lock on Critical Resource
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Failure to Use Default Case in Switch
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Untrusted Mobile Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Missing Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Use of Cookies in Security Decision
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Invalid Pointer Not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Incorrect Syntactic Object Comparison
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions (Missing Catch Block)
-601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')
-602	Draft	Design Principle Violation: Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Design Principle Violation: Not Failing Securely (aka 'Failing Open')
-637	Draft	Design Principle Violation: Not Using Economy of Mechanism
-638	Draft	Design Principle Violation: Not Using Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Incomplete	External Control of User State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')
-644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Improper Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')
-653	Draft	Design Principle Violation: Insufficient Compartmentalization
-654	Draft	Design Principle Violation: Reliance on a Single Factor in a Security Decision
-655	Draft	Design Principle Violation: Failure to Satisfy Psychological Acceptability
-656	Draft	Design Principle Violation: Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Insufficient Control of a Resource Through its Lifetime
-665	Draft	Incorrect or Incomplete Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Design Principle Violation: Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Incomplete	Insecure Permission Assignment for Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Insecure Method or Function
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Error Handling	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Insufficient Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Failure to Resolve Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Failure to Handle File Names that Identify Virtual Resources	0	
+67	Incomplete	Failure to Handle Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Failure to Handle Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')	0	
+78	Incomplete	Failure to Sanitize Data into an OS Command (aka 'OS Command Injection')	0	
+79	Draft	Failure to Sanitize Directives in a Web Page (aka 'Cross-site scripting' (XSS))	0	
+80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page	0	
+82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Incomplete	Failure to Sanitize Data within SQL Queries (aka 'SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Incomplete	Insufficient Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')	0	
+94	Draft	Code Injection	0	
+95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')	0	
+96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Insufficient Output Sanitization	0	
+117	Draft	Incorrect Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of an Allocated Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Failure to Handle Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Failure to Sanitize Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Failure to Sanitize Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Failure to Sanitize Comment Element	0	
+152	Draft	Failure to Sanitize Macro Symbol	0	
+153	Draft	Failure to Sanitize Substitution Character	0	
+154	Incomplete	Failure to Sanitize Variable Name Delimiter	0	
+155	Draft	Failure to Sanitize Wildcard or Matching Symbol	0	
+156	Draft	Failure to Sanitize Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Failure to Sanitize Leading Special Element	0	
+161	Incomplete	Failure to Sanitize Multiple Leading Special Elements	0	
+162	Incomplete	Failure to Sanitize Trailing Special Element	0	
+163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements	0	
+164	Incomplete	Failure to Sanitize Internal Special Element	0	
+165	Incomplete	Failure to Sanitize Multiple Internal Special Elements	0	
+166	Draft	Failure to Handle Missing Special Element	0	
+167	Draft	Failure to Handle Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow (Wrap or Wraparound)	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leaks	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Incomplete	Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')	0	
+228	Incomplete	Failure to Handle Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Failure to Handle Missing Value	0	
+231	Draft	Failure to Handle Extra Value	0	
+232	Draft	Failure to Handle Undefined Value	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Failure to Handle Extra Parameter	0	
+236	Draft	Failure to Handle Undefined Parameter	0	
+237	Incomplete	Element Problems	0	
+238	Draft	Failure to Handle Missing Element	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Failure to Resolve Inconsistent Elements	0	
+241	Draft	Failure to Handle Wrong Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Incomplete	Often Misused: Path Manipulation	0	
+250	Draft	Design Principle Violation: Failure to Use Least Privilege	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Misinterpreted Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Incomplete	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Insecure Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully	0	
+274	Draft	Failure to Handle Insufficient Privileges	0	
+276	Draft	Insecure Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Insecure Execution-assigned Permissions	0	
+280	Draft	Failure to Handle Insufficient Permissions or Privileges	0	
+281	Draft	Permission Preservation Failure	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Missing or Inconsistent Access Control	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Insufficient Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Failure to Follow Chain of Trust in Certificate Validation	0	
+297	Incomplete	Failure to Validate Host-specific Certificate Data	0	
+298	Draft	Failure to Validate Certificate Expiration	0	
+299	Draft	Failure to Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Improper Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Plaintext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Plaintext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Weak Encryption	0	
+327	Incomplete	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Failure to Handle Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improperly Verified Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Failure to Check Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Race Condition in Checking for Certificate Revocation	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Lock on Critical Resource	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Failure to Use Default Case in Switch	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Untrusted Mobile Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Missing Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Use of Cookies in Security Decision	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Invalid Pointer Not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Incorrect Syntactic Object Comparison	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions (Missing Catch Block)	0	
+601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')	0	
+602	Draft	Design Principle Violation: Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Design Principle Violation: Not Failing Securely (aka 'Failing Open')	0	
+637	Draft	Design Principle Violation: Not Using Economy of Mechanism	0	
+638	Draft	Design Principle Violation: Not Using Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Incomplete	External Control of User State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')	0	
+644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Improper Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')	0	
+653	Draft	Design Principle Violation: Insufficient Compartmentalization	0	
+654	Draft	Design Principle Violation: Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Design Principle Violation: Failure to Satisfy Psychological Acceptability	0	
+656	Draft	Design Principle Violation: Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Insufficient Control of a Resource Through its Lifetime	0	
+665	Draft	Incorrect or Incomplete Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Design Principle Violation: Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Incomplete	Insecure Permission Assignment for Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Insecure Method or Function	0	

--- a/csaf-rs/assets/cwe/cwe_1.2_2009-01-12.csv
+++ b/csaf-rs/assets/cwe/cwe_1.2_2009-01-12.csv
@@ -1,617 +1,617 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Error Handling
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Improper Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Failure to Resolve Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Failure to Handle File Names that Identify Virtual Resources
-67	Incomplete	Failure to Handle Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Failure to Handle Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')
-78	Draft	Failure to Preserve OS Command Structure (aka 'OS Command Injection')
-79	Draft	Failure to Preserve Web Page Structure (aka 'Cross-site Scripting')
-80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page
-82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Failure to Preserve SQL Query Structure (aka 'SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Incomplete	Insufficient Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')
-94	Draft	Failure to Control Generation of Code (aka 'Code Injection')
-95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')
-96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Incorrect Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Failure to Handle Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Failure to Sanitize Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Failure to Sanitize Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Failure to Sanitize Comment Element
-152	Draft	Failure to Sanitize Macro Symbol
-153	Draft	Failure to Sanitize Substitution Character
-154	Incomplete	Failure to Sanitize Variable Name Delimiter
-155	Draft	Failure to Sanitize Wildcard or Matching Symbol
-156	Draft	Failure to Sanitize Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Failure to Sanitize Leading Special Element
-161	Incomplete	Failure to Sanitize Multiple Leading Special Elements
-162	Incomplete	Failure to Sanitize Trailing Special Element
-163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements
-164	Incomplete	Failure to Sanitize Internal Special Element
-165	Incomplete	Failure to Sanitize Multiple Internal Special Elements
-166	Draft	Failure to Handle Missing Special Element
-167	Draft	Failure to Handle Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leak
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Incomplete	Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')
-228	Incomplete	Failure to Handle Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Failure to Handle Missing Value
-231	Draft	Failure to Handle Extra Value
-232	Draft	Failure to Handle Undefined Value
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Failure to Handle Extra Parameter
-236	Draft	Failure to Handle Undefined Parameter
-237	Incomplete	Element Problems
-238	Draft	Failure to Handle Missing Element
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Failure to Resolve Inconsistent Elements
-241	Draft	Failure to Handle Wrong Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Incomplete	Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Misinterpreted Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Insecure Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully
-274	Draft	Failure to Handle Insufficient Privileges
-276	Draft	Insecure Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Insecure Execution-assigned Permissions
-280	Draft	Failure to Handle Insufficient Permissions or Privileges
-281	Draft	Permission Preservation Failure
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Failure to Follow Chain of Trust in Certificate Validation
-297	Incomplete	Failure to Validate Host-specific Certificate Data
-298	Draft	Failure to Validate Certificate Expiration
-299	Draft	Failure to Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Improper Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Weak Encryption
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Failure to Handle Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improperly Verified Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Failure to Check Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Race Condition in Checking for Certificate Revocation
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Lock on Critical Resource
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Failure to Use Default Case in Switch
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Missing Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Use of Cookies in Security Decision
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Invalid Pointer Not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Incorrect Syntactic Object Comparison
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions (Missing Catch Block)
-601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely (aka 'Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')
-644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Improper Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Failure to Satisfy Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Insufficient Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Insecure Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Error Handling	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Handling	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Improper Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Failure to Resolve Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Failure to Handle File Names that Identify Virtual Resources	0	
+67	Incomplete	Failure to Handle Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Failure to Handle Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')	0	
+78	Draft	Failure to Preserve OS Command Structure (aka 'OS Command Injection')	0	
+79	Draft	Failure to Preserve Web Page Structure (aka 'Cross-site Scripting')	0	
+80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page	0	
+82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Failure to Preserve SQL Query Structure (aka 'SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Incomplete	Insufficient Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code (aka 'Code Injection')	0	
+95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')	0	
+96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Incorrect Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Failure to Handle Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Failure to Sanitize Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Failure to Sanitize Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Failure to Sanitize Comment Element	0	
+152	Draft	Failure to Sanitize Macro Symbol	0	
+153	Draft	Failure to Sanitize Substitution Character	0	
+154	Incomplete	Failure to Sanitize Variable Name Delimiter	0	
+155	Draft	Failure to Sanitize Wildcard or Matching Symbol	0	
+156	Draft	Failure to Sanitize Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Failure to Sanitize Leading Special Element	0	
+161	Incomplete	Failure to Sanitize Multiple Leading Special Elements	0	
+162	Incomplete	Failure to Sanitize Trailing Special Element	0	
+163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements	0	
+164	Incomplete	Failure to Sanitize Internal Special Element	0	
+165	Incomplete	Failure to Sanitize Multiple Internal Special Elements	0	
+166	Draft	Failure to Handle Missing Special Element	0	
+167	Draft	Failure to Handle Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leak	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Incomplete	Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')	0	
+228	Incomplete	Failure to Handle Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Failure to Handle Missing Value	0	
+231	Draft	Failure to Handle Extra Value	0	
+232	Draft	Failure to Handle Undefined Value	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Failure to Handle Extra Parameter	0	
+236	Draft	Failure to Handle Undefined Parameter	0	
+237	Incomplete	Element Problems	0	
+238	Draft	Failure to Handle Missing Element	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Failure to Resolve Inconsistent Elements	0	
+241	Draft	Failure to Handle Wrong Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Incomplete	Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Misinterpreted Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Insecure Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Failure to Check Whether Privileges Were Dropped Successfully	0	
+274	Draft	Failure to Handle Insufficient Privileges	0	
+276	Draft	Insecure Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Insecure Execution-assigned Permissions	0	
+280	Draft	Failure to Handle Insufficient Permissions or Privileges	0	
+281	Draft	Permission Preservation Failure	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Failure to Follow Chain of Trust in Certificate Validation	0	
+297	Incomplete	Failure to Validate Host-specific Certificate Data	0	
+298	Draft	Failure to Validate Certificate Expiration	0	
+299	Draft	Failure to Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Improper Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Weak Encryption	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Failure to Handle Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improperly Verified Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Failure to Check Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Race Condition in Checking for Certificate Revocation	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Lock on Critical Resource	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Failure to Use Default Case in Switch	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Missing Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Use of Cookies in Security Decision	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Invalid Pointer Not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Incorrect Syntactic Object Comparison	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions (Missing Catch Block)	0	
+601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without "Secure" Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely (aka 'Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')	0	
+644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Improper Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Failure to Satisfy Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Insufficient Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Insecure Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	

--- a/csaf-rs/assets/cwe/cwe_1.3_2009-03-10.csv
+++ b/csaf-rs/assets/cwe/cwe_1.3_2009-03-10.csv
@@ -1,624 +1,624 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Improper Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Failure to Resolve Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Failure to Handle Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')
-78	Draft	Failure to Preserve OS Command Structure (aka 'OS Command Injection')
-79	Draft	Failure to Preserve Web Page Structure (aka 'Cross-site Scripting')
-80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page
-82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Failure to Preserve SQL Query Structure (aka 'SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Incomplete	Insufficient Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')
-94	Draft	Failure to Control Generation of Code (aka 'Code Injection')
-95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')
-96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Incorrect Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Sanitization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Improper Sanitization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Improper Sanitization of Comment Delimiters
-152	Draft	Improper Sanitization of Macro Symbols
-153	Draft	Improper Sanitization of Substitution Characters
-154	Incomplete	Improper Sanitization of Variable Name Delimiters
-155	Draft	Improper Sanitization of Wildcards or Matching Symbols
-156	Draft	Improper Sanitization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Failure to Sanitize Leading Special Element
-161	Incomplete	Failure to Sanitize Multiple Leading Special Elements
-162	Incomplete	Failure to Sanitize Trailing Special Element
-163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements
-164	Incomplete	Failure to Sanitize Internal Special Element
-165	Incomplete	Failure to Sanitize Multiple Internal Special Elements
-166	Draft	Failure to Handle Missing Special Element
-167	Draft	Failure to Handle Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leak
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Incomplete	Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Incomplete	Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Insecure Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Successfully Dropped Privileges
-274	Draft	Failure to Handle Insufficient Privileges
-276	Draft	Insecure Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Insecure Execution-assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Permission Preservation Failure
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Improper Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Weak Encryption
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Failure to Handle Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improperly Verified Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Race Condition in Checking for Certificate Revocation
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Lock on Critical Resource
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Failure to Use Default Case in Switch
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Use of Cookies in Security Decision
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Invalid Pointer Not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Incorrect Syntactic Object Comparison
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely (aka 'Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')
-644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Improper Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Failure to Satisfy Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Insufficient Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Insecure Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Improper Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Failure to Resolve Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Failure to Resolve Links Before File Access (aka 'Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Failure to Handle Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane (aka 'Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Failure to Sanitize Data into a Control Plane (aka 'Command Injection')	0	
+78	Draft	Failure to Preserve OS Command Structure (aka 'OS Command Injection')	0	
+79	Draft	Failure to Preserve Web Page Structure (aka 'Cross-site Scripting')	0	
+80	Incomplete	Failure to Sanitize Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Failure to Sanitize Directives in an Error Message Web Page	0	
+82	Incomplete	Failure to Sanitize Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Failure to Preserve SQL Query Structure (aka 'SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries (aka 'LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Incomplete	Insufficient Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences (aka 'CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code (aka 'Code Injection')	0	
+95	Incomplete	Insufficient Control of Directives in Dynamically Evaluated Code (aka 'Eval Injection')	0	
+96	Draft	Insufficient Control of Directives in Statically Saved Code (Static Code Injection)	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Insufficient Control of Resource Identifiers (aka 'Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers (aka 'HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Incorrect Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource (aka 'Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Sanitization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Improper Sanitization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Sanitization of Comment Delimiters	0	
+152	Draft	Improper Sanitization of Macro Symbols	0	
+153	Draft	Improper Sanitization of Substitution Characters	0	
+154	Incomplete	Improper Sanitization of Variable Name Delimiters	0	
+155	Draft	Improper Sanitization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Sanitization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Failure to Sanitize Leading Special Element	0	
+161	Incomplete	Failure to Sanitize Multiple Leading Special Elements	0	
+162	Incomplete	Failure to Sanitize Trailing Special Element	0	
+163	Incomplete	Failure to Sanitize Multiple Trailing Special Elements	0	
+164	Incomplete	Failure to Sanitize Internal Special Element	0	
+165	Incomplete	Failure to Sanitize Multiple Internal Special Elements	0	
+166	Draft	Failure to Handle Missing Special Element	0	
+167	Draft	Failure to Handle Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leak	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Incomplete	Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract (aka 'API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release (aka 'Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Incomplete	Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Insecure Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Successfully Dropped Privileges	0	
+274	Draft	Failure to Handle Insufficient Privileges	0	
+276	Draft	Insecure Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Insecure Execution-assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Permission Preservation Failure	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint (aka 'Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Improper Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Weak Encryption	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Failure to Handle Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improperly Verified Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Race Condition in Checking for Certificate Revocation	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption (aka 'Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference (aka 'Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere (aka 'Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Failure to Handle Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Lock on Critical Resource	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests (aka 'HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code (aka 'Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Failure to Use Default Case in Switch	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final (aka 'Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Use of Cookies in Security Decision	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Invalid Pointer Not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Incorrect Syntactic Object Comparison	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site (aka 'Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor (aka 'Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely (aka 'Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions (aka 'XPath injection')	0	
+644	Incomplete	Insufficient Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Improper Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions (aka 'XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Failure to Satisfy Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Insufficient Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Failure to Enforce that Messages or Data are Well-Formed	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Insecure Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	

--- a/csaf-rs/assets/cwe/cwe_1.4_2009-05-27.csv
+++ b/csaf-rs/assets/cwe/cwe_1.4_2009-05-27.csv
@@ -1,638 +1,638 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Improper Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Failure to Sanitize Data into a Control Plane ('Command Injection')
-78	Draft	Failure to Preserve OS Command Structure ('OS Command Injection')
-79	Draft	Failure to Preserve Web Page Structure ('Cross-site Scripting')
-80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Sanitization of Script in an Error Message Web Page
-82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Failure to Preserve SQL Query Structure ('SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Incomplete	Improper Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Sanitization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Improper Sanitization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Improper Sanitization of Comment Delimiters
-152	Draft	Improper Sanitization of Macro Symbols
-153	Draft	Improper Sanitization of Substitution Characters
-154	Incomplete	Improper Sanitization of Variable Name Delimiters
-155	Draft	Improper Sanitization of Wildcards or Matching Symbols
-156	Draft	Improper Sanitization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Sanitization of Leading Special Elements
-161	Incomplete	Improper Sanitization of Multiple Leading Special Elements
-162	Incomplete	Improper Sanitization of Trailing Special Elements
-163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements
-164	Incomplete	Improper Sanitization of Internal Special Elements
-165	Incomplete	Improper Sanitization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leak
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Incomplete	Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Weak Encryption
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Lock on Critical Resource
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Use of Cookies in Security Decision
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of  Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')
-644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Improper Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Failure to Sanitize Data into a Control Plane ('Command Injection')	0	
+78	Draft	Failure to Preserve OS Command Structure ('OS Command Injection')	0	
+79	Draft	Failure to Preserve Web Page Structure ('Cross-site Scripting')	0	
+80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Sanitization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Failure to Preserve SQL Query Structure ('SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Incomplete	Improper Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Sanitization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Improper Sanitization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Sanitization of Comment Delimiters	0	
+152	Draft	Improper Sanitization of Macro Symbols	0	
+153	Draft	Improper Sanitization of Substitution Characters	0	
+154	Incomplete	Improper Sanitization of Variable Name Delimiters	0	
+155	Draft	Improper Sanitization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Sanitization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Sanitization of Leading Special Elements	0	
+161	Incomplete	Improper Sanitization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Sanitization of Trailing Special Elements	0	
+163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Sanitization of Internal Special Elements	0	
+165	Incomplete	Improper Sanitization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leak	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Incomplete	Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Weak Encryption	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Lock on Critical Resource	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Use of Cookies in Security Decision	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of  Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')	0	
+644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	

--- a/csaf-rs/assets/cwe/cwe_1.5_2009-07-27.csv
+++ b/csaf-rs/assets/cwe/cwe_1.5_2009-07-27.csv
@@ -1,648 +1,648 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Draft	Improper Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')
-79	Draft	Failure to Preserve Web Page Structure ('Cross-site Scripting')
-80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Sanitization of Script in an Error Message Web Page
-82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-100	Incomplete	Technology-Specific Input Validation Problems
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Unchecked Array Indexing
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Sanitization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Improper Sanitization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Improper Sanitization of Comment Delimiters
-152	Draft	Improper Sanitization of Macro Symbols
-153	Draft	Improper Sanitization of Substitution Characters
-154	Incomplete	Improper Sanitization of Variable Name Delimiters
-155	Draft	Improper Sanitization of Wildcards or Matching Symbols
-156	Draft	Improper Sanitization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Sanitization of Leading Special Elements
-161	Incomplete	Improper Sanitization of Multiple Leading Special Elements
-162	Incomplete	Improper Sanitization of Trailing Special Elements
-163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements
-164	Incomplete	Improper Sanitization of Internal Special Elements
-165	Incomplete	Improper Sanitization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leak
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of  Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')
-644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Draft	Improper Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Draft	Failure to Preserve Web Page Structure ('Cross-site Scripting')	0	
+80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Sanitization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+100	Incomplete	Technology-Specific Input Validation Problems	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Draft	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Boundary Beginning Violation ('Buffer Underwrite')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Unchecked Array Indexing	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Sanitization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Improper Sanitization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Sanitization of Comment Delimiters	0	
+152	Draft	Improper Sanitization of Macro Symbols	0	
+153	Draft	Improper Sanitization of Substitution Characters	0	
+154	Incomplete	Improper Sanitization of Variable Name Delimiters	0	
+155	Draft	Improper Sanitization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Sanitization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Sanitization of Leading Special Elements	0	
+161	Incomplete	Improper Sanitization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Sanitization of Trailing Special Elements	0	
+163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Sanitization of Internal Special Elements	0	
+165	Incomplete	Improper Sanitization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leak	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of  Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')	0	
+644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	

--- a/csaf-rs/assets/cwe/cwe_1.6_2009-10-29.csv
+++ b/csaf-rs/assets/cwe/cwe_1.6_2009-10-29.csv
@@ -1,651 +1,651 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')
-80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Sanitization of Script in an Error Message Web Page
-82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Sanitization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Improper Sanitization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Improper Sanitization of Comment Delimiters
-152	Draft	Improper Sanitization of Macro Symbols
-153	Draft	Improper Sanitization of Substitution Characters
-154	Incomplete	Improper Sanitization of Variable Name Delimiters
-155	Draft	Improper Sanitization of Wildcards or Matching Symbols
-156	Draft	Improper Sanitization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Sanitization of Leading Special Elements
-161	Incomplete	Improper Sanitization of Multiple Leading Special Elements
-162	Incomplete	Improper Sanitization of Trailing Special Elements
-163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements
-164	Incomplete	Improper Sanitization of Internal Special Elements
-165	Incomplete	Improper Sanitization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Leak (Information Disclosure)
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Discrepancy Information Leaks
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Behavioral Discrepancy Information Leak
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	External Behavioral Inconsistency Information Leak
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Error Message Information Leak
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Cross-boundary Cleansing Information Leak
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Draft	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Information Leak of System Data
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Information Leak Through CVS Repository
-528	Draft	Information Leak Through Core Dump Files
-529	Incomplete	Information Leak Through Access Control List Files
-530	Incomplete	Information Leak Through Backup (.~bk) Files
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Leaks
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')
-644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')	0	
+80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Sanitization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Sanitization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Improper Sanitization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Sanitization of Comment Delimiters	0	
+152	Draft	Improper Sanitization of Macro Symbols	0	
+153	Draft	Improper Sanitization of Substitution Characters	0	
+154	Incomplete	Improper Sanitization of Variable Name Delimiters	0	
+155	Draft	Improper Sanitization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Sanitization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Sanitization of Leading Special Elements	0	
+161	Incomplete	Improper Sanitization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Sanitization of Trailing Special Elements	0	
+163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Sanitization of Internal Special Elements	0	
+165	Incomplete	Improper Sanitization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Leak (Information Disclosure)	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Discrepancy Information Leaks	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Behavioral Discrepancy Information Leak	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	External Behavioral Inconsistency Information Leak	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Error Message Information Leak	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Cross-boundary Cleansing Information Leak	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Draft	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Information Leak of System Data	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Information Leak Through CVS Repository	0	
+528	Draft	Information Leak Through Core Dump Files	0	
+529	Incomplete	Information Leak Through Access Control List Files	0	
+530	Incomplete	Information Leak Through Backup (.~bk) Files	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Leaks	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')	0	
+644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	

--- a/csaf-rs/assets/cwe/cwe_1.7_2009-12-28.csv
+++ b/csaf-rs/assets/cwe/cwe_1.7_2009-12-28.csv
@@ -1,659 +1,659 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Path Traversal
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')
-80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Sanitization of Script in an Error Message Web Page
-82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Sanitization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Improper Sanitization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Improper Sanitization of Comment Delimiters
-152	Draft	Improper Sanitization of Macro Symbols
-153	Draft	Improper Sanitization of Substitution Characters
-154	Incomplete	Improper Sanitization of Variable Name Delimiters
-155	Draft	Improper Sanitization of Wildcards or Matching Symbols
-156	Draft	Improper Sanitization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Sanitization of Leading Special Elements
-161	Incomplete	Improper Sanitization of Multiple Leading Special Elements
-162	Incomplete	Improper Sanitization of Trailing Special Elements
-163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements
-164	Incomplete	Improper Sanitization of Internal Special Elements
-165	Incomplete	Improper Sanitization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Improper Cross-boundary Cleansing
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Hard-Coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	No Authentication for Critical Function
-307	Draft	Failure to Restrict Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Failure to Encrypt Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')
-644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Use of a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Path Traversal	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')	0	
+80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Sanitization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Sanitization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Improper Sanitization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Sanitization of Comment Delimiters	0	
+152	Draft	Improper Sanitization of Macro Symbols	0	
+153	Draft	Improper Sanitization of Substitution Characters	0	
+154	Incomplete	Improper Sanitization of Variable Name Delimiters	0	
+155	Draft	Improper Sanitization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Sanitization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Sanitization of Leading Special Elements	0	
+161	Incomplete	Improper Sanitization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Sanitization of Trailing Special Elements	0	
+163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Sanitization of Internal Special Elements	0	
+165	Incomplete	Improper Sanitization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Improper Cross-boundary Cleansing	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Hard-Coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	No Authentication for Critical Function	0	
+307	Draft	Failure to Restrict Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Failure to Encrypt Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')	0	
+644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Use of a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	

--- a/csaf-rs/assets/cwe/cwe_1.8.1_2010-04-05.csv
+++ b/csaf-rs/assets/cwe/cwe_1.8.1_2010-04-05.csv
@@ -1,668 +1,668 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')
-80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Sanitization of Script in an Error Message Web Page
-82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')	0	
+80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Sanitization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	

--- a/csaf-rs/assets/cwe/cwe_1.8_2010-02-16.csv
+++ b/csaf-rs/assets/cwe/cwe_1.8_2010-02-16.csv
@@ -1,668 +1,668 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane
-77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')
-80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Sanitization of Script in an Error Message Web Page
-82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Failure to Sanitize Script in Attributes in a Web Page
-84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages
-87	Draft	Failure to Sanitize Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Sanitization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Sanitization of Special Elements
-140	Draft	Failure to Sanitize Delimiters
-141	Draft	Failure to Sanitize Parameter/Argument Delimiters
-142	Draft	Failure to Sanitize Value Delimiters
-143	Draft	Failure to Sanitize Record Delimiters
-144	Draft	Failure to Sanitize Line Delimiters
-145	Incomplete	Failure to Sanitize Section Delimiters
-146	Incomplete	Failure to Sanitize Expression/Command Delimiters
-147	Draft	Improper Sanitization of Input Terminators
-148	Draft	Failure to Sanitize Input Leaders
-149	Draft	Failure to Sanitize Quoting Syntax
-150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences
-151	Draft	Improper Sanitization of Comment Delimiters
-152	Draft	Improper Sanitization of Macro Symbols
-153	Draft	Improper Sanitization of Substitution Characters
-154	Incomplete	Improper Sanitization of Variable Name Delimiters
-155	Draft	Improper Sanitization of Wildcards or Matching Symbols
-156	Draft	Improper Sanitization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Failure to Sanitize Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Sanitization of Leading Special Elements
-161	Incomplete	Improper Sanitization of Multiple Leading Special Elements
-162	Incomplete	Improper Sanitization of Trailing Special Elements
-163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements
-164	Incomplete	Improper Sanitization of Internal Special Elements
-165	Incomplete	Improper Sanitization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data Into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Mutable Objects Passed by Reference
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content
-642	Draft	External Control of Critical State Data
-643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')
-644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Failure to Sanitize Data into a Different Plane ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Failure to Resolve Equivalent Special Elements into a Different Plane	0	
+77	Draft	Improper Sanitization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Sanitization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Failure to Preserve Web Page Structure ('Cross-site Scripting')	0	
+80	Incomplete	Improper Sanitization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Sanitization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Sanitization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Failure to Sanitize Script in Attributes in a Web Page	0	
+84	Draft	Failure to Resolve Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Failure to Sanitize Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Failure to Sanitize Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Sanitization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Failure to Sanitize Data into LDAP Queries ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Failure to Sanitize CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Sanitization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Sanitization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Failure to Sanitize Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Failure to Sanitize CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Sanitization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Sanitization of Special Elements	0	
+140	Draft	Failure to Sanitize Delimiters	0	
+141	Draft	Failure to Sanitize Parameter/Argument Delimiters	0	
+142	Draft	Failure to Sanitize Value Delimiters	0	
+143	Draft	Failure to Sanitize Record Delimiters	0	
+144	Draft	Failure to Sanitize Line Delimiters	0	
+145	Incomplete	Failure to Sanitize Section Delimiters	0	
+146	Incomplete	Failure to Sanitize Expression/Command Delimiters	0	
+147	Draft	Improper Sanitization of Input Terminators	0	
+148	Draft	Failure to Sanitize Input Leaders	0	
+149	Draft	Failure to Sanitize Quoting Syntax	0	
+150	Incomplete	Failure to Sanitize Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Sanitization of Comment Delimiters	0	
+152	Draft	Improper Sanitization of Macro Symbols	0	
+153	Draft	Improper Sanitization of Substitution Characters	0	
+154	Incomplete	Improper Sanitization of Variable Name Delimiters	0	
+155	Draft	Improper Sanitization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Sanitization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Failure to Sanitize Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Sanitization of Leading Special Elements	0	
+161	Incomplete	Improper Sanitization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Sanitization of Trailing Special Elements	0	
+163	Incomplete	Improper Sanitization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Sanitization of Internal Special Elements	0	
+165	Incomplete	Improper Sanitization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data Into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Mutable Objects Passed by Reference	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Insufficient Filtering of File and Other Resource Names for Executable Content	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Failure to Sanitize Data within XPath Expressions ('XPath injection')	0	
+644	Incomplete	Improper Sanitization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Failure to Sanitize Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	

--- a/csaf-rs/assets/cwe/cwe_1.9_2010-06-21.csv
+++ b/csaf-rs/assets/cwe/cwe_1.9_2010-06-21.csv
@@ -1,668 +1,668 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Failure to Control Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Failure to Resolve Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Failure to Handle Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Failure to Handle Mixed Encoding
-176	Draft	Failure to Handle Unicode Encoding
-177	Draft	Failure to Handle URL Encoding (Hex Encoding)
-178	Incomplete	Failure to Resolve Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Leak Through Sent Data
-202	Draft	Privacy Leak through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Leak
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Internal Behavioral Inconsistency Information Leak
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Timing Discrepancy Information Leak
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Product-Generated Error Message Information Leak
-211	Incomplete	Product-External Error Message Information Leak
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intended Information Leak
-214	Incomplete	Process Environment Information Leak
-215	Draft	Information Leak Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Failure to Fulfill API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Failure to Change Working Directory in chroot Jail
-244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Access Control (Authorization) Issues
-285	Draft	Improper Access Control (Authorization)
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Failure to Add Integrity Check Value
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Race Condition
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Draft	State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Passing Mutable Objects to an Untrusted Method
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Failure to Report Error in Status Code
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	UNIX File Descriptor Leak
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Insufficient Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Failure to Protect Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Unsafe Function Call from a Signal Handler
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Data Leak Between Sessions
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Information Leak through Class Cloning
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Leak Through Caching
-525	Incomplete	Information Leak Through Browser Caching
-526	Incomplete	Information Leak Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Leak Through Test Code
-532	Incomplete	Information Leak Through Log Files
-533	Incomplete	Information Leak Through Server Log Files
-534	Draft	Information Leak Through Debug Log Files
-535	Incomplete	Information Leak Through Shell Error Message
-536	Incomplete	Information Leak Through Servlet Runtime Error Message
-537	Incomplete	Information Leak Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Leak Through Persistent Cookies
-540	Incomplete	Information Leak Through Source Code
-541	Incomplete	Information Leak Through Include Source Code
-542	Incomplete	Information Leak Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner
-544	Draft	Failure to Use a Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Leak Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Leak Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Failure to Follow Specification
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Leak Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Failure to Catch All Exceptions in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Leak Through XML External Entity File Disclosure
-612	Draft	Information Leak Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Leak Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Failure to Use Economy of Mechanism
-638	Draft	Failure to Use Complete Mediation
-639	Incomplete	Access Control Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Leak through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Insufficient Synchronization
-663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Insufficient Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Failure to Provide Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Failure to Handle Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Failure to Handle Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Failure to Control Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Failure to Constrain Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Failure to Resolve Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Failure to Handle Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Failure to Handle Mixed Encoding	0	
+176	Draft	Failure to Handle Unicode Encoding	0	
+177	Draft	Failure to Handle URL Encoding (Hex Encoding)	0	
+178	Incomplete	Failure to Resolve Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Leak Through Sent Data	0	
+202	Draft	Privacy Leak through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Leak	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Internal Behavioral Inconsistency Information Leak	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Timing Discrepancy Information Leak	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Product-Generated Error Message Information Leak	0	
+211	Incomplete	Product-External Error Message Information Leak	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intended Information Leak	0	
+214	Incomplete	Process Environment Information Leak	0	
+215	Draft	Information Leak Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Failure to Fulfill API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Failure to Change Working Directory in chroot Jail	0	
+244	Draft	Failure to Clear Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Access Control (Authorization) Issues	0	
+285	Draft	Improper Access Control (Authorization)	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Failure to Add Integrity Check Value	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Race Condition	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Draft	State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Passing Mutable Objects to an Untrusted Method	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Failure to Report Error in Status Code	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Failure to Release Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	UNIX File Descriptor Leak	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Insufficient Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Failure to Protect Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Unsafe Function Call from a Signal Handler	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Data Leak Between Sessions	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Information Leak through Class Cloning	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Leak Through Caching	0	
+525	Incomplete	Information Leak Through Browser Caching	0	
+526	Incomplete	Information Leak Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Leak Through Test Code	0	
+532	Incomplete	Information Leak Through Log Files	0	
+533	Incomplete	Information Leak Through Server Log Files	0	
+534	Draft	Information Leak Through Debug Log Files	0	
+535	Incomplete	Information Leak Through Shell Error Message	0	
+536	Incomplete	Information Leak Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Leak Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Leak Through Persistent Cookies	0	
+540	Incomplete	Information Leak Through Source Code	0	
+541	Incomplete	Information Leak Through Include Source Code	0	
+542	Incomplete	Information Leak Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern in a Non-thread-safe Manner	0	
+544	Draft	Failure to Use a Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Leak Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Leak Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Access Control Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Failure to Follow Specification	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Leak Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Failure to Catch All Exceptions in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Leak Through XML External Entity File Disclosure	0	
+612	Draft	Information Leak Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Leak Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Failure to Use Economy of Mechanism	0	
+638	Draft	Failure to Use Complete Mediation	0	
+639	Incomplete	Access Control Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Leak through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Insufficient Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in an Unsynchronized Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Insufficient Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Failure to Provide Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Failure to Handle Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	

--- a/csaf-rs/assets/cwe/cwe_2.0_2011-06-27.csv
+++ b/csaf-rs/assets/cwe/cwe_2.0_2011-06-27.csv
@@ -1,693 +1,693 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Generated Error Message
-211	Incomplete	Information Exposure Through External Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Exposure Through XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Generated Error Message	0	
+211	Incomplete	Information Exposure Through External Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Exposure Through XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	

--- a/csaf-rs/assets/cwe/cwe_2.10_2017-01-19.csv
+++ b/csaf-rs/assets/cwe/cwe_2.10_2017-01-19.csv
@@ -1,720 +1,720 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use ('Unused Variable')
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use ('Unused Variable')	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	

--- a/csaf-rs/assets/cwe/cwe_2.11_2017-05-05.csv
+++ b/csaf-rs/assets/cwe/cwe_2.11_2017-05-05.csv
@@ -1,728 +1,728 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Draft	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Draft	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use ('Unused Variable')
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Draft	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Draft	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use ('Unused Variable')	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	

--- a/csaf-rs/assets/cwe/cwe_2.12_2017-11-08.csv
+++ b/csaf-rs/assets/cwe/cwe_2.12_2017-11-08.csv
@@ -1,722 +1,722 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Incomplete	Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Draft	Improper Restriction of Cross-Origin Permission to window.opener.location
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Incomplete	Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Draft	Improper Restriction of Cross-Origin Permission to window.opener.location	0	

--- a/csaf-rs/assets/cwe/cwe_2.1_2011-09-13.csv
+++ b/csaf-rs/assets/cwe/cwe_2.1_2011-09-13.csv
@@ -1,693 +1,693 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Generated Error Message
-211	Incomplete	Information Exposure Through External Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Exposure Through XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Generated Error Message	0	
+211	Incomplete	Information Exposure Through External Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Exposure Through XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	

--- a/csaf-rs/assets/cwe/cwe_2.2_2012-05-14.csv
+++ b/csaf-rs/assets/cwe/cwe_2.2_2012-05-14.csv
@@ -1,693 +1,693 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Generated Error Message
-211	Incomplete	Information Exposure Through External Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Exposure Through XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Unvalidated Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Generated Error Message	0	
+211	Incomplete	Information Exposure Through External Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Exposure Through XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Unvalidated Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	

--- a/csaf-rs/assets/cwe/cwe_2.3_2012-10-30.csv
+++ b/csaf-rs/assets/cwe/cwe_2.3_2012-10-30.csv
@@ -1,693 +1,693 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-296	Draft	Improper Following of Chain of Trust for Certificate Validation
-297	Incomplete	Improper Validation of Host-specific Certificate Data
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy/Intermediary
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Trust of OpenSSL Certificate Without Validation
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Information Exposure Through XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Redirect Without Exit
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+296	Draft	Improper Following of Chain of Trust for Certificate Validation	0	
+297	Incomplete	Improper Validation of Host-specific Certificate Data	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy/Intermediary	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Trust of OpenSSL Certificate Without Validation	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Information Exposure Through XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Redirect Without Exit	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Unrestricted Recursive Entity References in DTDs ('XML Bomb')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	

--- a/csaf-rs/assets/cwe/cwe_2.4_2013-02-21.csv
+++ b/csaf-rs/assets/cwe/cwe_2.4_2013-02-21.csv
@@ -1,705 +1,705 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Parameter Problems
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Incomplete	Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-292	Incomplete	Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Plaintext Storage in a File or on Disk
-314	Draft	Plaintext Storage in the Registry
-315	Draft	Plaintext Storage in a Cookie
-316	Draft	Plaintext Storage in Memory
-317	Draft	Plaintext Storage in GUI
-318	Draft	Plaintext Storage in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Improperly Trusted Reverse DNS
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Parameter Problems	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Incomplete	Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+292	Incomplete	Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Plaintext Storage in a File or on Disk	0	
+314	Draft	Plaintext Storage in the Registry	0	
+315	Draft	Plaintext Storage in a Cookie	0	
+316	Draft	Plaintext Storage in Memory	0	
+317	Draft	Plaintext Storage in GUI	0	
+318	Draft	Plaintext Storage in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Improperly Trusted Reverse DNS	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	

--- a/csaf-rs/assets/cwe/cwe_2.5_2013-07-17.csv
+++ b/csaf-rs/assets/cwe/cwe_2.5_2013-07-17.csv
@@ -1,714 +1,714 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Privacy Violation
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	UI Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Authentication of Endpoint in a Communication Channel
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Restriction of Content Provider Export to Other Applications
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Privacy Violation	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	UI Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Authentication of Endpoint in a Communication Channel	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Restriction of Content Provider Export to Other Applications	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	

--- a/csaf-rs/assets/cwe/cwe_2.6_2014-02-19.csv
+++ b/csaf-rs/assets/cwe/cwe_2.6_2014-02-19.csv
@@ -1,717 +1,717 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak PRNG
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Unused Variable
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak PRNG	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Unused Variable	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	

--- a/csaf-rs/assets/cwe/cwe_2.7_2014-06-23.csv
+++ b/csaf-rs/assets/cwe/cwe_2.7_2014-06-23.csv
@@ -1,719 +1,719 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use ('Unused Variable')
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use ('Unused Variable')	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	

--- a/csaf-rs/assets/cwe/cwe_2.8_2014-07-31.csv
+++ b/csaf-rs/assets/cwe/cwe_2.8_2014-07-31.csv
@@ -1,719 +1,719 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Uncontrolled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use ('Unused Variable')
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Uncontrolled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use ('Unused Variable')	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	

--- a/csaf-rs/assets/cwe/cwe_2.9_2015-12-07.csv
+++ b/csaf-rs/assets/cwe/cwe_2.9_2015-12-07.csv
@@ -1,719 +1,719 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Incomplete	Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Improper Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-227	Draft	Improper Fulfillment of API Contract ('API Abuse')
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	PRNG Seed Error
-336	Draft	Same Seed in PRNG
-337	Draft	Predictable Seed in PRNG
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-398	Draft	Indicator of Poor Code Quality
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Interaction Error
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Functions
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-485	Draft	Insufficient Encapsulation
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Incomplete	Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use ('Unused Variable')
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Incomplete	Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-691	Draft	Insufficient Control Flow Management
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Coding Standards Violation
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Incomplete	Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Improper Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+227	Draft	Improper Fulfillment of API Contract ('API Abuse')	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	PRNG Seed Error	0	
+336	Draft	Same Seed in PRNG	0	
+337	Draft	Predictable Seed in PRNG	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+398	Draft	Indicator of Poor Code Quality	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Interaction Error	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Functions	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+485	Draft	Insufficient Encapsulation	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Incomplete	Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use ('Unused Variable')	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Incomplete	Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+691	Draft	Insufficient Control Flow Management	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Coding Standards Violation	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	

--- a/csaf-rs/assets/cwe/cwe_3.0_2017-11-08.csv
+++ b/csaf-rs/assets/cwe/cwe_3.0_2017-11-08.csv
@@ -1,730 +1,730 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Draft	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Draft	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Incomplete	Information Exposure Through Server Log Files
-534	Draft	Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Incomplete	Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Incomplete	Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Insufficient Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Incomplete	Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Draft	Improper Restriction of Cross-Origin Permission to window.opener.location
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Draft	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Draft	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Incomplete	Information Exposure Through Server Log Files	0	
+534	Draft	Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Incomplete	Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Incomplete	Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Insufficient Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Incomplete	Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Draft	Improper Restriction of Cross-Origin Permission to window.opener.location	0	

--- a/csaf-rs/assets/cwe/cwe_3.1_2018-03-29.csv
+++ b/csaf-rs/assets/cwe/cwe_3.1_2018-03-29.csv
@@ -1,736 +1,736 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Draft	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')
-401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Draft	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Array-Typed Field Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Variable Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Incomplete	Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Draft	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Incomplete	Uncontrolled Resource Consumption ('Resource Exhaustion')	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference ('Memory Leak')	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Draft	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Array-Typed Field Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Variable Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Incomplete	Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	

--- a/csaf-rs/assets/cwe/cwe_3.2_2019-01-03.csv
+++ b/csaf-rs/assets/cwe/cwe_3.2_2019-01-03.csv
@@ -1,827 +1,827 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Draft	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Incomplete	Uncontrolled Resource Consumption
-401	Draft	Improper Release of Memory Before Removing Last Reference
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Draft	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Information Exposure Through Log Files
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference ('XXE')
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Draft	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Incomplete	Uncontrolled Resource Consumption	0	
+401	Draft	Improper Release of Memory Before Removing Last Reference	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Draft	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Information Exposure Through Log Files	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference ('XXE')	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	

--- a/csaf-rs/assets/cwe/cwe_3.3_2019-06-20.csv
+++ b/csaf-rs/assets/cwe/cwe_3.3_2019-06-20.csv
@@ -1,829 +1,829 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Usable	Improper Input Validation
-22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Argument Injection or Modification
-89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Incomplete	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Incomplete	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Incomplete	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Incomplete	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Usable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Draft	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Incomplete	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Draft	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Draft	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Draft	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Inclusion of Sensitive Information in Log Files
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Incomplete	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Incomplete	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Incomplete	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Incomplete	Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Usable	Improper Input Validation	0	
+22	Draft	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Draft	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Usable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Argument Injection or Modification	0	
+89	Draft	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Usable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Incomplete	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Incomplete	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Incomplete	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Incomplete	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Usable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Draft	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Incomplete	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Draft	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Draft	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Draft	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Inclusion of Sensitive Information in Log Files	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Incomplete	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Incomplete	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Incomplete	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Incomplete	Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	

--- a/csaf-rs/assets/cwe/cwe_3.4.1_2019-09-23.csv
+++ b/csaf-rs/assets/cwe/cwe_3.4.1_2019-09-23.csv
@@ -1,829 +1,829 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Inclusion of Sensitive Information in Log Files
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Incomplete	Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Inclusion of Sensitive Information in Log Files	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Incomplete	Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	

--- a/csaf-rs/assets/cwe/cwe_3.4_2019-09-19.csv
+++ b/csaf-rs/assets/cwe/cwe_3.4_2019-09-19.csv
@@ -1,829 +1,829 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Delimitation of Arguments in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency 
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Failure to Sanitize Special Element
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive Whitelist
-184	Draft	Incomplete Blacklist
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Information Exposure
-201	Draft	Information Exposure Through Sent Data
-202	Draft	Exposure of Sensitive Data Through Data Queries
-203	Incomplete	Information Exposure Through Discrepancy
-204	Incomplete	Response Discrepancy Information Exposure
-205	Incomplete	Information Exposure Through Behavioral Discrepancy
-206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency
-207	Draft	Information Exposure Through an External Behavioral Inconsistency
-208	Incomplete	Information Exposure Through Timing Discrepancy
-209	Draft	Information Exposure Through an Error Message
-210	Draft	Information Exposure Through Self-generated Error Message
-211	Incomplete	Information Exposure Through Externally-Generated Error Message
-212	Incomplete	Improper Cross-boundary Removal of Sensitive Data
-213	Draft	Intentional Information Exposure
-214	Incomplete	Information Exposure Through Process Environment
-215	Draft	Information Exposure Through Debug Information
-216	Incomplete	Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Sensitive Data Under Web Root
-220	Draft	Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared Before Release
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Cryptography for Passwords
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Incomplete	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Predictability Problems
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Information ('Privacy Violation')
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Leftover Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Information Exposure Through Caching
-525	Incomplete	Information Exposure Through Browser Caching
-526	Incomplete	Information Exposure Through Environmental Variables
-527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Information Exposure Through Test Code
-532	Incomplete	Inclusion of Sensitive Information in Log Files
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Information Exposure Through Shell Error Message
-536	Incomplete	Information Exposure Through Servlet Runtime Error Message
-537	Incomplete	Information Exposure Through Java Runtime Error Message
-538	Draft	File and Directory Information Exposure
-539	Incomplete	Information Exposure Through Persistent Cookies
-540	Incomplete	Information Exposure Through Source Code
-541	Incomplete	Information Exposure Through Include Source Code
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Information Exposure Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Information Exposure Through Server Error Message
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Information Exposure Through Query Strings in GET Request
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Information Exposure Through Indexing of Private Data
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Information Exposure Through Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Information Exposure Through WSDL File
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Enforcement of Message or Data Structure
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Incomplete	Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Delimitation of Arguments in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency 	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Failure to Sanitize Special Element	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive Whitelist	0	
+184	Draft	Incomplete Blacklist	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Information Exposure	0	
+201	Draft	Information Exposure Through Sent Data	0	
+202	Draft	Exposure of Sensitive Data Through Data Queries	0	
+203	Incomplete	Information Exposure Through Discrepancy	0	
+204	Incomplete	Response Discrepancy Information Exposure	0	
+205	Incomplete	Information Exposure Through Behavioral Discrepancy	0	
+206	Incomplete	Information Exposure of Internal State Through Behavioral Inconsistency	0	
+207	Draft	Information Exposure Through an External Behavioral Inconsistency	0	
+208	Incomplete	Information Exposure Through Timing Discrepancy	0	
+209	Draft	Information Exposure Through an Error Message	0	
+210	Draft	Information Exposure Through Self-generated Error Message	0	
+211	Incomplete	Information Exposure Through Externally-Generated Error Message	0	
+212	Incomplete	Improper Cross-boundary Removal of Sensitive Data	0	
+213	Draft	Intentional Information Exposure	0	
+214	Incomplete	Information Exposure Through Process Environment	0	
+215	Draft	Information Exposure Through Debug Information	0	
+216	Incomplete	Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Sensitive Data Under Web Root	0	
+220	Draft	Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared Before Release	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Cryptography for Passwords	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint ('Man-in-the-Middle')	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Incomplete	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Predictability Problems	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Information ('Privacy Violation')	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Incorrect Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Leftover Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of System Data to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Information Exposure Through Caching	0	
+525	Incomplete	Information Exposure Through Browser Caching	0	
+526	Incomplete	Information Exposure Through Environmental Variables	0	
+527	Incomplete	Exposure of CVS Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Information Exposure Through Test Code	0	
+532	Incomplete	Inclusion of Sensitive Information in Log Files	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Information Exposure Through Shell Error Message	0	
+536	Incomplete	Information Exposure Through Servlet Runtime Error Message	0	
+537	Incomplete	Information Exposure Through Java Runtime Error Message	0	
+538	Draft	File and Directory Information Exposure	0	
+539	Incomplete	Information Exposure Through Persistent Cookies	0	
+540	Incomplete	Information Exposure Through Source Code	0	
+541	Incomplete	Information Exposure Through Include Source Code	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Information Exposure Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Information Exposure Through Server Error Message	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Information Exposure Through Query Strings in GET Request	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Information Exposure Through Indexing of Private Data	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Information Exposure Through Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Information Exposure Through WSDL File	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Enforcement of Message or Data Structure	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Incomplete	Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	

--- a/csaf-rs/assets/cwe/cwe_4.0_2020-02-24.csv
+++ b/csaf-rs/assets/cwe/cwe_4.0_2020-02-24.csv
@@ -1,862 +1,862 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Exposure of Sensitive Information Through Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared in Resource Before Release for Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Blacklist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Overly Permissive Cross-domain Whitelist
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Draft	Improper Isolation of Shared Resources on System-on-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Draft	Exposed Chip Debug Interface With Insufficient Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Incomplete	Improper Implementation of Lock Protection Registers
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Risky Cryptographic Primitive
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Exposure of Security-Sensitive Fuse Values During Debug
-1244	Incomplete	Improper Authorization on Physical Debug and Test Interfaces
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Incomplete	Missing Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Exposure of Sensitive Information Through Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared in Resource Before Release for Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Blacklist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Overly Permissive Cross-domain Whitelist	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Draft	Improper Isolation of Shared Resources on System-on-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Draft	Exposed Chip Debug Interface With Insufficient Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Incomplete	Improper Implementation of Lock Protection Registers	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Risky Cryptographic Primitive	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Exposure of Security-Sensitive Fuse Values During Debug	0	
+1244	Incomplete	Improper Authorization on Physical Debug and Test Interfaces	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Incomplete	Missing Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	

--- a/csaf-rs/assets/cwe/cwe_4.10_2023-01-31.csv
+++ b/csaf-rs/assets/cwe/cwe_4.10_2023-01-31.csv
@@ -1,958 +1,958 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Use of Weak Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Deprecated	DEPRECATED: Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Multiple Condition Expression	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Improper Isolation or Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Multiple Operations on Resource in Single-Operation Context	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Insufficient Technical Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Stable	Improper Prevention of Lock Bit Modification	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Stable	Improper Access Control for Register Interface	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Draft	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Stable	Improper Protection of Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Improper Access Control in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	0	
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1341	Incomplete	Multiple Releases of Same Resource or Handle	0	
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	0	
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	0	
+1385	Incomplete	Missing Origin Validation in WebSockets	0	
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	0	
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	0	
+1390	Incomplete	Weak Authentication	0	
+1391	Incomplete	Use of Weak Credentials	0	
+1392	Incomplete	Use of Default Credentials	0	
+1393	Incomplete	Use of Default Password	0	
+1394	Incomplete	Use of Default Cryptographic Key	0	
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	0	

--- a/csaf-rs/assets/cwe/cwe_4.11_2023-04-27.csv
+++ b/csaf-rs/assets/cwe/cwe_4.11_2023-04-27.csv
@@ -1,958 +1,958 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Use of Weak Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Deprecated	DEPRECATED: Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Multiple Condition Expression	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Improper Isolation or Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Multiple Operations on Resource in Single-Operation Context	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Insufficient Technical Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Stable	Improper Prevention of Lock Bit Modification	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Stable	Improper Access Control for Register Interface	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Draft	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Stable	Improper Protection of Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Improper Access Control in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	0	
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1341	Incomplete	Multiple Releases of Same Resource or Handle	0	
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	0	
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	0	
+1385	Incomplete	Missing Origin Validation in WebSockets	0	
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	0	
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	0	
+1390	Incomplete	Weak Authentication	0	
+1391	Incomplete	Use of Weak Credentials	0	
+1392	Incomplete	Use of Default Credentials	0	
+1393	Incomplete	Use of Default Password	0	
+1394	Incomplete	Use of Default Cryptographic Key	0	
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	0	

--- a/csaf-rs/assets/cwe/cwe_4.12_2023-06-29.csv
+++ b/csaf-rs/assets/cwe/cwe_4.12_2023-06-29.csv
@@ -1,958 +1,958 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Allowed-with-Review
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Allowed-with-Review
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Allowed-with-Review
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Allowed
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Allowed
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Allowed
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Allowed-with-Review
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Allowed-with-Review
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Allowed
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed
+427	Draft	Uncontrolled Search Path Element	1	Allowed
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Allowed-with-Review
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Allowed-with-Review
+662	Draft	Improper Synchronization	1	Allowed-with-Review
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Allowed-with-Review
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Allowed-with-Review
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Allowed-with-Review
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Allowed-with-Review
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Allowed
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Allowed
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Allowed
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Allowed
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Allowed
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Allowed
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Allowed
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Allowed
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Allowed
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Allowed
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Allowed
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Allowed
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Allowed-with-Review
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Allowed
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Allowed
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Allowed
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Allowed
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Allowed
+1066	Incomplete	Missing Serialization Control Element	1	Allowed
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Allowed
+1069	Incomplete	Empty Exception Block	1	Allowed
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Allowed
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Allowed
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Allowed
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Allowed
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Allowed-with-Review
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Allowed-with-Review
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Allowed
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Allowed
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Allowed
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Allowed
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Allowed
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Allowed
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Allowed
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Allowed
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Allowed
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Allowed
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Allowed
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Allowed
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Allowed
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Allowed
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Allowed
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Allowed
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Allowed
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Allowed
+1110	Incomplete	Incomplete Design Documentation	1	Allowed
+1111	Incomplete	Incomplete I/O Documentation	1	Allowed
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Allowed
+1113	Incomplete	Inappropriate Comment Style	1	Allowed
+1114	Incomplete	Inappropriate Whitespace Style	1	Allowed
+1115	Incomplete	Source Code Element without Standard Prologue	1	Allowed
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Allowed
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Allowed
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Allowed
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Allowed
+1122	Incomplete	Excessive Halstead Complexity	1	Allowed
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Allowed
+1125	Incomplete	Excessive Attack Surface	1	Allowed
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Insecure Default Initialization of Resource	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Security Identifier	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review

--- a/csaf-rs/assets/cwe/cwe_4.13_2023-10-26.csv
+++ b/csaf-rs/assets/cwe/cwe_4.13_2023-10-26.csv
@@ -1,959 +1,959 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Allowed-with-Review
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Allowed-with-Review
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Allowed-with-Review
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Allowed
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Allowed
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Allowed
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Allowed-with-Review
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Allowed-with-Review
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Allowed
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed
+427	Draft	Uncontrolled Search Path Element	1	Allowed
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Allowed-with-Review
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Allowed-with-Review
+662	Draft	Improper Synchronization	1	Allowed-with-Review
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Allowed-with-Review
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Allowed-with-Review
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Allowed-with-Review
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Allowed-with-Review
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Allowed
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Allowed
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Allowed
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Allowed
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Allowed
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Allowed
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Allowed
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Allowed
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Allowed
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Allowed
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Allowed
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Allowed
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Allowed-with-Review
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Allowed
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Allowed
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Allowed
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Allowed
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Allowed
+1066	Incomplete	Missing Serialization Control Element	1	Allowed
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Allowed
+1069	Incomplete	Empty Exception Block	1	Allowed
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Allowed
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Allowed
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Allowed
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Allowed
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Allowed-with-Review
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Allowed-with-Review
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Allowed
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Allowed
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Allowed
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Allowed
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Allowed
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Allowed
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Allowed
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Allowed
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Allowed
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Allowed
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Allowed
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Allowed
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Allowed
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Allowed
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Allowed
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Allowed
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Allowed
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Allowed
+1110	Incomplete	Incomplete Design Documentation	1	Allowed
+1111	Incomplete	Incomplete I/O Documentation	1	Allowed
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Allowed
+1113	Incomplete	Inappropriate Comment Style	1	Allowed
+1114	Incomplete	Inappropriate Whitespace Style	1	Allowed
+1115	Incomplete	Source Code Element without Standard Prologue	1	Allowed
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Allowed
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Allowed
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Allowed
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Allowed
+1122	Incomplete	Excessive Halstead Complexity	1	Allowed
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Allowed
+1125	Incomplete	Excessive Attack Surface	1	Allowed
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Security Identifier	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review

--- a/csaf-rs/assets/cwe/cwe_4.14_2024-02-29.csv
+++ b/csaf-rs/assets/cwe/cwe_4.14_2024-02-29.csv
@@ -1,963 +1,963 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Allowed-with-Review
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Allowed
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed
+427	Draft	Uncontrolled Search Path Element	1	Allowed
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.15_2024-07-16.csv
+++ b/csaf-rs/assets/cwe/cwe_4.15_2024-07-16.csv
@@ -1,964 +1,964 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Incomplete	Improper Validation of Generative AI Output
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Allowed-with-Review
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Allowed
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed
+427	Draft	Uncontrolled Search Path Element	1	Allowed
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged

--- a/csaf-rs/assets/cwe/cwe_4.16_2024-11-19.csv
+++ b/csaf-rs/assets/cwe/cwe_4.16_2024-11-19.csv
@@ -1,965 +1,965 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Incomplete	Improper Validation of Generative AI Output
-1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed-with-Review
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Allowed-with-Review
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Allowed
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed
+427	Draft	Uncontrolled Search Path Element	1	Allowed
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged
+1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.17_2025-04-03.csv
+++ b/csaf-rs/assets/cwe/cwe_4.17_2025-04-03.csv
@@ -1,968 +1,968 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Incomplete	Improper Validation of Generative AI Output
-1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting
-1428	Incomplete	Reliance on HTTP instead of HTTPS
-1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface
-1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed-with-Review
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Discouraged
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Allowed
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed-with-Review
+427	Draft	Uncontrolled Search Path Element	1	Allowed-with-Review
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged
+1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting	1	Allowed
+1428	Incomplete	Reliance on HTTP instead of HTTPS	1	Allowed
+1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface	1	Allowed
+1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.18_2025-09-09.csv
+++ b/csaf-rs/assets/cwe/cwe_4.18_2025-09-09.csv
@@ -1,969 +1,969 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Incomplete	Improper Validation of Generative AI Output
-1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting
-1428	Incomplete	Reliance on HTTP instead of HTTPS
-1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface
-1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs
-1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed-with-Review
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Discouraged
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Discouraged
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed-with-Review
+427	Draft	Uncontrolled Search Path Element	1	Allowed-with-Review
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged
+1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting	1	Allowed
+1428	Incomplete	Reliance on HTTP instead of HTTPS	1	Allowed
+1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface	1	Allowed
+1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs	1	Allowed
+1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.19.1_2026-01-21.csv
+++ b/csaf-rs/assets/cwe/cwe_4.19.1_2026-01-21.csv
@@ -1,969 +1,969 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Source Code Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Incomplete	Improper Validation of Generative AI Output
-1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting
-1428	Incomplete	Reliance on HTTP instead of HTTPS
-1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface
-1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs
-1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed-with-Review
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed-with-Review
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Discouraged
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Discouraged
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed-with-Review
+427	Draft	Uncontrolled Search Path Element	1	Allowed-with-Review
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed-with-Review
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Source Code Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged
+1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting	1	Allowed
+1428	Incomplete	Reliance on HTTP instead of HTTPS	1	Allowed
+1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface	1	Allowed
+1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs	1	Allowed
+1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.19_2025-12-11.csv
+++ b/csaf-rs/assets/cwe/cwe_4.19_2025-12-11.csv
@@ -1,969 +1,969 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Source Code Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Initialization of a Resource with an Insecure Default
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Insufficiently Trustworthy Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
-1395	Incomplete	Dependency on Vulnerable Third-Party Component
-1419	Incomplete	Incorrect Initialization of Resource
-1420	Incomplete	Exposure of Sensitive Information during Transient Execution
-1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Incomplete	Improper Validation of Generative AI Output
-1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting
-1428	Incomplete	Reliance on HTTP instead of HTTPS
-1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface
-1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs
-1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed-with-Review
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed-with-Review
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Discouraged
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Discouraged
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed-with-Review
+427	Draft	Uncontrolled Search Path Element	1	Allowed-with-Review
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of GET Request Method With Sensitive Query Strings	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet 	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed-with-Review
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Prohibited
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Source Code Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged
+1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting	1	Allowed
+1428	Incomplete	Reliance on HTTP instead of HTTPS	1	Allowed
+1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface	1	Allowed
+1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs	1	Allowed
+1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.1_2020-06-25.csv
+++ b/csaf-rs/assets/cwe/cwe_4.1_2020-06-25.csv
@@ -1,898 +1,898 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Exposure of Sensitive Information Through Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information Uncleared in Resource Before Release for Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Required Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Draft	Improper Isolation of Shared Resources on System-on-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Draft	Exposed Chip Debug and or Test Interface With Insufficient Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Incomplete	Improper Implementation of Lock Protection Registers
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Risky Cryptographic Primitive
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Exposure of Security-Sensitive Fuse Values During Debug
-1244	Incomplete	Improper Authorization on Physical Debug and Test Interfaces
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Incomplete	Missing Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1256	Incomplete	Hardware Features Enable Physical Attacks from Software
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Sensitive Information Uncleared During Hardware Debug Flows
-1259	Incomplete	Improper Protection of Security Identifiers
-1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings
-1263	Incomplete	Insufficient Physical Protection Mechanism
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Agents Included in Control Policy are not Contained in Less-Privileged Policy
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Identifiers
-1271	Incomplete	Missing Known Value on Reset for Registers Holding Security Settings
-1272	Incomplete	Debug/Power State Transitions Leak Information
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Block Incorrectly Connected to Larger System
-1277	Incomplete	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Primitives used without Successful Self-Test
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)
-1282	Incomplete	Assumed-Immutable Data Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Exposure of Sensitive Information Through Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information Uncleared in Resource Before Release for Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Required Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Draft	Improper Isolation of Shared Resources on System-on-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Draft	Exposed Chip Debug and or Test Interface With Insufficient Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Incomplete	Improper Implementation of Lock Protection Registers	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Risky Cryptographic Primitive	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Exposure of Security-Sensitive Fuse Values During Debug	0	
+1244	Incomplete	Improper Authorization on Physical Debug and Test Interfaces	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Incomplete	Missing Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1256	Incomplete	Hardware Features Enable Physical Attacks from Software	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Sensitive Information Uncleared During Hardware Debug Flows	0	
+1259	Incomplete	Improper Protection of Security Identifiers	0	
+1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings	0	
+1263	Incomplete	Insufficient Physical Protection Mechanism	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Agents Included in Control Policy are not Contained in Less-Privileged Policy	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Identifiers	0	
+1271	Incomplete	Missing Known Value on Reset for Registers Holding Security Settings	0	
+1272	Incomplete	Debug/Power State Transitions Leak Information	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Block Incorrectly Connected to Larger System	0	
+1277	Incomplete	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Primitives used without Successful Self-Test	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)	0	
+1282	Incomplete	Assumed-Immutable Data Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	

--- a/csaf-rs/assets/cwe/cwe_4.20_2026-04-30.csv
+++ b/csaf-rs/assets/cwe/cwe_4.20_2026-04-30.csv
@@ -1,969 +1,969 @@
-5	J2EE Misconfiguration: Data Transmission Without Encryption
-6	J2EE Misconfiguration: Insufficient Session-ID Length
-7	J2EE Misconfiguration: Missing Custom Error Page
-8	J2EE Misconfiguration: Entity Bean Declared Remote
-9	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	ASP.NET Misconfiguration: Creating Debug Binary
-12	ASP.NET Misconfiguration: Missing Custom Error Page
-13	ASP.NET Misconfiguration: Password in Configuration File
-14	Compiler Removal of Code to Clear Buffers
-15	External Control of System or Configuration Setting
-20	Improper Input Validation
-22	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Relative Path Traversal
-24	Path Traversal: '../filedir'
-25	Path Traversal: '/../filedir'
-26	Path Traversal: '/dir/../filename'
-27	Path Traversal: 'dir/../../filename'
-28	Path Traversal: '..\filedir'
-29	Path Traversal: '\..\filename'
-30	Path Traversal: '\dir\..\filename'
-31	Path Traversal: 'dir\..\..\filename'
-32	Path Traversal: '...' (Triple Dot)
-33	Path Traversal: '....' (Multiple Dot)
-34	Path Traversal: '....//'
-35	Path Traversal: '.../...//'
-36	Absolute Path Traversal
-37	Path Traversal: '/absolute/pathname/here'
-38	Path Traversal: '\absolute\pathname\here'
-39	Path Traversal: 'C:dirname'
-40	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Improper Resolution of Path Equivalence
-42	Path Equivalence: 'filename.' (Trailing Dot)
-43	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Path Equivalence: 'file.name' (Internal Dot)
-45	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Path Equivalence: 'filename ' (Trailing Space)
-47	Path Equivalence: ' filename' (Leading Space)
-48	Path Equivalence: 'file name' (Internal Whitespace)
-49	Path Equivalence: 'filename/' (Trailing Slash)
-50	Path Equivalence: '//multiple/leading/slash'
-51	Path Equivalence: '/multiple//internal/slash'
-52	Path Equivalence: '/multiple/trailing/slash//'
-53	Path Equivalence: '\multiple\\internal\backslash'
-54	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Path Equivalence: '/./' (Single Dot Directory)
-56	Path Equivalence: 'filedir*' (Wildcard)
-57	Path Equivalence: 'fakedir/../realdir/filename'
-58	Path Equivalence: Windows 8.3 Filename
-59	Improper Link Resolution Before File Access ('Link Following')
-61	UNIX Symbolic Link (Symlink) Following
-62	UNIX Hard Link
-64	Windows Shortcut Following (.LNK)
-65	Windows Hard Link
-66	Improper Handling of File Names that Identify Virtual Resources
-67	Improper Handling of Windows Device Names
-69	Improper Handling of Windows ::DATA Alternate Data Stream
-71	DEPRECATED: Apple '.DS_Store'
-72	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	External Control of File Name or Path
-74	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Improper Neutralization of Equivalent Special Elements
-77	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Improper Neutralization of Script in an Error Message Web Page
-82	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Improper Neutralization of Script in Attributes in a Web Page
-84	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Doubled Character XSS Manipulations
-86	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Improper Neutralization of Alternate XSS Syntax
-88	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	XML Injection (aka Blind XPath Injection)
-92	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Improper Control of Generation of Code ('Code Injection')
-95	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Improper Control of Resource Identifiers ('Resource Injection')
-102	Struts: Duplicate Validation Forms
-103	Struts: Incomplete validate() Method Definition
-104	Struts: Form Bean Does Not Extend Validation Class
-105	Struts: Form Field Without Validator
-106	Struts: Plug-in Framework not in Use
-107	Struts: Unused Validation Form
-108	Struts: Unvalidated Action Form
-109	Struts: Validator Turned Off
-110	Struts: Validator Without Form Field
-111	Direct Use of Unsafe JNI
-112	Missing XML Validation
-113	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Process Control
-115	Misinterpretation of Input
-116	Improper Encoding or Escaping of Output
-117	Improper Output Neutralization for Logs
-118	Incorrect Access of Indexable Resource ('Range Error')
-119	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Stack-based Buffer Overflow
-122	Heap-based Buffer Overflow
-123	Write-what-where Condition
-124	Buffer Underwrite ('Buffer Underflow')
-125	Out-of-bounds Read
-126	Buffer Over-read
-127	Buffer Under-read
-128	Wrap-around Error
-129	Improper Validation of Array Index
-130	Improper Handling of Length Parameter Inconsistency
-131	Incorrect Calculation of Buffer Size
-132	DEPRECATED: Miscalculated Null Termination
-134	Use of Externally-Controlled Format String
-135	Incorrect Calculation of Multi-Byte String Length
-138	Improper Neutralization of Special Elements
-140	Improper Neutralization of Delimiters
-141	Improper Neutralization of Parameter/Argument Delimiters
-142	Improper Neutralization of Value Delimiters
-143	Improper Neutralization of Record Delimiters
-144	Improper Neutralization of Line Delimiters
-145	Improper Neutralization of Section Delimiters
-146	Improper Neutralization of Expression/Command Delimiters
-147	Improper Neutralization of Input Terminators
-148	Improper Neutralization of Input Leaders
-149	Improper Neutralization of Quoting Syntax
-150	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Improper Neutralization of Comment Delimiters
-152	Improper Neutralization of Macro Symbols
-153	Improper Neutralization of Substitution Characters
-154	Improper Neutralization of Variable Name Delimiters
-155	Improper Neutralization of Wildcards or Matching Symbols
-156	Improper Neutralization of Whitespace
-157	Failure to Sanitize Paired Delimiters
-158	Improper Neutralization of Null Byte or NUL Character
-159	Improper Handling of Invalid Use of Special Elements
-160	Improper Neutralization of Leading Special Elements
-161	Improper Neutralization of Multiple Leading Special Elements
-162	Improper Neutralization of Trailing Special Elements
-163	Improper Neutralization of Multiple Trailing Special Elements
-164	Improper Neutralization of Internal Special Elements
-165	Improper Neutralization of Multiple Internal Special Elements
-166	Improper Handling of Missing Special Element
-167	Improper Handling of Additional Special Element
-168	Improper Handling of Inconsistent Special Elements
-170	Improper Null Termination
-172	Encoding Error
-173	Improper Handling of Alternate Encoding
-174	Double Decoding of the Same Data
-175	Improper Handling of Mixed Encoding
-176	Improper Handling of Unicode Encoding
-177	Improper Handling of URL Encoding (Hex Encoding)
-178	Improper Handling of Case Sensitivity
-179	Incorrect Behavior Order: Early Validation
-180	Incorrect Behavior Order: Validate Before Canonicalize
-181	Incorrect Behavior Order: Validate Before Filter
-182	Collapse of Data into Unsafe Value
-183	Permissive List of Allowed Inputs
-184	Incomplete List of Disallowed Inputs
-185	Incorrect Regular Expression
-186	Overly Restrictive Regular Expression
-187	Partial String Comparison
-188	Reliance on Data/Memory Layout
-190	Integer Overflow or Wraparound
-191	Integer Underflow (Wrap or Wraparound)
-192	Integer Coercion Error
-193	Off-by-one Error
-194	Unexpected Sign Extension
-195	Signed to Unsigned Conversion Error
-196	Unsigned to Signed Conversion Error
-197	Numeric Truncation Error
-198	Use of Incorrect Byte Ordering
-200	Exposure of Sensitive Information to an Unauthorized Actor
-201	Insertion of Sensitive Information Into Sent Data
-202	Exposure of Sensitive Information Through Data Queries
-203	Observable Discrepancy
-204	Observable Response Discrepancy
-205	Observable Behavioral Discrepancy
-206	Observable Internal Behavioral Discrepancy
-207	Observable Behavioral Discrepancy With Equivalent Products
-208	Observable Timing Discrepancy
-209	Generation of Error Message Containing Sensitive Information
-210	Self-generated Error Message Containing Sensitive Information
-211	Externally-Generated Error Message Containing Sensitive Information
-212	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Exposure of Sensitive Information Due to Incompatible Policies
-214	Invocation of Process Using Visible Sensitive Information
-215	Insertion of Sensitive Information Into Debugging Code
-216	DEPRECATED: Containment Errors (Container Errors)
-217	DEPRECATED: Failure to Protect Stored Data from Modification
-218	DEPRECATED: Failure to provide confidentiality for stored data
-219	Storage of File with Sensitive Data Under Web Root
-220	Storage of File With Sensitive Data Under FTP Root
-221	Information Loss or Omission
-222	Truncation of Security-relevant Information
-223	Omission of Security-relevant Information
-224	Obscured Security-relevant Information by Alternate Name
-225	DEPRECATED: General Information Management Problems
-226	Sensitive Information in Resource Not Removed Before Reuse
-228	Improper Handling of Syntactically Invalid Structure
-229	Improper Handling of Values
-230	Improper Handling of Missing Values
-231	Improper Handling of Extra Values
-232	Improper Handling of Undefined Values
-233	Improper Handling of Parameters
-234	Failure to Handle Missing Parameter
-235	Improper Handling of Extra Parameters
-236	Improper Handling of Undefined Parameters
-237	Improper Handling of Structural Elements
-238	Improper Handling of Incomplete Structural Elements
-239	Failure to Handle Incomplete Element
-240	Improper Handling of Inconsistent Structural Elements
-241	Improper Handling of Unexpected Data Type
-242	Use of Inherently Dangerous Function
-243	Creation of chroot Jail Without Changing Working Directory
-244	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	J2EE Bad Practices: Direct Management of Connections
-246	J2EE Bad Practices: Direct Use of Sockets
-247	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Uncaught Exception
-249	DEPRECATED: Often Misused: Path Manipulation
-250	Execution with Unnecessary Privileges
-252	Unchecked Return Value
-253	Incorrect Check of Function Return Value
-256	Plaintext Storage of a Password
-257	Storing Passwords in a Recoverable Format
-258	Empty Password in Configuration File
-259	Use of Hard-coded Password
-260	Password in Configuration File
-261	Weak Encoding for Password
-262	Not Using Password Aging
-263	Password Aging with Long Expiration
-266	Incorrect Privilege Assignment
-267	Privilege Defined With Unsafe Actions
-268	Privilege Chaining
-269	Improper Privilege Management
-270	Privilege Context Switching Error
-271	Privilege Dropping / Lowering Errors
-272	Least Privilege Violation
-273	Improper Check for Dropped Privileges
-274	Improper Handling of Insufficient Privileges
-276	Incorrect Default Permissions
-277	Insecure Inherited Permissions
-278	Insecure Preserved Inherited Permissions
-279	Incorrect Execution-Assigned Permissions
-280	Improper Handling of Insufficient Permissions or Privileges
-281	Improper Preservation of Permissions
-282	Improper Ownership Management
-283	Unverified Ownership
-284	Improper Access Control
-285	Improper Authorization
-286	Incorrect User Management
-287	Improper Authentication
-288	Authentication Bypass Using an Alternate Path or Channel
-289	Authentication Bypass by Alternate Name
-290	Authentication Bypass by Spoofing
-291	Reliance on IP Address for Authentication
-292	DEPRECATED: Trusting Self-reported DNS Name
-293	Using Referer Field for Authentication
-294	Authentication Bypass by Capture-replay
-295	Improper Certificate Validation
-296	Improper Following of a Certificate's Chain of Trust
-297	Improper Validation of Certificate with Host Mismatch
-298	Improper Validation of Certificate Expiration
-299	Improper Check for Certificate Revocation
-300	Channel Accessible by Non-Endpoint
-301	Reflection Attack in an Authentication Protocol
-302	Authentication Bypass by Assumed-Immutable Data
-303	Incorrect Implementation of Authentication Algorithm
-304	Missing Critical Step in Authentication
-305	Authentication Bypass by Primary Weakness
-306	Missing Authentication for Critical Function
-307	Improper Restriction of Excessive Authentication Attempts
-308	Use of Single-factor Authentication
-309	Use of Password System for Primary Authentication
-311	Missing Encryption of Sensitive Data
-312	Cleartext Storage of Sensitive Information
-313	Cleartext Storage in a File or on Disk
-314	Cleartext Storage in the Registry
-315	Cleartext Storage of Sensitive Information in a Cookie
-316	Cleartext Storage of Sensitive Information in Memory
-317	Cleartext Storage of Sensitive Information in GUI
-318	Cleartext Storage of Sensitive Information in Executable
-319	Cleartext Transmission of Sensitive Information
-321	Use of Hard-coded Cryptographic Key
-322	Key Exchange without Entity Authentication
-323	Reusing a Nonce, Key Pair in Encryption
-324	Use of a Key Past its Expiration Date
-325	Missing Cryptographic Step
-326	Inadequate Encryption Strength
-327	Use of a Broken or Risky Cryptographic Algorithm
-328	Use of Weak Hash
-329	Generation of Predictable IV with CBC Mode
-330	Use of Insufficiently Random Values
-331	Insufficient Entropy
-332	Insufficient Entropy in PRNG
-333	Improper Handling of Insufficient Entropy in TRNG
-334	Small Space of Random Values
-335	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Small Seed Space in PRNG
-340	Generation of Predictable Numbers or Identifiers
-341	Predictable from Observable State
-342	Predictable Exact Value from Previous Values
-343	Predictable Value Range from Previous Values
-344	Use of Invariant Value in Dynamically Changing Context
-345	Insufficient Verification of Data Authenticity
-346	Origin Validation Error
-347	Improper Verification of Cryptographic Signature
-348	Use of Less Trusted Source
-349	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Insufficient Type Distinction
-352	Cross-Site Request Forgery (CSRF)
-353	Missing Support for Integrity Check
-354	Improper Validation of Integrity Check Value
-356	Product UI does not Warn User of Unsafe Actions
-357	Insufficient UI Warning of Dangerous Operations
-358	Improperly Implemented Security Check for Standard
-359	Exposure of Private Personal Information to an Unauthorized Actor
-360	Trust of System Event Data
-362	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Race Condition Enabling Link Following
-364	Signal Handler Race Condition
-365	DEPRECATED: Race Condition in Switch
-366	Race Condition within a Thread
-367	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Context Switching Race Condition
-369	Divide By Zero
-370	Missing Check for Certificate Revocation after Initial Check
-372	Incomplete Internal State Distinction
-373	DEPRECATED: State Synchronization Error
-374	Passing Mutable Objects to an Untrusted Method
-375	Returning a Mutable Object to an Untrusted Caller
-377	Insecure Temporary File
-378	Creation of Temporary File With Insecure Permissions
-379	Creation of Temporary File in Directory with Insecure Permissions
-382	J2EE Bad Practices: Use of System.exit()
-383	J2EE Bad Practices: Direct Use of Threads
-384	Session Fixation
-385	Covert Timing Channel
-386	Symbolic Name not Mapping to Correct Object
-390	Detection of Error Condition Without Action
-391	Unchecked Error Condition
-392	Missing Report of Error Condition
-393	Return of Wrong Status Code
-394	Unexpected Status Code or Return Value
-395	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Declaration of Catch for Generic Exception
-397	Declaration of Throws for Generic Exception
-400	Uncontrolled Resource Consumption
-401	Missing Release of Memory after Effective Lifetime
-402	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Improper Resource Shutdown or Release
-405	Asymmetric Resource Consumption (Amplification)
-406	Insufficient Control of Network Message Volume (Network Amplification)
-407	Inefficient Algorithmic Complexity
-408	Incorrect Behavior Order: Early Amplification
-409	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Insufficient Resource Pool
-412	Unrestricted Externally Accessible Lock
-413	Improper Resource Locking
-414	Missing Lock Check
-415	Double Free
-416	Use After Free
-419	Unprotected Primary Channel
-420	Unprotected Alternate Channel
-421	Race Condition During Access to Alternate Channel
-422	Unprotected Windows Messaging Channel ('Shatter')
-423	DEPRECATED: Proxied Trusted Channel
-424	Improper Protection of Alternate Path
-425	Direct Request ('Forced Browsing')
-426	Untrusted Search Path
-427	Uncontrolled Search Path Element
-428	Unquoted Search Path or Element
-430	Deployment of Wrong Handler
-431	Missing Handler
-432	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Unparsed Raw Web Content Delivery
-434	Unrestricted Upload of File with Dangerous Type
-435	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Interpretation Conflict
-437	Incomplete Model of Endpoint Features
-439	Behavioral Change in New Version or Environment
-440	Expected Behavior Violation
-441	Unintended Proxy or Intermediary ('Confused Deputy')
-443	DEPRECATED: HTTP response splitting
-444	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	UI Discrepancy for Security Feature
-447	Unimplemented or Unsupported Feature in UI
-448	Obsolete Feature in UI
-449	The UI Performs the Wrong Action
-450	Multiple Interpretations of UI Input
-451	User Interface (UI) Misrepresentation of Critical Information
-453	Insecure Default Variable Initialization
-454	External Initialization of Trusted Variables or Data Stores
-455	Non-exit on Failed Initialization
-456	Missing Initialization of a Variable
-457	Use of Uninitialized Variable
-458	DEPRECATED: Incorrect Initialization
-459	Incomplete Cleanup
-460	Improper Cleanup on Thrown Exception
-462	Duplicate Key in Associative List (Alist)
-463	Deletion of Data Structure Sentinel
-464	Addition of Data Structure Sentinel
-466	Return of Pointer Value Outside of Expected Range
-467	Use of sizeof() on a Pointer Type
-468	Incorrect Pointer Scaling
-469	Use of Pointer Subtraction to Determine Size
-470	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Modification of Assumed-Immutable Data (MAID)
-472	External Control of Assumed-Immutable Web Parameter
-473	PHP External Variable Modification
-474	Use of Function with Inconsistent Implementations
-475	Undefined Behavior for Input to API
-476	NULL Pointer Dereference
-477	Use of Obsolete Function
-478	Missing Default Case in Multiple Condition Expression
-479	Signal Handler Use of a Non-reentrant Function
-480	Use of Incorrect Operator
-481	Assigning instead of Comparing
-482	Comparing instead of Assigning
-483	Incorrect Block Delimitation
-484	Omitted Break Statement in Switch
-486	Comparison of Classes by Name
-487	Reliance on Package-level Scope
-488	Exposure of Data Element to Wrong Session
-489	Active Debug Code
-491	Public cloneable() Method Without Final ('Object Hijack')
-492	Use of Inner Class Containing Sensitive Data
-493	Critical Public Variable Without Final Modifier
-494	Download of Code Without Integrity Check
-495	Private Data Structure Returned From A Public Method
-496	Public Data Assigned to Private Array-Typed Field
-497	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Cloneable Class Containing Sensitive Information
-499	Serializable Class Containing Sensitive Data
-500	Public Static Field Not Marked Final
-501	Trust Boundary Violation
-502	Deserialization of Untrusted Data
-506	Embedded Malicious Code
-507	Trojan Horse
-508	Non-Replicating Malicious Code
-509	Replicating Malicious Code (Virus or Worm)
-510	Trapdoor
-511	Logic/Time Bomb
-512	Spyware
-514	Covert Channel
-515	Covert Storage Channel
-516	DEPRECATED: Covert Timing Channel
-520	.NET Misconfiguration: Use of Impersonation
-521	Weak Password Requirements
-522	Insufficiently Protected Credentials
-523	Unprotected Transport of Credentials
-524	Use of Cache Containing Sensitive Information
-525	Use of Web Browser Cache Containing Sensitive Information
-526	Cleartext Storage of Sensitive Information in an Environment Variable
-527	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Exposure of Backup File to an Unauthorized Control Sphere
-531	Inclusion of Sensitive Information in Test Code
-532	Insertion of Sensitive Information into Log File
-533	DEPRECATED: Information Exposure Through Server Log Files
-534	DEPRECATED: Information Exposure Through Debug Log Files
-535	Exposure of Information Through Shell Error Message
-536	Servlet Runtime Error Message Containing Sensitive Information
-537	Java Runtime Error Message Containing Sensitive Information
-538	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Use of Persistent Cookies Containing Sensitive Information
-540	Inclusion of Sensitive Information in Source Code
-541	Inclusion of Sensitive Information in an Include File
-542	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Missing Standardized Error Handling Mechanism
-545	DEPRECATED: Use of Dynamic Class Loading
-546	Suspicious Comment
-547	Use of Hard-coded, Security-relevant Constants
-548	Exposure of Information Through Directory Listing
-549	Missing Password Field Masking
-550	Server-generated Error Message Containing Sensitive Information
-551	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Files or Directories Accessible to External Parties
-553	Command Shell in Externally Accessible Directory
-554	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Use of getlogin() in Multithreaded Application
-560	Use of umask() with chmod-style Argument
-561	Dead Code
-562	Return of Stack Variable Address
-563	Assignment to Variable without Use
-564	SQL Injection: Hibernate
-565	Reliance on Cookies without Validation and Integrity Checking
-566	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	finalize() Method Without super.finalize()
-570	Expression is Always False
-571	Expression is Always True
-572	Call to Thread run() instead of start()
-573	Improper Following of Specification by Caller
-574	EJB Bad Practices: Use of Synchronization Primitives
-575	EJB Bad Practices: Use of AWT Swing
-576	EJB Bad Practices: Use of Java I/O
-577	EJB Bad Practices: Use of Sockets
-578	EJB Bad Practices: Use of Class Loader
-579	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	clone() Method Without super.clone()
-581	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Array Declared Public, Final, and Static
-583	finalize() Method Declared Public
-584	Return Inside Finally Block
-585	Empty Synchronized Block
-586	Explicit Call to Finalize()
-587	Assignment of a Fixed Address to a Pointer
-588	Attempt to Access Child of a Non-structure Pointer
-589	Call to Non-ubiquitous API
-590	Free of Memory not on the Heap
-591	Sensitive Data Storage in Improperly Locked Memory
-592	DEPRECATED: Authentication Bypass Issues
-593	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	J2EE Framework: Saving Unserializable Objects to Disk
-595	Comparison of Object References Instead of Object Contents
-596	DEPRECATED: Incorrect Semantic Object Comparison
-597	Use of Wrong Operator in String Comparison
-598	Use of HTTP Request With Sensitive Query String
-599	Missing Validation of OpenSSL Certificate
-600	Uncaught Exception in Servlet
-601	URL Redirection to Untrusted Site ('Open Redirect')
-602	Client-Side Enforcement of Server-Side Security
-603	Use of Client-Side Authentication
-605	Multiple Binds to the Same Port
-606	Unchecked Input for Loop Condition
-607	Public Static Final Field References Mutable Object
-608	Struts: Non-private Field in ActionForm Class
-609	Double-Checked Locking
-610	Externally Controlled Reference to a Resource in Another Sphere
-611	Improper Restriction of XML External Entity Reference
-612	Improper Authorization of Index Containing Sensitive Information
-613	Insufficient Session Expiration
-614	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete Identification of Uploaded File Variables (PHP)
-617	Reachable Assertion
-618	Exposed Unsafe ActiveX Method
-619	Dangling Database Cursor ('Cursor Injection')
-620	Unverified Password Change
-621	Variable Extraction Error
-622	Improper Validation of Function Hook Arguments
-623	Unsafe ActiveX Control Marked Safe For Scripting
-624	Executable Regular Expression Error
-625	Permissive Regular Expression
-626	Null Byte Interaction Error (Poison Null Byte)
-627	Dynamic Variable Evaluation
-628	Function Call with Incorrectly Specified Arguments
-636	Not Failing Securely ('Failing Open')
-637	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Not Using Complete Mediation
-639	Authorization Bypass Through User-Controlled Key
-640	Weak Password Recovery Mechanism for Forgotten Password
-641	Improper Restriction of Names for Files and Other Resources
-642	External Control of Critical State Data
-643	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Overly Restrictive Account Lockout Mechanism
-646	Reliance on File Name or Extension of Externally-Supplied File
-647	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incorrect Use of Privileged APIs
-649	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Trusting HTTP Permission Methods on the Server Side
-651	Exposure of WSDL File Containing Sensitive Information
-652	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Improper Isolation or Compartmentalization
-654	Reliance on a Single Factor in a Security Decision
-655	Insufficient Psychological Acceptability
-656	Reliance on Security Through Obscurity
-657	Violation of Secure Design Principles
-662	Improper Synchronization
-663	Use of a Non-reentrant Function in a Concurrent Context
-664	Improper Control of a Resource Through its Lifetime
-665	Improper Initialization
-666	Operation on Resource in Wrong Phase of Lifetime
-667	Improper Locking
-668	Exposure of Resource to Wrong Sphere
-669	Incorrect Resource Transfer Between Spheres
-670	Always-Incorrect Control Flow Implementation
-671	Lack of Administrator Control over Security
-672	Operation on a Resource after Expiration or Release
-673	External Influence of Sphere Definition
-674	Uncontrolled Recursion
-675	Multiple Operations on Resource in Single-Operation Context
-676	Use of Potentially Dangerous Function
-680	Integer Overflow to Buffer Overflow
-681	Incorrect Conversion between Numeric Types
-682	Incorrect Calculation
-683	Function Call With Incorrect Order of Arguments
-684	Incorrect Provision of Specified Functionality
-685	Function Call With Incorrect Number of Arguments
-686	Function Call With Incorrect Argument Type
-687	Function Call With Incorrectly Specified Argument Value
-688	Function Call With Incorrect Variable or Reference as Argument
-689	Permission Race Condition During Resource Copy
-690	Unchecked Return Value to NULL Pointer Dereference
-691	Insufficient Control Flow Management
-692	Incomplete Denylist to Cross-Site Scripting
-693	Protection Mechanism Failure
-694	Use of Multiple Resources with Duplicate Identifier
-695	Use of Low-Level Functionality
-696	Incorrect Behavior Order
-697	Incorrect Comparison
-698	Execution After Redirect (EAR)
-703	Improper Check or Handling of Exceptional Conditions
-704	Incorrect Type Conversion or Cast
-705	Incorrect Control Flow Scoping
-706	Use of Incorrectly-Resolved Name or Reference
-707	Improper Neutralization
-708	Incorrect Ownership Assignment
-710	Improper Adherence to Coding Standards
-732	Incorrect Permission Assignment for Critical Resource
-733	Compiler Optimization Removal or Modification of Security-critical Code
-749	Exposed Dangerous Method or Function
-754	Improper Check for Unusual or Exceptional Conditions
-755	Improper Handling of Exceptional Conditions
-756	Missing Custom Error Page
-757	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Use of a One-Way Hash without a Salt
-760	Use of a One-Way Hash with a Predictable Salt
-761	Free of Pointer not at Start of Buffer
-762	Mismatched Memory Management Routines
-763	Release of Invalid Pointer or Reference
-764	Multiple Locks of a Critical Resource
-765	Multiple Unlocks of a Critical Resource
-766	Critical Data Element Declared Public
-767	Access to Critical Private Variable via Public Method
-768	Incorrect Short Circuit Evaluation
-769	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Allocation of Resources Without Limits or Throttling
-771	Missing Reference to Active Allocated Resource
-772	Missing Release of Resource after Effective Lifetime
-773	Missing Reference to Active File Descriptor or Handle
-774	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Regular Expression without Anchors
-778	Insufficient Logging
-779	Logging of Excessive Data
-780	Use of RSA Algorithm without OAEP
-781	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Exposed IOCTL with Insufficient Access Control
-783	Operator Precedence Logic Error
-784	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Access of Memory Location Before Start of Buffer
-787	Out-of-bounds Write
-788	Access of Memory Location After End of Buffer
-789	Memory Allocation with Excessive Size Value
-790	Improper Filtering of Special Elements
-791	Incomplete Filtering of Special Elements
-792	Incomplete Filtering of One or More Instances of Special Elements
-793	Only Filtering One Instance of a Special Element
-794	Incomplete Filtering of Multiple Instances of Special Elements
-795	Only Filtering Special Elements at a Specified Location
-796	Only Filtering Special Elements Relative to a Marker
-797	Only Filtering Special Elements at an Absolute Position
-798	Use of Hard-coded Credentials
-799	Improper Control of Interaction Frequency
-804	Guessable CAPTCHA
-805	Buffer Access with Incorrect Length Value
-806	Buffer Access Using Size of Source Buffer
-807	Reliance on Untrusted Inputs in a Security Decision
-820	Missing Synchronization
-821	Incorrect Synchronization
-822	Untrusted Pointer Dereference
-823	Use of Out-of-range Pointer Offset
-824	Access of Uninitialized Pointer
-825	Expired Pointer Dereference
-826	Premature Release of Resource During Expected Lifetime
-827	Improper Control of Document Type Definition
-828	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Inclusion of Functionality from Untrusted Control Sphere
-830	Inclusion of Web Functionality from an Untrusted Source
-831	Signal Handler Function Associated with Multiple Signals
-832	Unlock of a Resource that is not Locked
-833	Deadlock
-834	Excessive Iteration
-835	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Use of Password Hash Instead of Password for Authentication
-837	Improper Enforcement of a Single, Unique Action
-838	Inappropriate Encoding for Output Context
-839	Numeric Range Comparison Without Minimum Check
-841	Improper Enforcement of Behavioral Workflow
-842	Placement of User into Incorrect Group
-843	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Missing Authorization
-863	Incorrect Authorization
-908	Use of Uninitialized Resource
-909	Missing Initialization of Resource
-910	Use of Expired File Descriptor
-911	Improper Update of Reference Count
-912	Hidden Functionality
-913	Improper Control of Dynamically-Managed Code Resources
-914	Improper Control of Dynamically-Identified Variables
-915	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Use of Password Hash With Insufficient Computational Effort
-917	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Server-Side Request Forgery (SSRF)
-920	Improper Restriction of Power Consumption
-921	Storage of Sensitive Data in a Mechanism without Access Control
-922	Insecure Storage of Sensitive Information
-923	Improper Restriction of Communication Channel to Intended Endpoints
-924	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Improper Verification of Intent by Broadcast Receiver
-926	Improper Export of Android Application Components
-927	Use of Implicit Intent for Sensitive Communication
-939	Improper Authorization in Handler for Custom URL Scheme
-940	Improper Verification of Source of a Communication Channel
-941	Incorrectly Specified Destination in a Communication Channel
-942	Permissive Cross-domain Security Policy with Untrusted Domains
-943	Improper Neutralization of Special Elements in Data Query Logic
-1004	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Improper Restriction of Rendered UI Layers or Frames
-1022	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete Comparison with Missing Factors
-1024	Comparison of Incompatible Types
-1025	Comparison Using Wrong Factors
-1037	Processor Optimization Removal or Modification of Security-critical Code
-1038	Insecure Automated Optimizations
-1039	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism
-1041	Use of Redundant Code
-1042	Static Member Data Element outside of a Singleton Class Element
-1043	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Creation of Immutable Text Using String Concatenation
-1047	Modules with Circular Dependencies
-1048	Invokable Control Element with Large Number of Outward Calls
-1049	Excessive Data Query Operations in a Large Data Table
-1050	Excessive Platform Resource Consumption within a Loop
-1051	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Excessive Use of Hard-Coded Literals in Initialization
-1053	Missing Documentation for Design
-1054	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Multiple Inheritance from Concrete Classes
-1056	Invokable Control Element with Variadic Parameters
-1057	Data Access Operations Outside of Expected Data Manager Component
-1058	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Insufficient Technical Documentation
-1060	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Insufficient Encapsulation
-1062	Parent Class with References to Child Class
-1063	Creation of Class Instance within a Static Code Block
-1064	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Missing Serialization Control Element
-1067	Excessive Execution of Sequential Searches of Data Resource
-1068	Inconsistency Between Implementation and Documented Design
-1069	Empty Exception Block
-1070	Serializable Data Element Containing non-Serializable Item Elements
-1071	Empty Code Block
-1072	Data Resource Access without Use of Connection Pooling
-1073	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Class with Excessively Deep Inheritance
-1075	Unconditional Control Flow Transfer outside of Switch Block
-1076	Insufficient Adherence to Expected Conventions
-1077	Floating Point Comparison with Incorrect Operator
-1078	Inappropriate Source Code Style or Formatting
-1079	Parent Class without Virtual Destructor Method
-1080	Source Code File with Excessive Number of Lines of Code
-1082	Class Instance Self Destruction Control Element
-1083	Data Access from Outside Expected Data Manager Component
-1084	Invokable Control Element with Excessive File or Data Access Operations
-1085	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Class with Excessive Number of Child Classes
-1087	Class with Virtual Method without a Virtual Destructor
-1088	Synchronous Access of Remote Resource without Timeout
-1089	Large Data Table with Excessive Number of Indices
-1090	Method Containing Access of a Member Element from Another Class
-1091	Use of Object without Invoking Destructor Method
-1092	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Excessively Complex Data Representation
-1094	Excessive Index Range Scan for a Data Resource
-1095	Loop Condition Value Update within the Loop
-1096	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Inconsistent Naming Conventions for Identifiers
-1100	Insufficient Isolation of System-Dependent Functions
-1101	Reliance on Runtime Component in Generated Code
-1102	Reliance on Machine-Dependent Data Representation
-1103	Use of Platform-Dependent Third Party Components
-1104	Use of Unmaintained Third Party Components
-1105	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Insufficient Use of Symbolic Constants
-1107	Insufficient Isolation of Symbolic Constant Definitions
-1108	Excessive Reliance on Global Variables
-1109	Use of Same Variable for Multiple Purposes
-1110	Incomplete Design Documentation
-1111	Incomplete I/O Documentation
-1112	Incomplete Documentation of Program Execution
-1113	Inappropriate Comment Style
-1114	Inappropriate Whitespace Style
-1115	Source Code Element without Standard Prologue
-1116	Inaccurate Source Code Comments
-1117	Callable with Insufficient Behavioral Summary
-1118	Insufficient Documentation of Error Handling Techniques
-1119	Excessive Use of Unconditional Branching
-1120	Excessive Code Complexity
-1121	Excessive McCabe Cyclomatic Complexity
-1122	Excessive Halstead Complexity
-1123	Excessive Use of Self-Modifying Code
-1124	Excessively Deep Nesting
-1125	Excessive Attack Surface
-1126	Declaration of Variable with Unnecessarily Wide Scope
-1127	Compilation with Insufficient Warnings or Errors
-1164	Irrelevant Code
-1173	Improper Use of Validation Framework
-1174	ASP.NET Misconfiguration: Improper Model Validation
-1176	Inefficient CPU Computation
-1177	Use of Prohibited Code
-1187	DEPRECATED: Use of Uninitialized Resource
-1188	Initialization of a Resource with an Insecure Default
-1189	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	DMA Device Enabled Too Early in Boot Phase
-1191	On-Chip Debug and Test Interface With Improper Access Control
-1192	Improper Identifier for IP Block used in System-On-Chip (SOC)
-1193	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Generation of Weak Initialization Vector (IV)
-1209	Failure to Disable Reserved Bits
-1220	Insufficient Granularity of Access Control
-1221	Incorrect Register Defaults or Module Parameters
-1222	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Race Condition for Write-Once Attributes
-1224	Improper Restriction of Write-Once Bit Fields
-1229	Creation of Emergent Resource
-1230	Exposure of Sensitive Information Through Metadata
-1231	Improper Prevention of Lock Bit Modification
-1232	Improper Lock Behavior After Power State Transition
-1233	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Improper Neutralization of Formula Elements in a CSV File
-1239	Improper Zeroization of Hardware Register
-1240	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Use of Predictable Algorithm in Random Number Generator
-1242	Inclusion of Undocumented Features or Chicken Bits
-1243	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Improper Protection Against Voltage and Clock Glitches
-1248	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Mirrored Regions with Different Values
-1252	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Incorrect Selection of Fuse Values
-1254	Incorrect Comparison Logic Granularity
-1255	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Improper Restriction of Software Interfaces to Hardware Features
-1257	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Improper Restriction of Security Token Assignment
-1260	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Improper Handling of Single Event Upsets
-1262	Improper Access Control for Register Interface
-1263	Improper Physical Access Control
-1264	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Policy Uses Obsolete Encoding
-1268	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Product Released in Non-Release Configuration
-1270	Generation of Incorrect Security Tokens
-1271	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Device Unlock Credential Sharing
-1274	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Sensitive Cookie with Improper SameSite Attribute
-1276	Hardware Child Block Incorrectly Connected to Parent System
-1277	Firmware Not Updateable
-1278	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Access Control Check Implemented After Asset is Accessed
-1281	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Assumed-Immutable Data is Stored in Writable Memory
-1283	Mutable Attestation or Measurement Reporting Data
-1284	Improper Validation of Specified Quantity in Input
-1285	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Improper Validation of Syntactic Correctness of Input
-1287	Improper Validation of Specified Type of Input
-1288	Improper Validation of Consistency within Input
-1289	Improper Validation of Unsafe Equivalence in Input
-1290	Incorrect Decoding of Security Identifiers
-1291	Public Key Re-Use for Signing both Debug and Production Code
-1292	Incorrect Conversion of Security Identifiers
-1293	Missing Source Correlation of Multiple Independent Data
-1294	Insecure Security Identifier Mechanism
-1295	Debug Messages Revealing Unnecessary Information
-1296	Incorrect Chaining or Granularity of Debug Components
-1297	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Hardware Logic Contains Race Conditions
-1299	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Improper Protection of Physical Side Channels
-1301	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)
-1303	Non-Transparent Sharing of Microarchitectural Resources
-1304	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Missing Ability to Patch ROM Code
-1311	Improper Translation of Security Attributes by Fabric Bridge
-1312	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Missing Write Protection for Parametric Data Values
-1315	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Improper Access Control in Fabric Bridge
-1318	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Improper Management of Sensitive Trace Data
-1324	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Improperly Controlled Sequential Memory Allocation
-1326	Missing Immutable Root of Trust in Hardware
-1327	Binding to an Unrestricted IP Address
-1328	Security Version Number Mutable to Older Versions
-1329	Reliance on Component That is Not Updateable
-1330	Remanent Data Readable after Memory Erase
-1331	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Improper Handling of Faults that Lead to Instruction Skips
-1333	Inefficient Regular Expression Complexity
-1334	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Incorrect Bitwise Shift of Integer
-1336	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Improper Protections Against Hardware Overheating
-1339	Insufficient Precision or Accuracy of a Real Number
-1341	Multiple Releases of Same Resource or Handle
-1342	Information Exposure through Microarchitectural State after Transient Execution
-1351	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Reliance on Insufficiently Trustworthy Component
-1384	Improper Handling of Physical or Environmental Conditions
-1385	Missing Origin Validation in WebSockets
-1386	Insecure Operation on Windows Junction / Mount Point
-1389	Incorrect Parsing of Numbers with Different Radices
-1390	Weak Authentication
-1391	Use of Weak Credentials
-1392	Use of Default Credentials
-1393	Use of Default Password
-1394	Use of Default Cryptographic Key
-1395	Dependency on Vulnerable Third-Party Component
-1419	Incorrect Initialization of Resource
-1420	Exposure of Sensitive Information during Transient Execution
-1421	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution
-1422	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution
-1423	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution
-1426	Improper Validation of Generative AI Output
-1427	Improper Neutralization of Input Used for LLM Prompting
-1428	Reliance on HTTP instead of HTTPS
-1429	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface
-1431	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs
-1434	Insecure Setting of Generative AI/ML Model Inference Parameters
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	1	Allowed
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	1	Allowed
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	1	Allowed
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	1	Allowed
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	1	Allowed
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	1	Allowed
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	1	Allowed
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	1	Allowed
+14	Draft	Compiler Removal of Code to Clear Buffers	1	Allowed
+15	Incomplete	External Control of System or Configuration Setting	1	Allowed
+20	Stable	Improper Input Validation	1	Discouraged
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	1	Allowed-with-Review
+23	Draft	Relative Path Traversal	1	Allowed
+24	Incomplete	Path Traversal: '../filedir'	1	Allowed
+25	Incomplete	Path Traversal: '/../filedir'	1	Allowed
+26	Draft	Path Traversal: '/dir/../filename'	1	Allowed
+27	Draft	Path Traversal: 'dir/../../filename'	1	Allowed
+28	Incomplete	Path Traversal: '..\filedir'	1	Allowed
+29	Incomplete	Path Traversal: '\..\filename'	1	Allowed
+30	Draft	Path Traversal: '\dir\..\filename'	1	Allowed
+31	Draft	Path Traversal: 'dir\..\..\filename'	1	Allowed
+32	Incomplete	Path Traversal: '...' (Triple Dot)	1	Allowed
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	1	Allowed
+34	Incomplete	Path Traversal: '....//'	1	Allowed
+35	Incomplete	Path Traversal: '.../...//'	1	Allowed
+36	Draft	Absolute Path Traversal	1	Allowed
+37	Draft	Path Traversal: '/absolute/pathname/here'	1	Allowed
+38	Draft	Path Traversal: '\absolute\pathname\here'	1	Allowed
+39	Draft	Path Traversal: 'C:dirname'	1	Allowed
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	1	Allowed
+41	Incomplete	Improper Resolution of Path Equivalence	1	Allowed
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	1	Allowed
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	1	Allowed
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	1	Allowed
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	1	Allowed
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	1	Allowed
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	1	Allowed
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	1	Allowed
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	1	Allowed
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	1	Allowed
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	1	Allowed
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	1	Allowed
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	1	Allowed
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	1	Allowed
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	1	Allowed
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	1	Allowed
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	1	Allowed
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	1	Allowed
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	1	Allowed
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	1	Allowed
+62	Incomplete	UNIX Hard Link	1	Allowed
+64	Incomplete	Windows Shortcut Following (.LNK)	1	Allowed
+65	Incomplete	Windows Hard Link	1	Allowed
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	1	Allowed
+67	Incomplete	Improper Handling of Windows Device Names	1	Allowed
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	1	Allowed
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	1	Prohibited
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	1	Allowed
+73	Draft	External Control of File Name or Path	1	Allowed
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	1	Discouraged
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	1	Discouraged
+76	Draft	Improper Neutralization of Equivalent Special Elements	1	Allowed
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	1	Allowed-with-Review
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	1	Allowed
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	1	Allowed
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	1	Allowed
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	1	Allowed
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	1	Allowed
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	1	Allowed
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	1	Allowed
+85	Draft	Doubled Character XSS Manipulations	1	Allowed
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	1	Allowed
+87	Draft	Improper Neutralization of Alternate XSS Syntax	1	Allowed
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	1	Allowed
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	1	Allowed
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	1	Allowed
+91	Draft	XML Injection (aka Blind XPath Injection)	1	Allowed-with-Review
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	1	Prohibited
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	1	Allowed
+94	Draft	Improper Control of Generation of Code ('Code Injection')	1	Allowed-with-Review
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	1	Allowed
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	1	Allowed
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	1	Allowed
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	1	Allowed
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	1	Allowed-with-Review
+102	Incomplete	Struts: Duplicate Validation Forms	1	Allowed
+103	Draft	Struts: Incomplete validate() Method Definition	1	Allowed
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	1	Allowed
+105	Draft	Struts: Form Field Without Validator	1	Allowed
+106	Draft	Struts: Plug-in Framework not in Use	1	Allowed
+107	Draft	Struts: Unused Validation Form	1	Allowed
+108	Incomplete	Struts: Unvalidated Action Form	1	Allowed
+109	Draft	Struts: Validator Turned Off	1	Allowed
+110	Draft	Struts: Validator Without Form Field	1	Allowed
+111	Draft	Direct Use of Unsafe JNI	1	Allowed
+112	Draft	Missing XML Validation	1	Allowed
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	1	Allowed
+114	Incomplete	Process Control	1	Discouraged
+115	Incomplete	Misinterpretation of Input	1	Allowed
+116	Draft	Improper Encoding or Escaping of Output	1	Allowed-with-Review
+117	Draft	Improper Output Neutralization for Logs	1	Allowed
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	1	Discouraged
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	1	Discouraged
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	1	Allowed-with-Review
+121	Draft	Stack-based Buffer Overflow	1	Allowed
+122	Draft	Heap-based Buffer Overflow	1	Allowed
+123	Draft	Write-what-where Condition	1	Allowed
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	1	Allowed
+125	Draft	Out-of-bounds Read	1	Allowed
+126	Draft	Buffer Over-read	1	Allowed
+127	Draft	Buffer Under-read	1	Allowed
+128	Incomplete	Wrap-around Error	1	Allowed
+129	Draft	Improper Validation of Array Index	1	Allowed
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	1	Allowed
+131	Draft	Incorrect Calculation of Buffer Size	1	Allowed
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	1	Prohibited
+134	Draft	Use of Externally-Controlled Format String	1	Allowed
+135	Draft	Incorrect Calculation of Multi-Byte String Length	1	Allowed
+138	Draft	Improper Neutralization of Special Elements	1	Discouraged
+140	Draft	Improper Neutralization of Delimiters	1	Allowed
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	1	Allowed
+142	Draft	Improper Neutralization of Value Delimiters	1	Allowed
+143	Draft	Improper Neutralization of Record Delimiters	1	Allowed
+144	Draft	Improper Neutralization of Line Delimiters	1	Allowed
+145	Incomplete	Improper Neutralization of Section Delimiters	1	Allowed
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	1	Allowed
+147	Draft	Improper Neutralization of Input Terminators	1	Allowed
+148	Draft	Improper Neutralization of Input Leaders	1	Allowed
+149	Draft	Improper Neutralization of Quoting Syntax	1	Allowed
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	1	Allowed
+151	Draft	Improper Neutralization of Comment Delimiters	1	Allowed
+152	Draft	Improper Neutralization of Macro Symbols	1	Allowed
+153	Draft	Improper Neutralization of Substitution Characters	1	Allowed
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	1	Allowed
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	1	Allowed
+156	Draft	Improper Neutralization of Whitespace	1	Allowed
+157	Draft	Failure to Sanitize Paired Delimiters	1	Allowed
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	1	Allowed
+159	Draft	Improper Handling of Invalid Use of Special Elements	1	Allowed-with-Review
+160	Incomplete	Improper Neutralization of Leading Special Elements	1	Allowed
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	1	Allowed
+162	Incomplete	Improper Neutralization of Trailing Special Elements	1	Allowed
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	1	Allowed
+164	Incomplete	Improper Neutralization of Internal Special Elements	1	Allowed
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	1	Allowed
+166	Draft	Improper Handling of Missing Special Element	1	Allowed
+167	Draft	Improper Handling of Additional Special Element	1	Allowed
+168	Draft	Improper Handling of Inconsistent Special Elements	1	Allowed
+170	Incomplete	Improper Null Termination	1	Allowed
+172	Draft	Encoding Error	1	Allowed-with-Review
+173	Draft	Improper Handling of Alternate Encoding	1	Allowed
+174	Draft	Double Decoding of the Same Data	1	Allowed
+175	Draft	Improper Handling of Mixed Encoding	1	Allowed
+176	Draft	Improper Handling of Unicode Encoding	1	Allowed
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	1	Allowed
+178	Incomplete	Improper Handling of Case Sensitivity	1	Allowed
+179	Incomplete	Incorrect Behavior Order: Early Validation	1	Allowed
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	1	Allowed
+181	Draft	Incorrect Behavior Order: Validate Before Filter	1	Allowed
+182	Draft	Collapse of Data into Unsafe Value	1	Allowed
+183	Draft	Permissive List of Allowed Inputs	1	Allowed
+184	Draft	Incomplete List of Disallowed Inputs	1	Allowed
+185	Draft	Incorrect Regular Expression	1	Allowed-with-Review
+186	Draft	Overly Restrictive Regular Expression	1	Allowed
+187	Incomplete	Partial String Comparison	1	Allowed
+188	Draft	Reliance on Data/Memory Layout	1	Allowed
+190	Stable	Integer Overflow or Wraparound	1	Allowed
+191	Draft	Integer Underflow (Wrap or Wraparound)	1	Allowed
+192	Incomplete	Integer Coercion Error	1	Allowed
+193	Draft	Off-by-one Error	1	Allowed
+194	Incomplete	Unexpected Sign Extension	1	Allowed
+195	Draft	Signed to Unsigned Conversion Error	1	Allowed
+196	Draft	Unsigned to Signed Conversion Error	1	Allowed
+197	Incomplete	Numeric Truncation Error	1	Allowed
+198	Draft	Use of Incorrect Byte Ordering	1	Allowed
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	1	Discouraged
+201	Draft	Insertion of Sensitive Information Into Sent Data	1	Allowed
+202	Draft	Exposure of Sensitive Information Through Data Queries	1	Allowed
+203	Incomplete	Observable Discrepancy	1	Allowed
+204	Incomplete	Observable Response Discrepancy	1	Allowed
+205	Incomplete	Observable Behavioral Discrepancy	1	Allowed
+206	Incomplete	Observable Internal Behavioral Discrepancy	1	Allowed
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	1	Allowed
+208	Incomplete	Observable Timing Discrepancy	1	Allowed
+209	Draft	Generation of Error Message Containing Sensitive Information	1	Allowed
+210	Draft	Self-generated Error Message Containing Sensitive Information	1	Allowed
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	1	Allowed
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	1	Allowed
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	1	Allowed
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	1	Allowed
+215	Draft	Insertion of Sensitive Information Into Debugging Code	1	Allowed
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	1	Prohibited
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	1	Prohibited
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	1	Prohibited
+219	Draft	Storage of File with Sensitive Data Under Web Root	1	Allowed
+220	Draft	Storage of File With Sensitive Data Under FTP Root	1	Allowed
+221	Incomplete	Information Loss or Omission	1	Allowed-with-Review
+222	Draft	Truncation of Security-relevant Information	1	Allowed
+223	Draft	Omission of Security-relevant Information	1	Allowed
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	1	Allowed
+225	Deprecated	DEPRECATED: General Information Management Problems	1	Prohibited
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	1	Allowed
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	1	Allowed-with-Review
+229	Incomplete	Improper Handling of Values	1	Allowed
+230	Draft	Improper Handling of Missing Values	1	Allowed
+231	Draft	Improper Handling of Extra Values	1	Allowed
+232	Draft	Improper Handling of Undefined Values	1	Allowed
+233	Incomplete	Improper Handling of Parameters	1	Allowed
+234	Incomplete	Failure to Handle Missing Parameter	1	Discouraged
+235	Draft	Improper Handling of Extra Parameters	1	Allowed
+236	Draft	Improper Handling of Undefined Parameters	1	Allowed
+237	Incomplete	Improper Handling of Structural Elements	1	Allowed
+238	Draft	Improper Handling of Incomplete Structural Elements	1	Allowed
+239	Draft	Failure to Handle Incomplete Element	1	Allowed
+240	Draft	Improper Handling of Inconsistent Structural Elements	1	Allowed
+241	Draft	Improper Handling of Unexpected Data Type	1	Allowed
+242	Draft	Use of Inherently Dangerous Function	1	Allowed
+243	Draft	Creation of chroot Jail Without Changing Working Directory	1	Allowed
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	1	Allowed
+245	Draft	J2EE Bad Practices: Direct Management of Connections	1	Allowed
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	1	Allowed
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	1	Prohibited
+248	Draft	Uncaught Exception	1	Allowed
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	1	Prohibited
+250	Draft	Execution with Unnecessary Privileges	1	Allowed
+252	Draft	Unchecked Return Value	1	Allowed
+253	Incomplete	Incorrect Check of Function Return Value	1	Allowed
+256	Incomplete	Plaintext Storage of a Password	1	Allowed
+257	Incomplete	Storing Passwords in a Recoverable Format	1	Allowed
+258	Incomplete	Empty Password in Configuration File	1	Allowed
+259	Draft	Use of Hard-coded Password	1	Allowed
+260	Incomplete	Password in Configuration File	1	Allowed
+261	Incomplete	Weak Encoding for Password	1	Allowed
+262	Draft	Not Using Password Aging	1	Allowed
+263	Draft	Password Aging with Long Expiration	1	Discouraged
+266	Draft	Incorrect Privilege Assignment	1	Allowed
+267	Incomplete	Privilege Defined With Unsafe Actions	1	Allowed
+268	Draft	Privilege Chaining	1	Allowed
+269	Draft	Improper Privilege Management	1	Discouraged
+270	Draft	Privilege Context Switching Error	1	Allowed
+271	Incomplete	Privilege Dropping / Lowering Errors	1	Allowed-with-Review
+272	Incomplete	Least Privilege Violation	1	Allowed
+273	Incomplete	Improper Check for Dropped Privileges	1	Allowed
+274	Draft	Improper Handling of Insufficient Privileges	1	Discouraged
+276	Draft	Incorrect Default Permissions	1	Allowed
+277	Draft	Insecure Inherited Permissions	1	Allowed
+278	Incomplete	Insecure Preserved Inherited Permissions	1	Allowed
+279	Draft	Incorrect Execution-Assigned Permissions	1	Allowed
+280	Draft	Improper Handling of Insufficient Permissions or Privileges	1	Allowed
+281	Draft	Improper Preservation of Permissions	1	Allowed
+282	Draft	Improper Ownership Management	1	Allowed-with-Review
+283	Draft	Unverified Ownership	1	Allowed
+284	Incomplete	Improper Access Control	1	Discouraged
+285	Draft	Improper Authorization	1	Discouraged
+286	Incomplete	Incorrect User Management	1	Allowed-with-Review
+287	Draft	Improper Authentication	1	Discouraged
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	1	Allowed
+289	Incomplete	Authentication Bypass by Alternate Name	1	Allowed
+290	Incomplete	Authentication Bypass by Spoofing	1	Allowed
+291	Incomplete	Reliance on IP Address for Authentication	1	Allowed
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	1	Prohibited
+293	Draft	Using Referer Field for Authentication	1	Allowed
+294	Incomplete	Authentication Bypass by Capture-replay	1	Allowed
+295	Draft	Improper Certificate Validation	1	Allowed
+296	Draft	Improper Following of a Certificate's Chain of Trust	1	Allowed
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	1	Allowed
+298	Draft	Improper Validation of Certificate Expiration	1	Allowed
+299	Draft	Improper Check for Certificate Revocation	1	Allowed
+300	Draft	Channel Accessible by Non-Endpoint	1	Discouraged
+301	Draft	Reflection Attack in an Authentication Protocol	1	Allowed
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	1	Allowed
+303	Draft	Incorrect Implementation of Authentication Algorithm	1	Allowed
+304	Draft	Missing Critical Step in Authentication	1	Allowed
+305	Draft	Authentication Bypass by Primary Weakness	1	Allowed
+306	Draft	Missing Authentication for Critical Function	1	Allowed
+307	Draft	Improper Restriction of Excessive Authentication Attempts	1	Allowed
+308	Draft	Use of Single-factor Authentication	1	Allowed
+309	Draft	Use of Password System for Primary Authentication	1	Allowed
+311	Draft	Missing Encryption of Sensitive Data	1	Discouraged
+312	Draft	Cleartext Storage of Sensitive Information	1	Allowed
+313	Draft	Cleartext Storage in a File or on Disk	1	Allowed
+314	Draft	Cleartext Storage in the Registry	1	Allowed
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	1	Allowed
+316	Draft	Cleartext Storage of Sensitive Information in Memory	1	Allowed
+317	Draft	Cleartext Storage of Sensitive Information in GUI	1	Allowed
+318	Draft	Cleartext Storage of Sensitive Information in Executable	1	Allowed
+319	Draft	Cleartext Transmission of Sensitive Information	1	Allowed
+321	Draft	Use of Hard-coded Cryptographic Key	1	Allowed
+322	Draft	Key Exchange without Entity Authentication	1	Allowed
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	1	Allowed
+324	Draft	Use of a Key Past its Expiration Date	1	Allowed
+325	Draft	Missing Cryptographic Step	1	Allowed
+326	Draft	Inadequate Encryption Strength	1	Allowed-with-Review
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	1	Allowed-with-Review
+328	Draft	Use of Weak Hash	1	Allowed
+329	Draft	Generation of Predictable IV with CBC Mode	1	Allowed
+330	Stable	Use of Insufficiently Random Values	1	Discouraged
+331	Draft	Insufficient Entropy	1	Allowed
+332	Draft	Insufficient Entropy in PRNG	1	Allowed
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	1	Allowed
+334	Draft	Small Space of Random Values	1	Allowed
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	1	Allowed
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	1	Allowed
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	1	Allowed
+339	Draft	Small Seed Space in PRNG	1	Allowed
+340	Incomplete	Generation of Predictable Numbers or Identifiers	1	Allowed-with-Review
+341	Draft	Predictable from Observable State	1	Allowed
+342	Draft	Predictable Exact Value from Previous Values	1	Allowed
+343	Draft	Predictable Value Range from Previous Values	1	Allowed
+344	Draft	Use of Invariant Value in Dynamically Changing Context	1	Allowed
+345	Draft	Insufficient Verification of Data Authenticity	1	Discouraged
+346	Draft	Origin Validation Error	1	Allowed-with-Review
+347	Draft	Improper Verification of Cryptographic Signature	1	Allowed
+348	Draft	Use of Less Trusted Source	1	Allowed
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	1	Allowed
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	1	Allowed
+351	Draft	Insufficient Type Distinction	1	Allowed
+352	Stable	Cross-Site Request Forgery (CSRF)	1	Allowed
+353	Draft	Missing Support for Integrity Check	1	Allowed
+354	Draft	Improper Validation of Integrity Check Value	1	Allowed
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	1	Allowed
+357	Draft	Insufficient UI Warning of Dangerous Operations	1	Allowed
+358	Draft	Improperly Implemented Security Check for Standard	1	Allowed
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	1	Allowed
+360	Incomplete	Trust of System Event Data	1	Allowed
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	1	Allowed-with-Review
+363	Draft	Race Condition Enabling Link Following	1	Allowed
+364	Incomplete	Signal Handler Race Condition	1	Allowed
+365	Deprecated	DEPRECATED: Race Condition in Switch	1	Prohibited
+366	Draft	Race Condition within a Thread	1	Allowed
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	1	Allowed
+368	Draft	Context Switching Race Condition	1	Allowed
+369	Draft	Divide By Zero	1	Allowed
+370	Draft	Missing Check for Certificate Revocation after Initial Check	1	Allowed
+372	Draft	Incomplete Internal State Distinction	1	Discouraged
+373	Deprecated	DEPRECATED: State Synchronization Error	1	Prohibited
+374	Draft	Passing Mutable Objects to an Untrusted Method	1	Allowed
+375	Draft	Returning a Mutable Object to an Untrusted Caller	1	Allowed
+377	Incomplete	Insecure Temporary File	1	Allowed-with-Review
+378	Draft	Creation of Temporary File With Insecure Permissions	1	Allowed
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	1	Allowed
+382	Draft	J2EE Bad Practices: Use of System.exit()	1	Allowed
+383	Draft	J2EE Bad Practices: Direct Use of Threads	1	Allowed
+384	Incomplete	Session Fixation	1	Allowed
+385	Incomplete	Covert Timing Channel	1	Allowed
+386	Draft	Symbolic Name not Mapping to Correct Object	1	Allowed
+390	Draft	Detection of Error Condition Without Action	1	Allowed
+391	Incomplete	Unchecked Error Condition	1	Prohibited
+392	Draft	Missing Report of Error Condition	1	Allowed
+393	Draft	Return of Wrong Status Code	1	Allowed
+394	Draft	Unexpected Status Code or Return Value	1	Allowed
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	1	Allowed
+396	Draft	Declaration of Catch for Generic Exception	1	Allowed
+397	Draft	Declaration of Throws for Generic Exception	1	Allowed
+400	Draft	Uncontrolled Resource Consumption	1	Discouraged
+401	Draft	Missing Release of Memory after Effective Lifetime	1	Allowed
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	1	Allowed-with-Review
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	1	Allowed
+404	Draft	Improper Resource Shutdown or Release	1	Allowed-with-Review
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	1	Allowed-with-Review
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	1	Allowed-with-Review
+407	Incomplete	Inefficient Algorithmic Complexity	1	Allowed-with-Review
+408	Draft	Incorrect Behavior Order: Early Amplification	1	Allowed
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	1	Allowed
+410	Incomplete	Insufficient Resource Pool	1	Allowed
+412	Incomplete	Unrestricted Externally Accessible Lock	1	Allowed
+413	Draft	Improper Resource Locking	1	Allowed
+414	Draft	Missing Lock Check	1	Allowed
+415	Draft	Double Free	1	Allowed
+416	Stable	Use After Free	1	Allowed
+419	Draft	Unprotected Primary Channel	1	Allowed
+420	Draft	Unprotected Alternate Channel	1	Allowed
+421	Draft	Race Condition During Access to Alternate Channel	1	Allowed
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	1	Allowed
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	1	Prohibited
+424	Draft	Improper Protection of Alternate Path	1	Allowed-with-Review
+425	Incomplete	Direct Request ('Forced Browsing')	1	Allowed
+426	Stable	Untrusted Search Path	1	Allowed-with-Review
+427	Draft	Uncontrolled Search Path Element	1	Allowed-with-Review
+428	Draft	Unquoted Search Path or Element	1	Allowed
+430	Incomplete	Deployment of Wrong Handler	1	Allowed
+431	Draft	Missing Handler	1	Allowed
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	1	Allowed
+433	Incomplete	Unparsed Raw Web Content Delivery	1	Allowed
+434	Draft	Unrestricted Upload of File with Dangerous Type	1	Allowed
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	1	Discouraged
+436	Incomplete	Interpretation Conflict	1	Allowed-with-Review
+437	Incomplete	Incomplete Model of Endpoint Features	1	Allowed
+439	Draft	Behavioral Change in New Version or Environment	1	Allowed
+440	Draft	Expected Behavior Violation	1	Allowed
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	1	Allowed-with-Review
+443	Deprecated	DEPRECATED: HTTP response splitting	1	Prohibited
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	1	Allowed
+446	Incomplete	UI Discrepancy for Security Feature	1	Allowed-with-Review
+447	Draft	Unimplemented or Unsupported Feature in UI	1	Allowed
+448	Draft	Obsolete Feature in UI	1	Allowed
+449	Incomplete	The UI Performs the Wrong Action	1	Allowed
+450	Draft	Multiple Interpretations of UI Input	1	Allowed
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	1	Allowed-with-Review
+453	Draft	Insecure Default Variable Initialization	1	Allowed
+454	Draft	External Initialization of Trusted Variables or Data Stores	1	Allowed
+455	Draft	Non-exit on Failed Initialization	1	Allowed
+456	Draft	Missing Initialization of a Variable	1	Allowed
+457	Draft	Use of Uninitialized Variable	1	Allowed
+458	Deprecated	DEPRECATED: Incorrect Initialization	1	Prohibited
+459	Draft	Incomplete Cleanup	1	Allowed
+460	Draft	Improper Cleanup on Thrown Exception	1	Allowed
+462	Incomplete	Duplicate Key in Associative List (Alist)	1	Allowed
+463	Incomplete	Deletion of Data Structure Sentinel	1	Allowed
+464	Incomplete	Addition of Data Structure Sentinel	1	Allowed
+466	Draft	Return of Pointer Value Outside of Expected Range	1	Allowed
+467	Draft	Use of sizeof() on a Pointer Type	1	Allowed
+468	Incomplete	Incorrect Pointer Scaling	1	Allowed
+469	Draft	Use of Pointer Subtraction to Determine Size	1	Allowed
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	1	Allowed
+471	Draft	Modification of Assumed-Immutable Data (MAID)	1	Allowed
+472	Draft	External Control of Assumed-Immutable Web Parameter	1	Allowed
+473	Draft	PHP External Variable Modification	1	Allowed
+474	Draft	Use of Function with Inconsistent Implementations	1	Allowed
+475	Incomplete	Undefined Behavior for Input to API	1	Allowed
+476	Stable	NULL Pointer Dereference	1	Allowed
+477	Draft	Use of Obsolete Function	1	Allowed
+478	Draft	Missing Default Case in Multiple Condition Expression	1	Allowed
+479	Draft	Signal Handler Use of a Non-reentrant Function	1	Allowed
+480	Draft	Use of Incorrect Operator	1	Allowed
+481	Draft	Assigning instead of Comparing	1	Allowed
+482	Draft	Comparing instead of Assigning	1	Allowed
+483	Draft	Incorrect Block Delimitation	1	Allowed
+484	Draft	Omitted Break Statement in Switch	1	Allowed
+486	Draft	Comparison of Classes by Name	1	Allowed
+487	Incomplete	Reliance on Package-level Scope	1	Allowed
+488	Draft	Exposure of Data Element to Wrong Session	1	Allowed
+489	Draft	Active Debug Code	1	Allowed
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	1	Allowed
+492	Draft	Use of Inner Class Containing Sensitive Data	1	Allowed
+493	Draft	Critical Public Variable Without Final Modifier	1	Allowed
+494	Draft	Download of Code Without Integrity Check	1	Allowed
+495	Draft	Private Data Structure Returned From A Public Method	1	Allowed
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	1	Allowed
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	1	Allowed
+498	Draft	Cloneable Class Containing Sensitive Information	1	Allowed
+499	Draft	Serializable Class Containing Sensitive Data	1	Allowed
+500	Draft	Public Static Field Not Marked Final	1	Allowed
+501	Draft	Trust Boundary Violation	1	Allowed
+502	Draft	Deserialization of Untrusted Data	1	Allowed
+506	Incomplete	Embedded Malicious Code	1	Allowed-with-Review
+507	Incomplete	Trojan Horse	1	Allowed
+508	Incomplete	Non-Replicating Malicious Code	1	Allowed
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	1	Allowed
+510	Incomplete	Trapdoor	1	Allowed
+511	Incomplete	Logic/Time Bomb	1	Allowed
+512	Incomplete	Spyware	1	Allowed
+514	Incomplete	Covert Channel	1	Allowed-with-Review
+515	Incomplete	Covert Storage Channel	1	Allowed
+516	Deprecated	DEPRECATED: Covert Timing Channel	1	Prohibited
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	1	Allowed
+521	Draft	Weak Password Requirements	1	Allowed
+522	Incomplete	Insufficiently Protected Credentials	1	Allowed-with-Review
+523	Incomplete	Unprotected Transport of Credentials	1	Allowed
+524	Incomplete	Use of Cache Containing Sensitive Information	1	Allowed
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	1	Allowed
+526	Incomplete	Cleartext Storage of Sensitive Information in an Environment Variable	1	Allowed
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	1	Allowed
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	1	Allowed
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	1	Allowed
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	1	Allowed
+531	Incomplete	Inclusion of Sensitive Information in Test Code	1	Allowed
+532	Incomplete	Insertion of Sensitive Information into Log File	1	Allowed
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	1	Prohibited
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	1	Prohibited
+535	Incomplete	Exposure of Information Through Shell Error Message	1	Allowed
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	1	Allowed
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	1	Allowed
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	1	Allowed
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	1	Allowed
+540	Incomplete	Inclusion of Sensitive Information in Source Code	1	Allowed
+541	Incomplete	Inclusion of Sensitive Information in an Include File	1	Allowed
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	1	Prohibited
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	1	Allowed
+544	Draft	Missing Standardized Error Handling Mechanism	1	Allowed
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	1	Prohibited
+546	Draft	Suspicious Comment	1	Allowed
+547	Draft	Use of Hard-coded, Security-relevant Constants	1	Allowed
+548	Draft	Exposure of Information Through Directory Listing	1	Allowed
+549	Draft	Missing Password Field Masking	1	Allowed
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	1	Allowed
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	1	Allowed
+552	Draft	Files or Directories Accessible to External Parties	1	Allowed
+553	Incomplete	Command Shell in Externally Accessible Directory	1	Allowed
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	1	Allowed
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	1	Allowed
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	1	Allowed
+558	Draft	Use of getlogin() in Multithreaded Application	1	Allowed
+560	Draft	Use of umask() with chmod-style Argument	1	Allowed
+561	Draft	Dead Code	1	Allowed
+562	Draft	Return of Stack Variable Address	1	Allowed
+563	Draft	Assignment to Variable without Use	1	Allowed
+564	Incomplete	SQL Injection: Hibernate	1	Allowed
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	1	Allowed
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	1	Allowed
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	1	Allowed
+568	Draft	finalize() Method Without super.finalize()	1	Allowed
+570	Draft	Expression is Always False	1	Allowed
+571	Draft	Expression is Always True	1	Allowed
+572	Draft	Call to Thread run() instead of start()	1	Allowed
+573	Draft	Improper Following of Specification by Caller	1	Allowed-with-Review
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	1	Allowed
+575	Draft	EJB Bad Practices: Use of AWT Swing	1	Allowed
+576	Draft	EJB Bad Practices: Use of Java I/O	1	Allowed
+577	Draft	EJB Bad Practices: Use of Sockets	1	Allowed
+578	Draft	EJB Bad Practices: Use of Class Loader	1	Allowed
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	1	Allowed
+580	Draft	clone() Method Without super.clone()	1	Allowed
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	1	Allowed
+582	Draft	Array Declared Public, Final, and Static	1	Allowed
+583	Incomplete	finalize() Method Declared Public	1	Allowed
+584	Draft	Return Inside Finally Block	1	Allowed
+585	Draft	Empty Synchronized Block	1	Allowed
+586	Draft	Explicit Call to Finalize()	1	Allowed
+587	Draft	Assignment of a Fixed Address to a Pointer	1	Allowed
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	1	Allowed
+589	Incomplete	Call to Non-ubiquitous API	1	Allowed
+590	Incomplete	Free of Memory not on the Heap	1	Allowed
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	1	Allowed
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	1	Prohibited
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	1	Allowed
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	1	Allowed
+595	Incomplete	Comparison of Object References Instead of Object Contents	1	Allowed
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	1	Prohibited
+597	Draft	Use of Wrong Operator in String Comparison	1	Allowed
+598	Draft	Use of HTTP Request With Sensitive Query String	1	Allowed
+599	Incomplete	Missing Validation of OpenSSL Certificate	1	Allowed
+600	Draft	Uncaught Exception in Servlet	1	Allowed
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	1	Allowed
+602	Draft	Client-Side Enforcement of Server-Side Security	1	Allowed-with-Review
+603	Draft	Use of Client-Side Authentication	1	Allowed
+605	Draft	Multiple Binds to the Same Port	1	Allowed
+606	Draft	Unchecked Input for Loop Condition	1	Allowed
+607	Draft	Public Static Final Field References Mutable Object	1	Allowed
+608	Draft	Struts: Non-private Field in ActionForm Class	1	Allowed
+609	Draft	Double-Checked Locking	1	Allowed
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	1	Discouraged
+611	Draft	Improper Restriction of XML External Entity Reference	1	Allowed
+612	Draft	Improper Authorization of Index Containing Sensitive Information	1	Allowed
+613	Incomplete	Insufficient Session Expiration	1	Allowed-with-Review
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	1	Allowed
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	1	Allowed
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	1	Allowed
+617	Draft	Reachable Assertion	1	Allowed
+618	Incomplete	Exposed Unsafe ActiveX Method	1	Allowed
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	1	Allowed
+620	Draft	Unverified Password Change	1	Allowed
+621	Incomplete	Variable Extraction Error	1	Allowed
+622	Draft	Improper Validation of Function Hook Arguments	1	Allowed
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	1	Allowed
+624	Incomplete	Executable Regular Expression Error	1	Allowed
+625	Draft	Permissive Regular Expression	1	Allowed
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	1	Allowed
+627	Incomplete	Dynamic Variable Evaluation	1	Allowed
+628	Draft	Function Call with Incorrectly Specified Arguments	1	Allowed
+636	Draft	Not Failing Securely ('Failing Open')	1	Allowed-with-Review
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	1	Allowed-with-Review
+638	Draft	Not Using Complete Mediation	1	Allowed-with-Review
+639	Incomplete	Authorization Bypass Through User-Controlled Key	1	Allowed
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	1	Allowed-with-Review
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	1	Allowed
+642	Draft	External Control of Critical State Data	1	Allowed-with-Review
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	1	Allowed
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	1	Allowed
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	1	Allowed
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	1	Allowed
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	1	Allowed
+648	Incomplete	Incorrect Use of Privileged APIs	1	Allowed
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	1	Allowed
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	1	Allowed
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	1	Allowed
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	1	Allowed
+653	Draft	Improper Isolation or Compartmentalization	1	Allowed
+654	Draft	Reliance on a Single Factor in a Security Decision	1	Allowed
+655	Draft	Insufficient Psychological Acceptability	1	Allowed-with-Review
+656	Draft	Reliance on Security Through Obscurity	1	Allowed-with-Review
+657	Draft	Violation of Secure Design Principles	1	Discouraged
+662	Draft	Improper Synchronization	1	Discouraged
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	1	Allowed
+664	Draft	Improper Control of a Resource Through its Lifetime	1	Discouraged
+665	Draft	Improper Initialization	1	Discouraged
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	1	Discouraged
+667	Draft	Improper Locking	1	Allowed-with-Review
+668	Draft	Exposure of Resource to Wrong Sphere	1	Discouraged
+669	Draft	Incorrect Resource Transfer Between Spheres	1	Allowed-with-Review
+670	Draft	Always-Incorrect Control Flow Implementation	1	Allowed-with-Review
+671	Draft	Lack of Administrator Control over Security	1	Allowed-with-Review
+672	Draft	Operation on a Resource after Expiration or Release	1	Allowed-with-Review
+673	Draft	External Influence of Sphere Definition	1	Allowed-with-Review
+674	Draft	Uncontrolled Recursion	1	Allowed-with-Review
+675	Draft	Multiple Operations on Resource in Single-Operation Context	1	Allowed-with-Review
+676	Draft	Use of Potentially Dangerous Function	1	Allowed
+680	Draft	Integer Overflow to Buffer Overflow	1	Discouraged
+681	Draft	Incorrect Conversion between Numeric Types	1	Allowed
+682	Draft	Incorrect Calculation	1	Discouraged
+683	Draft	Function Call With Incorrect Order of Arguments	1	Allowed
+684	Draft	Incorrect Provision of Specified Functionality	1	Allowed-with-Review
+685	Draft	Function Call With Incorrect Number of Arguments	1	Allowed
+686	Draft	Function Call With Incorrect Argument Type	1	Allowed
+687	Draft	Function Call With Incorrectly Specified Argument Value	1	Allowed
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	1	Allowed
+689	Draft	Permission Race Condition During Resource Copy	1	Allowed
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	1	Discouraged
+691	Draft	Insufficient Control Flow Management	1	Discouraged
+692	Draft	Incomplete Denylist to Cross-Site Scripting	1	Discouraged
+693	Draft	Protection Mechanism Failure	1	Discouraged
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	1	Allowed
+695	Incomplete	Use of Low-Level Functionality	1	Allowed
+696	Incomplete	Incorrect Behavior Order	1	Allowed-with-Review
+697	Incomplete	Incorrect Comparison	1	Discouraged
+698	Incomplete	Execution After Redirect (EAR)	1	Allowed
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	1	Discouraged
+704	Incomplete	Incorrect Type Conversion or Cast	1	Allowed-with-Review
+705	Incomplete	Incorrect Control Flow Scoping	1	Allowed-with-Review
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	1	Allowed-with-Review
+707	Incomplete	Improper Neutralization	1	Discouraged
+708	Incomplete	Incorrect Ownership Assignment	1	Allowed
+710	Incomplete	Improper Adherence to Coding Standards	1	Discouraged
+732	Draft	Incorrect Permission Assignment for Critical Resource	1	Allowed-with-Review
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	1	Allowed
+749	Incomplete	Exposed Dangerous Method or Function	1	Allowed
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	1	Allowed-with-Review
+755	Incomplete	Improper Handling of Exceptional Conditions	1	Discouraged
+756	Incomplete	Missing Custom Error Page	1	Allowed
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	1	Allowed
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	1	Allowed-with-Review
+759	Incomplete	Use of a One-Way Hash without a Salt	1	Allowed
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	1	Allowed
+761	Incomplete	Free of Pointer not at Start of Buffer	1	Allowed
+762	Incomplete	Mismatched Memory Management Routines	1	Allowed
+763	Incomplete	Release of Invalid Pointer or Reference	1	Allowed
+764	Incomplete	Multiple Locks of a Critical Resource	1	Allowed
+765	Incomplete	Multiple Unlocks of a Critical Resource	1	Allowed
+766	Incomplete	Critical Data Element Declared Public	1	Allowed
+767	Incomplete	Access to Critical Private Variable via Public Method	1	Allowed
+768	Incomplete	Incorrect Short Circuit Evaluation	1	Allowed
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	1	Prohibited
+770	Incomplete	Allocation of Resources Without Limits or Throttling	1	Allowed
+771	Incomplete	Missing Reference to Active Allocated Resource	1	Allowed
+772	Draft	Missing Release of Resource after Effective Lifetime	1	Allowed
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	1	Allowed
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	1	Allowed
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	1	Allowed
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	1	Allowed
+777	Incomplete	Regular Expression without Anchors	1	Allowed
+778	Draft	Insufficient Logging	1	Allowed
+779	Draft	Logging of Excessive Data	1	Allowed
+780	Incomplete	Use of RSA Algorithm without OAEP	1	Allowed
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	1	Allowed
+782	Draft	Exposed IOCTL with Insufficient Access Control	1	Allowed
+783	Draft	Operator Precedence Logic Error	1	Allowed
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	1	Allowed
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	1	Allowed
+786	Incomplete	Access of Memory Location Before Start of Buffer	1	Discouraged
+787	Draft	Out-of-bounds Write	1	Allowed-with-Review
+788	Incomplete	Access of Memory Location After End of Buffer	1	Discouraged
+789	Draft	Memory Allocation with Excessive Size Value	1	Allowed
+790	Incomplete	Improper Filtering of Special Elements	1	Allowed-with-Review
+791	Incomplete	Incomplete Filtering of Special Elements	1	Allowed
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	1	Allowed
+793	Incomplete	Only Filtering One Instance of a Special Element	1	Allowed
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	1	Allowed
+795	Incomplete	Only Filtering Special Elements at a Specified Location	1	Allowed
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	1	Allowed
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	1	Allowed
+798	Draft	Use of Hard-coded Credentials	1	Allowed-with-Review
+799	Incomplete	Improper Control of Interaction Frequency	1	Allowed-with-Review
+804	Incomplete	Guessable CAPTCHA	1	Allowed
+805	Incomplete	Buffer Access with Incorrect Length Value	1	Allowed
+806	Incomplete	Buffer Access Using Size of Source Buffer	1	Allowed
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	1	Allowed
+820	Incomplete	Missing Synchronization	1	Allowed
+821	Incomplete	Incorrect Synchronization	1	Allowed
+822	Incomplete	Untrusted Pointer Dereference	1	Allowed
+823	Incomplete	Use of Out-of-range Pointer Offset	1	Allowed
+824	Incomplete	Access of Uninitialized Pointer	1	Allowed
+825	Incomplete	Expired Pointer Dereference	1	Allowed
+826	Incomplete	Premature Release of Resource During Expected Lifetime	1	Allowed
+827	Incomplete	Improper Control of Document Type Definition	1	Allowed
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	1	Allowed
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	1	Allowed
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	1	Allowed
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	1	Allowed
+832	Incomplete	Unlock of a Resource that is not Locked	1	Allowed
+833	Incomplete	Deadlock	1	Allowed
+834	Incomplete	Excessive Iteration	1	Discouraged
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	1	Allowed
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	1	Allowed
+837	Incomplete	Improper Enforcement of a Single, Unique Action	1	Allowed
+838	Incomplete	Inappropriate Encoding for Output Context	1	Allowed
+839	Incomplete	Numeric Range Comparison Without Minimum Check	1	Allowed
+841	Incomplete	Improper Enforcement of Behavioral Workflow	1	Allowed
+842	Incomplete	Placement of User into Incorrect Group	1	Allowed
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	1	Allowed
+862	Incomplete	Missing Authorization	1	Allowed-with-Review
+863	Incomplete	Incorrect Authorization	1	Allowed-with-Review
+908	Incomplete	Use of Uninitialized Resource	1	Allowed
+909	Incomplete	Missing Initialization of Resource	1	Allowed-with-Review
+910	Incomplete	Use of Expired File Descriptor	1	Allowed
+911	Incomplete	Improper Update of Reference Count	1	Allowed
+912	Incomplete	Hidden Functionality	1	Allowed-with-Review
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	1	Allowed-with-Review
+914	Incomplete	Improper Control of Dynamically-Identified Variables	1	Allowed
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	1	Allowed
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	1	Allowed
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	1	Allowed
+918	Incomplete	Server-Side Request Forgery (SSRF)	1	Allowed
+920	Incomplete	Improper Restriction of Power Consumption	1	Allowed
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	1	Allowed
+922	Incomplete	Insecure Storage of Sensitive Information	1	Allowed-with-Review
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	1	Allowed-with-Review
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	1	Allowed
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	1	Allowed
+926	Incomplete	Improper Export of Android Application Components	1	Allowed
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	1	Allowed
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	1	Allowed
+940	Incomplete	Improper Verification of Source of a Communication Channel	1	Allowed
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	1	Allowed
+942	Incomplete	Permissive Cross-domain Security Policy with Untrusted Domains	1	Allowed
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	1	Allowed-with-Review
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	1	Allowed
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	1	Allowed
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	1	Allowed
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	1	Allowed
+1023	Incomplete	Incomplete Comparison with Missing Factors	1	Allowed-with-Review
+1024	Incomplete	Comparison of Incompatible Types	1	Allowed
+1025	Incomplete	Comparison Using Wrong Factors	1	Allowed
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	1	Allowed
+1038	Draft	Insecure Automated Optimizations	1	Allowed-with-Review
+1039	Incomplete	Inadequate Detection or Handling of Adversarial Input Perturbations in Automated Recognition Mechanism	1	Allowed-with-Review
+1041	Incomplete	Use of Redundant Code	1	Prohibited
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	1	Prohibited
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	1	Prohibited
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	1	Prohibited
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	1	Allowed
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	1	Allowed
+1047	Incomplete	Modules with Circular Dependencies	1	Prohibited
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	1	Prohibited
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	1	Allowed
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	1	Allowed
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	1	Prohibited
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	1	Allowed
+1053	Incomplete	Missing Documentation for Design	1	Prohibited
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	1	Prohibited
+1055	Incomplete	Multiple Inheritance from Concrete Classes	1	Prohibited
+1056	Incomplete	Invokable Control Element with Variadic Parameters	1	Prohibited
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	1	Prohibited
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	1	Allowed
+1059	Incomplete	Insufficient Technical Documentation	1	Prohibited
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	1	Prohibited
+1061	Incomplete	Insufficient Encapsulation	1	Allowed-with-Review
+1062	Incomplete	Parent Class with References to Child Class	1	Prohibited
+1063	Incomplete	Creation of Class Instance within a Static Code Block	1	Prohibited
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	1	Prohibited
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	1	Prohibited
+1066	Incomplete	Missing Serialization Control Element	1	Prohibited
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	1	Allowed
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	1	Prohibited
+1069	Incomplete	Empty Exception Block	1	Allowed
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	1	Prohibited
+1071	Incomplete	Empty Code Block	1	Allowed
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	1	Prohibited
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	1	Prohibited
+1074	Incomplete	Class with Excessively Deep Inheritance	1	Prohibited
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	1	Allowed
+1076	Incomplete	Insufficient Adherence to Expected Conventions	1	Prohibited
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	1	Allowed
+1078	Incomplete	Inappropriate Source Code Style or Formatting	1	Prohibited
+1079	Incomplete	Parent Class without Virtual Destructor Method	1	Allowed
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	1	Prohibited
+1082	Incomplete	Class Instance Self Destruction Control Element	1	Prohibited
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	1	Prohibited
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	1	Prohibited
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	1	Prohibited
+1086	Incomplete	Class with Excessive Number of Child Classes	1	Prohibited
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	1	Allowed
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	1	Allowed
+1089	Incomplete	Large Data Table with Excessive Number of Indices	1	Allowed
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	1	Prohibited
+1091	Incomplete	Use of Object without Invoking Destructor Method	1	Allowed
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	1	Prohibited
+1093	Incomplete	Excessively Complex Data Representation	1	Allowed-with-Review
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	1	Prohibited
+1095	Incomplete	Loop Condition Value Update within the Loop	1	Prohibited
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	1	Allowed
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	1	Prohibited
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	1	Allowed
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	1	Prohibited
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	1	Allowed
+1101	Incomplete	Reliance on Runtime Component in Generated Code	1	Prohibited
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	1	Allowed
+1103	Incomplete	Use of Platform-Dependent Third Party Components	1	Prohibited
+1104	Incomplete	Use of Unmaintained Third Party Components	1	Allowed
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	1	Prohibited
+1106	Incomplete	Insufficient Use of Symbolic Constants	1	Prohibited
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	1	Prohibited
+1108	Incomplete	Excessive Reliance on Global Variables	1	Allowed
+1109	Incomplete	Use of Same Variable for Multiple Purposes	1	Prohibited
+1110	Incomplete	Incomplete Design Documentation	1	Prohibited
+1111	Incomplete	Incomplete I/O Documentation	1	Prohibited
+1112	Incomplete	Incomplete Documentation of Program Execution	1	Prohibited
+1113	Incomplete	Inappropriate Comment Style	1	Prohibited
+1114	Incomplete	Inappropriate Whitespace Style	1	Prohibited
+1115	Incomplete	Source Code Element without Standard Prologue	1	Prohibited
+1116	Incomplete	Inaccurate Source Code Comments	1	Allowed
+1117	Incomplete	Callable with Insufficient Behavioral Summary	1	Prohibited
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	1	Prohibited
+1119	Incomplete	Excessive Use of Unconditional Branching	1	Prohibited
+1120	Incomplete	Excessive Code Complexity	1	Allowed-with-Review
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	1	Prohibited
+1122	Incomplete	Excessive Halstead Complexity	1	Prohibited
+1123	Incomplete	Excessive Use of Self-Modifying Code	1	Allowed
+1124	Incomplete	Excessively Deep Nesting	1	Prohibited
+1125	Incomplete	Excessive Attack Surface	1	Prohibited
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	1	Allowed
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	1	Allowed
+1164	Incomplete	Irrelevant Code	1	Allowed-with-Review
+1173	Draft	Improper Use of Validation Framework	1	Allowed
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	1	Allowed
+1176	Incomplete	Inefficient CPU Computation	1	Allowed-with-Review
+1177	Incomplete	Use of Prohibited Code	1	Allowed-with-Review
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	1	Prohibited
+1188	Incomplete	Initialization of a Resource with an Insecure Default	1	Allowed
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	1	Allowed
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	1	Allowed
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	1	Allowed
+1192	Draft	Improper Identifier for IP Block used in System-On-Chip (SOC)	1	Allowed
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	1	Allowed
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	1	Allowed
+1209	Incomplete	Failure to Disable Reserved Bits	1	Allowed
+1220	Incomplete	Insufficient Granularity of Access Control	1	Allowed
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	1	Allowed
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	1	Allowed
+1223	Incomplete	Race Condition for Write-Once Attributes	1	Allowed
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	1	Allowed
+1229	Incomplete	Creation of Emergent Resource	1	Allowed-with-Review
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	1	Allowed
+1231	Stable	Improper Prevention of Lock Bit Modification	1	Allowed
+1232	Incomplete	Improper Lock Behavior After Power State Transition	1	Allowed
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	1	Allowed
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	1	Allowed
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	1	Allowed
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	1	Allowed
+1239	Draft	Improper Zeroization of Hardware Register	1	Allowed
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	1	Allowed
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	1	Allowed
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	1	Allowed
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	1	Allowed
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	1	Allowed
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	1	Allowed
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	1	Allowed
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	1	Allowed
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	1	Allowed
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	1	Allowed
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	1	Allowed
+1251	Incomplete	Mirrored Regions with Different Values	1	Allowed
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	1	Allowed
+1253	Draft	Incorrect Selection of Fuse Values	1	Allowed
+1254	Draft	Incorrect Comparison Logic Granularity	1	Allowed
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	1	Allowed
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	1	Allowed
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	1	Allowed
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	1	Allowed
+1259	Incomplete	Improper Restriction of Security Token Assignment	1	Allowed
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	1	Allowed
+1261	Draft	Improper Handling of Single Event Upsets	1	Allowed
+1262	Stable	Improper Access Control for Register Interface	1	Allowed
+1263	Incomplete	Improper Physical Access Control	1	Allowed-with-Review
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	1	Allowed
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	1	Allowed
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	1	Allowed
+1267	Draft	Policy Uses Obsolete Encoding	1	Allowed
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	1	Allowed
+1269	Incomplete	Product Released in Non-Release Configuration	1	Allowed
+1270	Incomplete	Generation of Incorrect Security Tokens	1	Allowed
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	1	Allowed
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	1	Allowed
+1273	Incomplete	Device Unlock Credential Sharing	1	Allowed
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	1	Allowed
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	1	Allowed
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	1	Allowed
+1277	Draft	Firmware Not Updateable	1	Allowed
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	1	Allowed
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	1	Allowed
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	1	Allowed
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	1	Allowed
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	1	Allowed
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	1	Allowed
+1284	Incomplete	Improper Validation of Specified Quantity in Input	1	Allowed
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	1	Allowed
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	1	Allowed
+1287	Incomplete	Improper Validation of Specified Type of Input	1	Allowed
+1288	Incomplete	Improper Validation of Consistency within Input	1	Allowed
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	1	Allowed
+1290	Incomplete	Incorrect Decoding of Security Identifiers	1	Allowed
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	1	Allowed
+1292	Draft	Incorrect Conversion of Security Identifiers	1	Allowed
+1293	Draft	Missing Source Correlation of Multiple Independent Data	1	Allowed
+1294	Incomplete	Insecure Security Identifier Mechanism	1	Allowed-with-Review
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	1	Allowed
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	1	Allowed
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	1	Allowed
+1298	Draft	Hardware Logic Contains Race Conditions	1	Allowed
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	1	Allowed
+1300	Stable	Improper Protection of Physical Side Channels	1	Allowed
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	1	Allowed
+1302	Incomplete	Missing Source Identifier in Entity Transactions on a System-On-Chip (SOC)	1	Allowed
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	1	Allowed
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	1	Allowed
+1310	Draft	Missing Ability to Patch ROM Code	1	Allowed
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	1	Allowed
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	1	Allowed
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	1	Allowed
+1314	Draft	Missing Write Protection for Parametric Data Values	1	Allowed
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	1	Allowed
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	1	Allowed
+1317	Draft	Improper Access Control in Fabric Bridge	1	Allowed
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	1	Allowed
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	1	Allowed
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	1	Allowed
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	1	Allowed
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	1	Allowed
+1323	Draft	Improper Management of Sensitive Trace Data	1	Allowed
+1324	Deprecated	DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface	1	Prohibited
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	1	Allowed
+1326	Draft	Missing Immutable Root of Trust in Hardware	1	Allowed
+1327	Incomplete	Binding to an Unrestricted IP Address	1	Allowed
+1328	Draft	Security Version Number Mutable to Older Versions	1	Allowed
+1329	Incomplete	Reliance on Component That is Not Updateable	1	Allowed
+1330	Draft	Remanent Data Readable after Memory Erase	1	Allowed
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	1	Allowed
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	1	Allowed
+1333	Draft	Inefficient Regular Expression Complexity	1	Allowed
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	1	Allowed
+1335	Draft	Incorrect Bitwise Shift of Integer	1	Allowed
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	1	Allowed
+1338	Draft	Improper Protections Against Hardware Overheating	1	Allowed
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	1	Allowed
+1341	Incomplete	Multiple Releases of Same Resource or Handle	1	Allowed
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	1	Allowed
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	1	Allowed
+1357	Incomplete	Reliance on Insufficiently Trustworthy Component	1	Allowed-with-Review
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	1	Allowed-with-Review
+1385	Incomplete	Missing Origin Validation in WebSockets	1	Allowed
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	1	Allowed
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	1	Allowed
+1390	Incomplete	Weak Authentication	1	Allowed-with-Review
+1391	Incomplete	Use of Weak Credentials	1	Allowed-with-Review
+1392	Incomplete	Use of Default Credentials	1	Allowed
+1393	Incomplete	Use of Default Password	1	Allowed
+1394	Incomplete	Use of Default Cryptographic Key	1	Allowed
+1395	Incomplete	Dependency on Vulnerable Third-Party Component	1	Allowed-with-Review
+1419	Incomplete	Incorrect Initialization of Resource	1	Allowed-with-Review
+1420	Incomplete	Exposure of Sensitive Information during Transient Execution	1	Allowed-with-Review
+1421	Incomplete	Exposure of Sensitive Information in Shared Microarchitectural Structures during Transient Execution	1	Allowed
+1422	Incomplete	Exposure of Sensitive Information caused by Incorrect Data Forwarding during Transient Execution	1	Allowed
+1423	Incomplete	Exposure of Sensitive Information caused by Shared Microarchitectural Predictor State that Influences Transient Execution	1	Allowed
+1426	Incomplete	Improper Validation of Generative AI Output	1	Discouraged
+1427	Incomplete	Improper Neutralization of Input Used for LLM Prompting	1	Allowed
+1428	Incomplete	Reliance on HTTP instead of HTTPS	1	Allowed
+1429	Incomplete	Missing Security-Relevant Feedback for Unexecuted Operations in Hardware Interface	1	Allowed
+1431	Incomplete	Driving Intermediate Cryptographic State/Results to Hardware Module Outputs	1	Allowed
+1434	Draft	Insecure Setting of Generative AI/ML Model Inference Parameters	1	Allowed

--- a/csaf-rs/assets/cwe/cwe_4.2_2020-08-20.csv
+++ b/csaf-rs/assets/cwe/cwe_4.2_2020-08-20.csv
@@ -1,914 +1,914 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Differences in Behavior to Error Inputs
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Uncontrolled Memory Allocation
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Incomplete	Improper Implementation of Lock Protection Registers
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Risky Cryptographic Primitive
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Incomplete	Hardware Features Enable Physical Attacks from Software
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Unitialized Value on Reset for Registers Holding Security Settings
-1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Incomplete	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Incomplete	Improper Protection Against Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Differences in Behavior to Error Inputs	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Uncontrolled Memory Allocation	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Incomplete	Improper Implementation of Lock Protection Registers	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Risky Cryptographic Primitive	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Incomplete	Hardware Features Enable Physical Attacks from Software	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Unitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Incomplete	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Incomplete	Improper Protection Against Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	

--- a/csaf-rs/assets/cwe/cwe_4.3_2020-12-10.csv
+++ b/csaf-rs/assets/cwe/cwe_4.3_2020-12-10.csv
@@ -1,939 +1,939 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using a Random IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Incomplete	Improper Implementation of Lock Protection Registers
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Risky Cryptographic Primitive
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Incomplete	Hardware Features Enable Physical Attacks from Software
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Unitialized Value on Reset for Registers Holding Security Settings
-1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Incomplete	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Incomplete	Improper Protection Against Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Missing Security Checks in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Draft	Improper Isolation of Shared Resources in Network On Chip
-1332	Incomplete	Insufficient Protection Against Instruction Skipping Via Fault Injection
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1338	Draft	Improper Protections Against Hardware Overheating
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using a Random IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Incomplete	Improper Implementation of Lock Protection Registers	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Risky Cryptographic Primitive	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Incomplete	Hardware Features Enable Physical Attacks from Software	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Unitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Incomplete	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Incomplete	Improper Protection Against Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Missing Security Checks in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Draft	Improper Isolation of Shared Resources in Network On Chip	0	
+1332	Incomplete	Insufficient Protection Against Instruction Skipping Via Fault Injection	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	

--- a/csaf-rs/assets/cwe/cwe_4.4_2021-03-15.csv
+++ b/csaf-rs/assets/cwe/cwe_4.4_2021-03-15.csv
@@ -1,941 +1,941 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Unprotected Storage of Credentials
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Not Using an Unpredictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Incomplete	Improper Implementation of Lock Protection Registers
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Risky Cryptographic Primitive
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Incomplete	Hardware Features Enable Physical Attacks from Software
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Incomplete	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Incomplete	Improper Protection Against Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Missing Security Checks in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Draft	Improper Isolation of Shared Resources in Network On Chip
-1332	Incomplete	Insufficient Protection Against Instruction Skipping Via Fault Injection
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1338	Draft	Improper Protections Against Hardware Overheating
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED (Duplicate): Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED (Duplicate): Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED (Duplicate): General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED (Duplicate): Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Unprotected Storage of Credentials	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED (Duplicate): Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Not Using an Unpredictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED (Duplicate): Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED (Duplicate): HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED (Duplicate): Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Incomplete	Improper Implementation of Lock Protection Registers	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Risky Cryptographic Primitive	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Incomplete	Hardware Features Enable Physical Attacks from Software	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Incomplete	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior (Halt and Catch Fire)	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Incomplete	Improper Protection Against Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Missing Security Checks in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Draft	Improper Isolation of Shared Resources in Network On Chip	0	
+1332	Incomplete	Insufficient Protection Against Instruction Skipping Via Fault Injection	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	

--- a/csaf-rs/assets/cwe/cwe_4.5_2021-07-20.csv
+++ b/csaf-rs/assets/cwe/cwe_4.5_2021-07-20.csv
@@ -1,945 +1,945 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Reversible One-Way Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Insufficient Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Duplicate Operations on Resource
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Incomplete	Improper Implementation of Lock Protection Registers
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Risky Cryptographic Primitive
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Incomplete	Hardware Features Enable Physical Attacks from Software
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Incomplete	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Incomplete	Improper Protection Against Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Missing Security Checks in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Draft	Improper Isolation of Shared Resources in Network On Chip
-1332	Incomplete	Insufficient Protection Against Instruction Skipping Via Fault Injection
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Reversible One-Way Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Insufficient Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Duplicate Operations on Resource	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Draft	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Draft	Exposed Chip Debug and Test Interface With Insufficient or Missing Authorization	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Incomplete	Improper Implementation of Lock Protection Registers	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Incomplete	Improper Hardware Lock Protection for Security Sensitive Controls	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Risky Cryptographic Primitive	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Incomplete	Improper Access to Sensitive Information Using Debug and Test Interfaces	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Incomplete	Missing or Improperly Implemented Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Incomplete	Hardware Features Enable Physical Attacks from Software	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Draft	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Incomplete	Register Interface Allows Software Access to Sensitive Data or Security Settings	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Incomplete	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Incomplete	Insufficient Protections on the Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Incomplete	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Incomplete	Improper Protection Against Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Missing Security Checks in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Draft	Improper Isolation of Shared Resources in Network On Chip	0	
+1332	Incomplete	Insufficient Protection Against Instruction Skipping Via Fault Injection	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	

--- a/csaf-rs/assets/cwe/cwe_4.6_2021-10-28.csv
+++ b/csaf-rs/assets/cwe/cwe_4.6_2021-10-28.csv
@@ -1,947 +1,947 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Draft	Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Incomplete Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Missing Security Checks in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Use of Weak Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Draft	Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Improper Isolation or Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Multiple Operations on Resource in Single-Operation Context	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Incomplete Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Stable	Improper Prevention of Lock Bit Modification	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Stable	Improper Access Control for Register Interface	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Draft	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Stable	Improper Protection of Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Missing Security Checks in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	0	
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1341	Incomplete	Multiple Releases of Same Resource or Handle	0	
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	

--- a/csaf-rs/assets/cwe/cwe_4.7_2022-04-28.csv
+++ b/csaf-rs/assets/cwe/cwe_4.7_2022-04-28.csv
@@ -1,950 +1,950 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Missing Security Checks in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Uncontrolled Component
-1384	Incomplete	Improper Handling of Extreme Physical Environment Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Use of Weak Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Deprecated	DEPRECATED: Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Improper Isolation or Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Multiple Operations on Resource in Single-Operation Context	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Insufficient Technical Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Stable	Improper Prevention of Lock Bit Modification	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Stable	Improper Access Control for Register Interface	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Draft	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Stable	Improper Protection of Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Missing Security Checks in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	0	
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1341	Incomplete	Multiple Releases of Same Resource or Handle	0	
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	
+1357	Incomplete	Reliance on Uncontrolled Component	0	
+1384	Incomplete	Improper Handling of Extreme Physical Environment Conditions	0	
+1385	Incomplete	Missing Origin Validation in WebSockets	0	

--- a/csaf-rs/assets/cwe/cwe_4.8_2022-06-28.csv
+++ b/csaf-rs/assets/cwe/cwe_4.8_2022-06-28.csv
@@ -1,951 +1,951 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Switch Statement
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Missing Security Checks in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Uncontrolled Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Use of Weak Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Deprecated	DEPRECATED: Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Switch Statement	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Improper Isolation or Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Multiple Operations on Resource in Single-Operation Context	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Insufficient Technical Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Stable	Improper Prevention of Lock Bit Modification	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Stable	Improper Access Control for Register Interface	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Draft	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Stable	Improper Protection of Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Missing Security Checks in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Out of Bounds Signal Level Alerts	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	0	
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1341	Incomplete	Multiple Releases of Same Resource or Handle	0	
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	
+1357	Incomplete	Reliance on Uncontrolled Component	0	
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	0	
+1385	Incomplete	Missing Origin Validation in WebSockets	0	
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	0	

--- a/csaf-rs/assets/cwe/cwe_4.9_2022-10-13.csv
+++ b/csaf-rs/assets/cwe/cwe_4.9_2022-10-13.csv
@@ -1,957 +1,957 @@
-5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption
-6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length
-7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page
-8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote
-9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods
-11	Draft	ASP.NET Misconfiguration: Creating Debug Binary
-12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page
-13	Draft	ASP.NET Misconfiguration: Password in Configuration File
-14	Draft	Compiler Removal of Code to Clear Buffers
-15	Incomplete	External Control of System or Configuration Setting
-20	Stable	Improper Input Validation
-22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-23	Draft	Relative Path Traversal
-24	Incomplete	Path Traversal: '../filedir'
-25	Incomplete	Path Traversal: '/../filedir'
-26	Draft	Path Traversal: '/dir/../filename'
-27	Draft	Path Traversal: 'dir/../../filename'
-28	Incomplete	Path Traversal: '..\filedir'
-29	Incomplete	Path Traversal: '\..\filename'
-30	Draft	Path Traversal: '\dir\..\filename'
-31	Draft	Path Traversal: 'dir\..\..\filename'
-32	Incomplete	Path Traversal: '...' (Triple Dot)
-33	Incomplete	Path Traversal: '....' (Multiple Dot)
-34	Incomplete	Path Traversal: '....//'
-35	Incomplete	Path Traversal: '.../...//'
-36	Draft	Absolute Path Traversal
-37	Draft	Path Traversal: '/absolute/pathname/here'
-38	Draft	Path Traversal: '\absolute\pathname\here'
-39	Draft	Path Traversal: 'C:dirname'
-40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)
-41	Incomplete	Improper Resolution of Path Equivalence
-42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)
-43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)
-44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)
-45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)
-46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)
-47	Incomplete	Path Equivalence: ' filename' (Leading Space)
-48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)
-49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)
-50	Incomplete	Path Equivalence: '//multiple/leading/slash'
-51	Incomplete	Path Equivalence: '/multiple//internal/slash'
-52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'
-53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'
-54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)
-55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)
-56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)
-57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'
-58	Incomplete	Path Equivalence: Windows 8.3 Filename
-59	Draft	Improper Link Resolution Before File Access ('Link Following')
-61	Incomplete	UNIX Symbolic Link (Symlink) Following
-62	Incomplete	UNIX Hard Link
-64	Incomplete	Windows Shortcut Following (.LNK)
-65	Incomplete	Windows Hard Link
-66	Draft	Improper Handling of File Names that Identify Virtual Resources
-67	Incomplete	Improper Handling of Windows Device Names
-69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream
-71	Deprecated	DEPRECATED: Apple '.DS_Store'
-72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path
-73	Draft	External Control of File Name or Path
-74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')
-75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)
-76	Draft	Improper Neutralization of Equivalent Special Elements
-77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')
-78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')
-79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)
-81	Incomplete	Improper Neutralization of Script in an Error Message Web Page
-82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page
-83	Draft	Improper Neutralization of Script in Attributes in a Web Page
-84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page
-85	Draft	Doubled Character XSS Manipulations
-86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages
-87	Draft	Improper Neutralization of Alternate XSS Syntax
-88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')
-89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')
-91	Draft	XML Injection (aka Blind XPath Injection)
-92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters
-93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')
-94	Draft	Improper Control of Generation of Code ('Code Injection')
-95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')
-96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')
-97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page
-98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')
-99	Draft	Improper Control of Resource Identifiers ('Resource Injection')
-102	Incomplete	Struts: Duplicate Validation Forms
-103	Draft	Struts: Incomplete validate() Method Definition
-104	Draft	Struts: Form Bean Does Not Extend Validation Class
-105	Draft	Struts: Form Field Without Validator
-106	Draft	Struts: Plug-in Framework not in Use
-107	Draft	Struts: Unused Validation Form
-108	Incomplete	Struts: Unvalidated Action Form
-109	Draft	Struts: Validator Turned Off
-110	Draft	Struts: Validator Without Form Field
-111	Draft	Direct Use of Unsafe JNI
-112	Draft	Missing XML Validation
-113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')
-114	Incomplete	Process Control
-115	Incomplete	Misinterpretation of Input
-116	Draft	Improper Encoding or Escaping of Output
-117	Draft	Improper Output Neutralization for Logs
-118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')
-119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer
-120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')
-121	Draft	Stack-based Buffer Overflow
-122	Draft	Heap-based Buffer Overflow
-123	Draft	Write-what-where Condition
-124	Incomplete	Buffer Underwrite ('Buffer Underflow')
-125	Draft	Out-of-bounds Read
-126	Draft	Buffer Over-read
-127	Draft	Buffer Under-read
-128	Incomplete	Wrap-around Error
-129	Draft	Improper Validation of Array Index
-130	Incomplete	Improper Handling of Length Parameter Inconsistency
-131	Draft	Incorrect Calculation of Buffer Size
-132	Deprecated	DEPRECATED: Miscalculated Null Termination
-134	Draft	Use of Externally-Controlled Format String
-135	Draft	Incorrect Calculation of Multi-Byte String Length
-138	Draft	Improper Neutralization of Special Elements
-140	Draft	Improper Neutralization of Delimiters
-141	Draft	Improper Neutralization of Parameter/Argument Delimiters
-142	Draft	Improper Neutralization of Value Delimiters
-143	Draft	Improper Neutralization of Record Delimiters
-144	Draft	Improper Neutralization of Line Delimiters
-145	Incomplete	Improper Neutralization of Section Delimiters
-146	Incomplete	Improper Neutralization of Expression/Command Delimiters
-147	Draft	Improper Neutralization of Input Terminators
-148	Draft	Improper Neutralization of Input Leaders
-149	Draft	Improper Neutralization of Quoting Syntax
-150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences
-151	Draft	Improper Neutralization of Comment Delimiters
-152	Draft	Improper Neutralization of Macro Symbols
-153	Draft	Improper Neutralization of Substitution Characters
-154	Incomplete	Improper Neutralization of Variable Name Delimiters
-155	Draft	Improper Neutralization of Wildcards or Matching Symbols
-156	Draft	Improper Neutralization of Whitespace
-157	Draft	Failure to Sanitize Paired Delimiters
-158	Incomplete	Improper Neutralization of Null Byte or NUL Character
-159	Draft	Improper Handling of Invalid Use of Special Elements
-160	Incomplete	Improper Neutralization of Leading Special Elements
-161	Incomplete	Improper Neutralization of Multiple Leading Special Elements
-162	Incomplete	Improper Neutralization of Trailing Special Elements
-163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements
-164	Incomplete	Improper Neutralization of Internal Special Elements
-165	Incomplete	Improper Neutralization of Multiple Internal Special Elements
-166	Draft	Improper Handling of Missing Special Element
-167	Draft	Improper Handling of Additional Special Element
-168	Draft	Improper Handling of Inconsistent Special Elements
-170	Incomplete	Improper Null Termination
-172	Draft	Encoding Error
-173	Draft	Improper Handling of Alternate Encoding
-174	Draft	Double Decoding of the Same Data
-175	Draft	Improper Handling of Mixed Encoding
-176	Draft	Improper Handling of Unicode Encoding
-177	Draft	Improper Handling of URL Encoding (Hex Encoding)
-178	Incomplete	Improper Handling of Case Sensitivity
-179	Incomplete	Incorrect Behavior Order: Early Validation
-180	Draft	Incorrect Behavior Order: Validate Before Canonicalize
-181	Draft	Incorrect Behavior Order: Validate Before Filter
-182	Draft	Collapse of Data into Unsafe Value
-183	Draft	Permissive List of Allowed Inputs
-184	Draft	Incomplete List of Disallowed Inputs
-185	Draft	Incorrect Regular Expression
-186	Draft	Overly Restrictive Regular Expression
-187	Incomplete	Partial String Comparison
-188	Draft	Reliance on Data/Memory Layout
-190	Stable	Integer Overflow or Wraparound
-191	Draft	Integer Underflow (Wrap or Wraparound)
-192	Incomplete	Integer Coercion Error
-193	Draft	Off-by-one Error
-194	Incomplete	Unexpected Sign Extension
-195	Draft	Signed to Unsigned Conversion Error
-196	Draft	Unsigned to Signed Conversion Error
-197	Incomplete	Numeric Truncation Error
-198	Draft	Use of Incorrect Byte Ordering
-200	Draft	Exposure of Sensitive Information to an Unauthorized Actor
-201	Draft	Insertion of Sensitive Information Into Sent Data
-202	Draft	Exposure of Sensitive Information Through Data Queries
-203	Incomplete	Observable Discrepancy
-204	Incomplete	Observable Response Discrepancy
-205	Incomplete	Observable Behavioral Discrepancy
-206	Incomplete	Observable Internal Behavioral Discrepancy
-207	Draft	Observable Behavioral Discrepancy With Equivalent Products
-208	Incomplete	Observable Timing Discrepancy
-209	Draft	Generation of Error Message Containing Sensitive Information
-210	Draft	Self-generated Error Message Containing Sensitive Information
-211	Incomplete	Externally-Generated Error Message Containing Sensitive Information
-212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer
-213	Draft	Exposure of Sensitive Information Due to Incompatible Policies
-214	Incomplete	Invocation of Process Using Visible Sensitive Information
-215	Draft	Insertion of Sensitive Information Into Debugging Code
-216	Deprecated	DEPRECATED: Containment Errors (Container Errors)
-217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification
-218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data
-219	Draft	Storage of File with Sensitive Data Under Web Root
-220	Draft	Storage of File With Sensitive Data Under FTP Root
-221	Incomplete	Information Loss or Omission
-222	Draft	Truncation of Security-relevant Information
-223	Draft	Omission of Security-relevant Information
-224	Incomplete	Obscured Security-relevant Information by Alternate Name
-225	Deprecated	DEPRECATED: General Information Management Problems
-226	Draft	Sensitive Information in Resource Not Removed Before Reuse
-228	Incomplete	Improper Handling of Syntactically Invalid Structure
-229	Incomplete	Improper Handling of Values
-230	Draft	Improper Handling of Missing Values
-231	Draft	Improper Handling of Extra Values
-232	Draft	Improper Handling of Undefined Values
-233	Incomplete	Improper Handling of Parameters
-234	Incomplete	Failure to Handle Missing Parameter
-235	Draft	Improper Handling of Extra Parameters
-236	Draft	Improper Handling of Undefined Parameters
-237	Incomplete	Improper Handling of Structural Elements
-238	Draft	Improper Handling of Incomplete Structural Elements
-239	Draft	Failure to Handle Incomplete Element
-240	Draft	Improper Handling of Inconsistent Structural Elements
-241	Draft	Improper Handling of Unexpected Data Type
-242	Draft	Use of Inherently Dangerous Function
-243	Draft	Creation of chroot Jail Without Changing Working Directory
-244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')
-245	Draft	J2EE Bad Practices: Direct Management of Connections
-246	Draft	J2EE Bad Practices: Direct Use of Sockets
-247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision
-248	Draft	Uncaught Exception
-249	Deprecated	DEPRECATED: Often Misused: Path Manipulation
-250	Draft	Execution with Unnecessary Privileges
-252	Draft	Unchecked Return Value
-253	Incomplete	Incorrect Check of Function Return Value
-256	Incomplete	Plaintext Storage of a Password
-257	Incomplete	Storing Passwords in a Recoverable Format
-258	Incomplete	Empty Password in Configuration File
-259	Draft	Use of Hard-coded Password
-260	Incomplete	Password in Configuration File
-261	Incomplete	Weak Encoding for Password
-262	Draft	Not Using Password Aging
-263	Draft	Password Aging with Long Expiration
-266	Draft	Incorrect Privilege Assignment
-267	Incomplete	Privilege Defined With Unsafe Actions
-268	Draft	Privilege Chaining
-269	Draft	Improper Privilege Management
-270	Draft	Privilege Context Switching Error
-271	Incomplete	Privilege Dropping / Lowering Errors
-272	Incomplete	Least Privilege Violation
-273	Incomplete	Improper Check for Dropped Privileges
-274	Draft	Improper Handling of Insufficient Privileges
-276	Draft	Incorrect Default Permissions
-277	Draft	Insecure Inherited Permissions
-278	Incomplete	Insecure Preserved Inherited Permissions
-279	Draft	Incorrect Execution-Assigned Permissions
-280	Draft	Improper Handling of Insufficient Permissions or Privileges 
-281	Draft	Improper Preservation of Permissions
-282	Draft	Improper Ownership Management
-283	Draft	Unverified Ownership
-284	Incomplete	Improper Access Control
-285	Draft	Improper Authorization
-286	Incomplete	Incorrect User Management
-287	Draft	Improper Authentication
-288	Incomplete	Authentication Bypass Using an Alternate Path or Channel
-289	Incomplete	Authentication Bypass by Alternate Name
-290	Incomplete	Authentication Bypass by Spoofing
-291	Incomplete	Reliance on IP Address for Authentication
-292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name
-293	Draft	Using Referer Field for Authentication
-294	Incomplete	Authentication Bypass by Capture-replay
-295	Draft	Improper Certificate Validation
-296	Draft	Improper Following of a Certificate's Chain of Trust
-297	Incomplete	Improper Validation of Certificate with Host Mismatch
-298	Draft	Improper Validation of Certificate Expiration
-299	Draft	Improper Check for Certificate Revocation
-300	Draft	Channel Accessible by Non-Endpoint
-301	Draft	Reflection Attack in an Authentication Protocol
-302	Incomplete	Authentication Bypass by Assumed-Immutable Data
-303	Draft	Incorrect Implementation of Authentication Algorithm
-304	Draft	Missing Critical Step in Authentication
-305	Draft	Authentication Bypass by Primary Weakness
-306	Draft	Missing Authentication for Critical Function
-307	Draft	Improper Restriction of Excessive Authentication Attempts
-308	Draft	Use of Single-factor Authentication
-309	Draft	Use of Password System for Primary Authentication
-311	Draft	Missing Encryption of Sensitive Data
-312	Draft	Cleartext Storage of Sensitive Information
-313	Draft	Cleartext Storage in a File or on Disk
-314	Draft	Cleartext Storage in the Registry
-315	Draft	Cleartext Storage of Sensitive Information in a Cookie
-316	Draft	Cleartext Storage of Sensitive Information in Memory
-317	Draft	Cleartext Storage of Sensitive Information in GUI
-318	Draft	Cleartext Storage of Sensitive Information in Executable
-319	Draft	Cleartext Transmission of Sensitive Information
-321	Draft	Use of Hard-coded Cryptographic Key
-322	Draft	Key Exchange without Entity Authentication
-323	Incomplete	Reusing a Nonce, Key Pair in Encryption
-324	Draft	Use of a Key Past its Expiration Date
-325	Draft	Missing Cryptographic Step
-326	Draft	Inadequate Encryption Strength
-327	Draft	Use of a Broken or Risky Cryptographic Algorithm
-328	Draft	Use of Weak Hash
-329	Draft	Generation of Predictable IV with CBC Mode
-330	Stable	Use of Insufficiently Random Values
-331	Draft	Insufficient Entropy
-332	Draft	Insufficient Entropy in PRNG
-333	Draft	Improper Handling of Insufficient Entropy in TRNG
-334	Draft	Small Space of Random Values
-335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)
-336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)
-337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)
-338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)
-339	Draft	Small Seed Space in PRNG
-340	Incomplete	Generation of Predictable Numbers or Identifiers
-341	Draft	Predictable from Observable State
-342	Draft	Predictable Exact Value from Previous Values
-343	Draft	Predictable Value Range from Previous Values
-344	Draft	Use of Invariant Value in Dynamically Changing Context
-345	Draft	Insufficient Verification of Data Authenticity
-346	Draft	Origin Validation Error
-347	Draft	Improper Verification of Cryptographic Signature
-348	Draft	Use of Less Trusted Source
-349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data
-350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action
-351	Draft	Insufficient Type Distinction
-352	Stable	Cross-Site Request Forgery (CSRF)
-353	Draft	Missing Support for Integrity Check
-354	Draft	Improper Validation of Integrity Check Value
-356	Incomplete	Product UI does not Warn User of Unsafe Actions
-357	Draft	Insufficient UI Warning of Dangerous Operations
-358	Draft	Improperly Implemented Security Check for Standard
-359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor
-360	Incomplete	Trust of System Event Data
-362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')
-363	Draft	Race Condition Enabling Link Following
-364	Incomplete	Signal Handler Race Condition
-365	Deprecated	DEPRECATED: Race Condition in Switch
-366	Draft	Race Condition within a Thread
-367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition
-368	Draft	Context Switching Race Condition
-369	Draft	Divide By Zero
-370	Draft	Missing Check for Certificate Revocation after Initial Check
-372	Draft	Incomplete Internal State Distinction
-373	Deprecated	DEPRECATED: State Synchronization Error
-374	Draft	Passing Mutable Objects to an Untrusted Method
-375	Draft	Returning a Mutable Object to an Untrusted Caller
-377	Incomplete	Insecure Temporary File
-378	Draft	Creation of Temporary File With Insecure Permissions
-379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions
-382	Draft	J2EE Bad Practices: Use of System.exit()
-383	Draft	J2EE Bad Practices: Direct Use of Threads
-384	Incomplete	Session Fixation
-385	Incomplete	Covert Timing Channel
-386	Draft	Symbolic Name not Mapping to Correct Object
-390	Draft	Detection of Error Condition Without Action
-391	Incomplete	Unchecked Error Condition
-392	Draft	Missing Report of Error Condition
-393	Draft	Return of Wrong Status Code
-394	Draft	Unexpected Status Code or Return Value
-395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference
-396	Draft	Declaration of Catch for Generic Exception
-397	Draft	Declaration of Throws for Generic Exception
-400	Draft	Uncontrolled Resource Consumption
-401	Draft	Missing Release of Memory after Effective Lifetime
-402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')
-403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')
-404	Draft	Improper Resource Shutdown or Release
-405	Incomplete	Asymmetric Resource Consumption (Amplification)
-406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)
-407	Incomplete	Inefficient Algorithmic Complexity
-408	Draft	Incorrect Behavior Order: Early Amplification
-409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)
-410	Incomplete	Insufficient Resource Pool
-412	Incomplete	Unrestricted Externally Accessible Lock
-413	Draft	Improper Resource Locking
-414	Draft	Missing Lock Check
-415	Draft	Double Free
-416	Stable	Use After Free
-419	Draft	Unprotected Primary Channel
-420	Draft	Unprotected Alternate Channel
-421	Draft	Race Condition During Access to Alternate Channel
-422	Draft	Unprotected Windows Messaging Channel ('Shatter')
-423	Deprecated	DEPRECATED: Proxied Trusted Channel
-424	Draft	Improper Protection of Alternate Path
-425	Incomplete	Direct Request ('Forced Browsing')
-426	Stable	Untrusted Search Path
-427	Draft	Uncontrolled Search Path Element
-428	Draft	Unquoted Search Path or Element
-430	Incomplete	Deployment of Wrong Handler
-431	Draft	Missing Handler
-432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations
-433	Incomplete	Unparsed Raw Web Content Delivery
-434	Draft	Unrestricted Upload of File with Dangerous Type
-435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities
-436	Incomplete	Interpretation Conflict
-437	Incomplete	Incomplete Model of Endpoint Features
-439	Draft	Behavioral Change in New Version or Environment
-440	Draft	Expected Behavior Violation
-441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')
-443	Deprecated	DEPRECATED: HTTP response splitting
-444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')
-446	Incomplete	UI Discrepancy for Security Feature
-447	Draft	Unimplemented or Unsupported Feature in UI
-448	Draft	Obsolete Feature in UI
-449	Incomplete	The UI Performs the Wrong Action
-450	Draft	Multiple Interpretations of UI Input
-451	Draft	User Interface (UI) Misrepresentation of Critical Information
-453	Draft	Insecure Default Variable Initialization
-454	Draft	External Initialization of Trusted Variables or Data Stores
-455	Draft	Non-exit on Failed Initialization
-456	Draft	Missing Initialization of a Variable
-457	Draft	Use of Uninitialized Variable
-458	Deprecated	DEPRECATED: Incorrect Initialization
-459	Draft	Incomplete Cleanup
-460	Draft	Improper Cleanup on Thrown Exception
-462	Incomplete	Duplicate Key in Associative List (Alist)
-463	Incomplete	Deletion of Data Structure Sentinel
-464	Incomplete	Addition of Data Structure Sentinel
-466	Draft	Return of Pointer Value Outside of Expected Range
-467	Draft	Use of sizeof() on a Pointer Type
-468	Incomplete	Incorrect Pointer Scaling
-469	Draft	Use of Pointer Subtraction to Determine Size
-470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')
-471	Draft	Modification of Assumed-Immutable Data (MAID)
-472	Draft	External Control of Assumed-Immutable Web Parameter
-473	Draft	PHP External Variable Modification
-474	Draft	Use of Function with Inconsistent Implementations
-475	Incomplete	Undefined Behavior for Input to API
-476	Stable	NULL Pointer Dereference
-477	Draft	Use of Obsolete Function
-478	Draft	Missing Default Case in Multiple Condition Expression
-479	Draft	Signal Handler Use of a Non-reentrant Function
-480	Draft	Use of Incorrect Operator
-481	Draft	Assigning instead of Comparing
-482	Draft	Comparing instead of Assigning
-483	Draft	Incorrect Block Delimitation
-484	Draft	Omitted Break Statement in Switch
-486	Draft	Comparison of Classes by Name
-487	Incomplete	Reliance on Package-level Scope
-488	Draft	Exposure of Data Element to Wrong Session
-489	Draft	Active Debug Code
-491	Draft	Public cloneable() Method Without Final ('Object Hijack')
-492	Draft	Use of Inner Class Containing Sensitive Data
-493	Draft	Critical Public Variable Without Final Modifier
-494	Draft	Download of Code Without Integrity Check
-495	Draft	Private Data Structure Returned From A Public Method
-496	Incomplete	Public Data Assigned to Private Array-Typed Field
-497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere
-498	Draft	Cloneable Class Containing Sensitive Information
-499	Draft	Serializable Class Containing Sensitive Data
-500	Draft	Public Static Field Not Marked Final
-501	Draft	Trust Boundary Violation
-502	Draft	Deserialization of Untrusted Data
-506	Incomplete	Embedded Malicious Code
-507	Incomplete	Trojan Horse
-508	Incomplete	Non-Replicating Malicious Code
-509	Incomplete	Replicating Malicious Code (Virus or Worm)
-510	Incomplete	Trapdoor
-511	Incomplete	Logic/Time Bomb
-512	Incomplete	Spyware
-514	Incomplete	Covert Channel
-515	Incomplete	Covert Storage Channel
-516	Deprecated	DEPRECATED: Covert Timing Channel
-520	Incomplete	.NET Misconfiguration: Use of Impersonation
-521	Draft	Weak Password Requirements
-522	Incomplete	Insufficiently Protected Credentials
-523	Incomplete	Unprotected Transport of Credentials
-524	Incomplete	Use of Cache Containing Sensitive Information
-525	Incomplete	Use of Web Browser Cache Containing Sensitive Information
-526	Incomplete	Exposure of Sensitive Information Through Environmental Variables
-527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere
-528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere
-529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere
-530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere
-531	Incomplete	Inclusion of Sensitive Information in Test Code
-532	Incomplete	Insertion of Sensitive Information into Log File
-533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files
-534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files
-535	Incomplete	Exposure of Information Through Shell Error Message
-536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information
-537	Incomplete	Java Runtime Error Message Containing Sensitive Information
-538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory
-539	Incomplete	Use of Persistent Cookies Containing Sensitive Information
-540	Incomplete	Inclusion of Sensitive Information in Source Code
-541	Incomplete	Inclusion of Sensitive Information in an Include File
-542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files
-543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context
-544	Draft	Missing Standardized Error Handling Mechanism
-545	Deprecated	DEPRECATED: Use of Dynamic Class Loading
-546	Draft	Suspicious Comment
-547	Draft	Use of Hard-coded, Security-relevant Constants
-548	Draft	Exposure of Information Through Directory Listing
-549	Draft	Missing Password Field Masking
-550	Incomplete	Server-generated Error Message Containing Sensitive Information
-551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization
-552	Draft	Files or Directories Accessible to External Parties
-553	Incomplete	Command Shell in Externally Accessible Directory
-554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework
-555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File
-556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation
-558	Draft	Use of getlogin() in Multithreaded Application
-560	Draft	Use of umask() with chmod-style Argument
-561	Draft	Dead Code
-562	Draft	Return of Stack Variable Address
-563	Draft	Assignment to Variable without Use
-564	Incomplete	SQL Injection: Hibernate
-565	Incomplete	Reliance on Cookies without Validation and Integrity Checking
-566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key
-567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context
-568	Draft	finalize() Method Without super.finalize()
-570	Draft	Expression is Always False
-571	Draft	Expression is Always True
-572	Draft	Call to Thread run() instead of start()
-573	Draft	Improper Following of Specification by Caller
-574	Draft	EJB Bad Practices: Use of Synchronization Primitives
-575	Draft	EJB Bad Practices: Use of AWT Swing
-576	Draft	EJB Bad Practices: Use of Java I/O
-577	Draft	EJB Bad Practices: Use of Sockets
-578	Draft	EJB Bad Practices: Use of Class Loader
-579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session
-580	Draft	clone() Method Without super.clone()
-581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined
-582	Draft	Array Declared Public, Final, and Static
-583	Incomplete	finalize() Method Declared Public
-584	Draft	Return Inside Finally Block
-585	Draft	Empty Synchronized Block
-586	Draft	Explicit Call to Finalize()
-587	Draft	Assignment of a Fixed Address to a Pointer
-588	Incomplete	Attempt to Access Child of a Non-structure Pointer
-589	Incomplete	Call to Non-ubiquitous API
-590	Incomplete	Free of Memory not on the Heap
-591	Draft	Sensitive Data Storage in Improperly Locked Memory
-592	Deprecated	DEPRECATED: Authentication Bypass Issues
-593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created
-594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk
-595	Incomplete	Comparison of Object References Instead of Object Contents
-596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison
-597	Draft	Use of Wrong Operator in String Comparison
-598	Draft	Use of GET Request Method With Sensitive Query Strings
-599	Incomplete	Missing Validation of OpenSSL Certificate
-600	Draft	Uncaught Exception in Servlet 
-601	Draft	URL Redirection to Untrusted Site ('Open Redirect')
-602	Draft	Client-Side Enforcement of Server-Side Security
-603	Draft	Use of Client-Side Authentication
-605	Draft	Multiple Binds to the Same Port
-606	Draft	Unchecked Input for Loop Condition
-607	Draft	Public Static Final Field References Mutable Object
-608	Draft	Struts: Non-private Field in ActionForm Class
-609	Draft	Double-Checked Locking
-610	Draft	Externally Controlled Reference to a Resource in Another Sphere
-611	Draft	Improper Restriction of XML External Entity Reference
-612	Draft	Improper Authorization of Index Containing Sensitive Information
-613	Incomplete	Insufficient Session Expiration
-614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-615	Incomplete	Inclusion of Sensitive Information in Source Code Comments
-616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)
-617	Draft	Reachable Assertion
-618	Incomplete	Exposed Unsafe ActiveX Method
-619	Incomplete	Dangling Database Cursor ('Cursor Injection')
-620	Draft	Unverified Password Change
-621	Incomplete	Variable Extraction Error
-622	Draft	Improper Validation of Function Hook Arguments
-623	Draft	Unsafe ActiveX Control Marked Safe For Scripting
-624	Incomplete	Executable Regular Expression Error
-625	Draft	Permissive Regular Expression
-626	Draft	Null Byte Interaction Error (Poison Null Byte)
-627	Incomplete	Dynamic Variable Evaluation
-628	Draft	Function Call with Incorrectly Specified Arguments
-636	Draft	Not Failing Securely ('Failing Open')
-637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')
-638	Draft	Not Using Complete Mediation
-639	Incomplete	Authorization Bypass Through User-Controlled Key
-640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password
-641	Incomplete	Improper Restriction of Names for Files and Other Resources
-642	Draft	External Control of Critical State Data
-643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')
-644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax
-645	Incomplete	Overly Restrictive Account Lockout Mechanism
-646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File
-647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions
-648	Incomplete	Incorrect Use of Privileged APIs
-649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking
-650	Incomplete	Trusting HTTP Permission Methods on the Server Side
-651	Incomplete	Exposure of WSDL File Containing Sensitive Information
-652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')
-653	Draft	Improper Isolation or Compartmentalization
-654	Draft	Reliance on a Single Factor in a Security Decision
-655	Draft	Insufficient Psychological Acceptability
-656	Draft	Reliance on Security Through Obscurity
-657	Draft	Violation of Secure Design Principles
-662	Draft	Improper Synchronization
-663	Draft	Use of a Non-reentrant Function in a Concurrent Context
-664	Draft	Improper Control of a Resource Through its Lifetime
-665	Draft	Improper Initialization
-666	Draft	Operation on Resource in Wrong Phase of Lifetime
-667	Draft	Improper Locking
-668	Draft	Exposure of Resource to Wrong Sphere
-669	Draft	Incorrect Resource Transfer Between Spheres
-670	Draft	Always-Incorrect Control Flow Implementation
-671	Draft	Lack of Administrator Control over Security
-672	Draft	Operation on a Resource after Expiration or Release
-673	Draft	External Influence of Sphere Definition
-674	Draft	Uncontrolled Recursion
-675	Draft	Multiple Operations on Resource in Single-Operation Context
-676	Draft	Use of Potentially Dangerous Function
-680	Draft	Integer Overflow to Buffer Overflow
-681	Draft	Incorrect Conversion between Numeric Types
-682	Draft	Incorrect Calculation
-683	Draft	Function Call With Incorrect Order of Arguments
-684	Draft	Incorrect Provision of Specified Functionality
-685	Draft	Function Call With Incorrect Number of Arguments
-686	Draft	Function Call With Incorrect Argument Type
-687	Draft	Function Call With Incorrectly Specified Argument Value
-688	Draft	Function Call With Incorrect Variable or Reference as Argument
-689	Draft	Permission Race Condition During Resource Copy
-690	Draft	Unchecked Return Value to NULL Pointer Dereference
-691	Draft	Insufficient Control Flow Management
-692	Draft	Incomplete Denylist to Cross-Site Scripting
-693	Draft	Protection Mechanism Failure
-694	Incomplete	Use of Multiple Resources with Duplicate Identifier
-695	Incomplete	Use of Low-Level Functionality
-696	Incomplete	Incorrect Behavior Order
-697	Incomplete	Incorrect Comparison
-698	Incomplete	Execution After Redirect (EAR)
-703	Incomplete	Improper Check or Handling of Exceptional Conditions
-704	Incomplete	Incorrect Type Conversion or Cast
-705	Incomplete	Incorrect Control Flow Scoping
-706	Incomplete	Use of Incorrectly-Resolved Name or Reference
-707	Incomplete	Improper Neutralization
-708	Incomplete	Incorrect Ownership Assignment
-710	Incomplete	Improper Adherence to Coding Standards
-732	Draft	Incorrect Permission Assignment for Critical Resource
-733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code
-749	Incomplete	Exposed Dangerous Method or Function
-754	Incomplete	Improper Check for Unusual or Exceptional Conditions
-755	Incomplete	Improper Handling of Exceptional Conditions
-756	Incomplete	Missing Custom Error Page
-757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')
-758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior
-759	Incomplete	Use of a One-Way Hash without a Salt
-760	Incomplete	Use of a One-Way Hash with a Predictable Salt
-761	Incomplete	Free of Pointer not at Start of Buffer
-762	Incomplete	Mismatched Memory Management Routines
-763	Incomplete	Release of Invalid Pointer or Reference
-764	Incomplete	Multiple Locks of a Critical Resource
-765	Incomplete	Multiple Unlocks of a Critical Resource
-766	Incomplete	Critical Data Element Declared Public
-767	Incomplete	Access to Critical Private Variable via Public Method
-768	Incomplete	Incorrect Short Circuit Evaluation
-769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption
-770	Incomplete	Allocation of Resources Without Limits or Throttling
-771	Incomplete	Missing Reference to Active Allocated Resource
-772	Draft	Missing Release of Resource after Effective Lifetime
-773	Incomplete	Missing Reference to Active File Descriptor or Handle
-774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling
-775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime
-776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')
-777	Incomplete	Regular Expression without Anchors
-778	Draft	Insufficient Logging
-779	Draft	Logging of Excessive Data
-780	Incomplete	Use of RSA Algorithm without OAEP
-781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code
-782	Draft	Exposed IOCTL with Insufficient Access Control
-783	Draft	Operator Precedence Logic Error
-784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision
-785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer
-786	Incomplete	Access of Memory Location Before Start of Buffer
-787	Draft	Out-of-bounds Write
-788	Incomplete	Access of Memory Location After End of Buffer
-789	Draft	Memory Allocation with Excessive Size Value
-790	Incomplete	Improper Filtering of Special Elements
-791	Incomplete	Incomplete Filtering of Special Elements
-792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements
-793	Incomplete	Only Filtering One Instance of a Special Element
-794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements
-795	Incomplete	Only Filtering Special Elements at a Specified Location
-796	Incomplete	Only Filtering Special Elements Relative to a Marker
-797	Incomplete	Only Filtering Special Elements at an Absolute Position
-798	Draft	Use of Hard-coded Credentials
-799	Incomplete	Improper Control of Interaction Frequency
-804	Incomplete	Guessable CAPTCHA
-805	Incomplete	Buffer Access with Incorrect Length Value
-806	Incomplete	Buffer Access Using Size of Source Buffer
-807	Incomplete	Reliance on Untrusted Inputs in a Security Decision
-820	Incomplete	Missing Synchronization
-821	Incomplete	Incorrect Synchronization
-822	Incomplete	Untrusted Pointer Dereference
-823	Incomplete	Use of Out-of-range Pointer Offset
-824	Incomplete	Access of Uninitialized Pointer
-825	Incomplete	Expired Pointer Dereference
-826	Incomplete	Premature Release of Resource During Expected Lifetime
-827	Incomplete	Improper Control of Document Type Definition
-828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe
-829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere
-830	Incomplete	Inclusion of Web Functionality from an Untrusted Source
-831	Incomplete	Signal Handler Function Associated with Multiple Signals
-832	Incomplete	Unlock of a Resource that is not Locked
-833	Incomplete	Deadlock
-834	Incomplete	Excessive Iteration
-835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')
-836	Incomplete	Use of Password Hash Instead of Password for Authentication
-837	Incomplete	Improper Enforcement of a Single, Unique Action
-838	Incomplete	Inappropriate Encoding for Output Context
-839	Incomplete	Numeric Range Comparison Without Minimum Check
-841	Incomplete	Improper Enforcement of Behavioral Workflow
-842	Incomplete	Placement of User into Incorrect Group
-843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')
-862	Incomplete	Missing Authorization
-863	Incomplete	Incorrect Authorization
-908	Incomplete	Use of Uninitialized Resource
-909	Incomplete	Missing Initialization of Resource
-910	Incomplete	Use of Expired File Descriptor
-911	Incomplete	Improper Update of Reference Count
-912	Incomplete	Hidden Functionality
-913	Incomplete	Improper Control of Dynamically-Managed Code Resources
-914	Incomplete	Improper Control of Dynamically-Identified Variables
-915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes
-916	Incomplete	Use of Password Hash With Insufficient Computational Effort
-917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')
-918	Incomplete	Server-Side Request Forgery (SSRF)
-920	Incomplete	Improper Restriction of Power Consumption
-921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control
-922	Incomplete	Insecure Storage of Sensitive Information
-923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints
-924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel
-925	Incomplete	Improper Verification of Intent by Broadcast Receiver
-926	Incomplete	Improper Export of Android Application Components
-927	Incomplete	Use of Implicit Intent for Sensitive Communication
-939	Incomplete	Improper Authorization in Handler for Custom URL Scheme
-940	Incomplete	Improper Verification of Source of a Communication Channel
-941	Incomplete	Incorrectly Specified Destination in a Communication Channel
-942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains
-943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic
-1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag
-1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User
-1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames
-1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access
-1023	Incomplete	Incomplete Comparison with Missing Factors
-1024	Incomplete	Comparison of Incompatible Types
-1025	Incomplete	Comparison Using Wrong Factors
-1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code
-1038	Draft	Insecure Automated Optimizations
-1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations
-1041	Incomplete	Use of Redundant Code
-1042	Incomplete	Static Member Data Element outside of a Singleton Class Element
-1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements
-1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range
-1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor
-1046	Incomplete	Creation of Immutable Text Using String Concatenation
-1047	Incomplete	Modules with Circular Dependencies
-1048	Incomplete	Invokable Control Element with Large Number of Outward Calls
-1049	Incomplete	Excessive Data Query Operations in a Large Data Table
-1050	Incomplete	Excessive Platform Resource Consumption within a Loop
-1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data
-1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization
-1053	Incomplete	Missing Documentation for Design
-1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer
-1055	Incomplete	Multiple Inheritance from Concrete Classes
-1056	Incomplete	Invokable Control Element with Variadic Parameters
-1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component
-1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element
-1059	Incomplete	Insufficient Technical Documentation
-1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses
-1061	Incomplete	Insufficient Encapsulation
-1062	Incomplete	Parent Class with References to Child Class
-1063	Incomplete	Creation of Class Instance within a Static Code Block
-1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters
-1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers
-1066	Incomplete	Missing Serialization Control Element
-1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource
-1068	Incomplete	Inconsistency Between Implementation and Documented Design
-1069	Incomplete	Empty Exception Block
-1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements
-1071	Incomplete	Empty Code Block
-1072	Incomplete	Data Resource Access without Use of Connection Pooling
-1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses
-1074	Incomplete	Class with Excessively Deep Inheritance
-1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block
-1076	Incomplete	Insufficient Adherence to Expected Conventions
-1077	Incomplete	Floating Point Comparison with Incorrect Operator
-1078	Incomplete	Inappropriate Source Code Style or Formatting
-1079	Incomplete	Parent Class without Virtual Destructor Method
-1080	Incomplete	Source Code File with Excessive Number of Lines of Code
-1082	Incomplete	Class Instance Self Destruction Control Element
-1083	Incomplete	Data Access from Outside Expected Data Manager Component
-1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations
-1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code
-1086	Incomplete	Class with Excessive Number of Child Classes
-1087	Incomplete	Class with Virtual Method without a Virtual Destructor
-1088	Incomplete	Synchronous Access of Remote Resource without Timeout
-1089	Incomplete	Large Data Table with Excessive Number of Indices
-1090	Incomplete	Method Containing Access of a Member Element from Another Class
-1091	Incomplete	Use of Object without Invoking Destructor Method
-1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers
-1093	Incomplete	Excessively Complex Data Representation
-1094	Incomplete	Excessive Index Range Scan for a Data Resource
-1095	Incomplete	Loop Condition Value Update within the Loop
-1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization
-1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element
-1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element
-1099	Incomplete	Inconsistent Naming Conventions for Identifiers
-1100	Incomplete	Insufficient Isolation of System-Dependent Functions
-1101	Incomplete	Reliance on Runtime Component in Generated Code
-1102	Incomplete	Reliance on Machine-Dependent Data Representation
-1103	Incomplete	Use of Platform-Dependent Third Party Components
-1104	Incomplete	Use of Unmaintained Third Party Components
-1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality
-1106	Incomplete	Insufficient Use of Symbolic Constants
-1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions
-1108	Incomplete	Excessive Reliance on Global Variables
-1109	Incomplete	Use of Same Variable for Multiple Purposes
-1110	Incomplete	Incomplete Design Documentation
-1111	Incomplete	Incomplete I/O Documentation
-1112	Incomplete	Incomplete Documentation of Program Execution
-1113	Incomplete	Inappropriate Comment Style
-1114	Incomplete	Inappropriate Whitespace Style
-1115	Incomplete	Source Code Element without Standard Prologue
-1116	Incomplete	Inaccurate Comments
-1117	Incomplete	Callable with Insufficient Behavioral Summary
-1118	Incomplete	Insufficient Documentation of Error Handling Techniques
-1119	Incomplete	Excessive Use of Unconditional Branching
-1120	Incomplete	Excessive Code Complexity
-1121	Incomplete	Excessive McCabe Cyclomatic Complexity
-1122	Incomplete	Excessive Halstead Complexity
-1123	Incomplete	Excessive Use of Self-Modifying Code
-1124	Incomplete	Excessively Deep Nesting
-1125	Incomplete	Excessive Attack Surface
-1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope
-1127	Incomplete	Compilation with Insufficient Warnings or Errors
-1164	Incomplete	Irrelevant Code
-1173	Draft	Improper Use of Validation Framework
-1174	Draft	ASP.NET Misconfiguration: Improper Model Validation
-1176	Incomplete	Inefficient CPU Computation
-1177	Incomplete	Use of Prohibited Code
-1187	Deprecated	DEPRECATED: Use of Uninitialized Resource
-1188	Incomplete	Insecure Default Initialization of Resource
-1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)
-1190	Draft	DMA Device Enabled Too Early in Boot Phase
-1191	Stable	On-Chip Debug and Test Interface With Improper Access Control
-1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers
-1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control
-1204	Incomplete	Generation of Weak Initialization Vector (IV)
-1209	Incomplete	Failure to Disable Reserved Bits
-1220	Incomplete	Insufficient Granularity of Access Control
-1221	Incomplete	Incorrect Register Defaults or Module Parameters
-1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks
-1223	Incomplete	Race Condition for Write-Once Attributes
-1224	Incomplete	Improper Restriction of Write-Once Bit Fields
-1229	Incomplete	Creation of Emergent Resource
-1230	Incomplete	Exposure of Sensitive Information Through Metadata
-1231	Stable	Improper Prevention of Lock Bit Modification
-1232	Incomplete	Improper Lock Behavior After Power State Transition
-1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection
-1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks
-1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations
-1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File
-1239	Draft	Improper Zeroization of Hardware Register
-1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation
-1241	Draft	Use of Predictable Algorithm in Random Number Generator
-1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits
-1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug
-1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State
-1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic
-1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories
-1247	Stable	Improper Protection Against Voltage and Clock Glitches
-1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications
-1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System
-1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State
-1251	Incomplete	Mirrored Regions with Different Values
-1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations
-1253	Draft	Incorrect Selection of Fuse Values
-1254	Draft	Incorrect Comparison Logic Granularity
-1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks
-1256	Stable	Improper Restriction of Software Interfaces to Hardware Features
-1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions
-1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information
-1259	Incomplete	Improper Restriction of Security Token Assignment
-1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges
-1261	Draft	Improper Handling of Single Event Upsets
-1262	Stable	Improper Access Control for Register Interface
-1263	Incomplete	Improper Physical Access Control
-1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels
-1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls
-1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device
-1267	Draft	Policy Uses Obsolete Encoding
-1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents
-1269	Incomplete	Product Released in Non-Release Configuration
-1270	Incomplete	Generation of Incorrect Security Tokens
-1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings
-1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition
-1273	Incomplete	Device Unlock Credential Sharing
-1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code
-1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute
-1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System
-1277	Draft	Firmware Not Updateable
-1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques
-1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready
-1280	Incomplete	Access Control Check Implemented After Asset is Accessed
-1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior
-1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory
-1283	Incomplete	Mutable Attestation or Measurement Reporting Data
-1284	Incomplete	Improper Validation of Specified Quantity in Input
-1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input
-1286	Incomplete	Improper Validation of Syntactic Correctness of Input
-1287	Incomplete	Improper Validation of Specified Type of Input
-1288	Incomplete	Improper Validation of Consistency within Input
-1289	Incomplete	Improper Validation of Unsafe Equivalence in Input
-1290	Incomplete	Incorrect Decoding of Security Identifiers 
-1291	Draft	Public Key Re-Use for Signing both Debug and Production Code
-1292	Draft	Incorrect Conversion of Security Identifiers
-1293	Draft	Missing Source Correlation of Multiple Independent Data
-1294	Incomplete	Insecure Security Identifier Mechanism
-1295	Incomplete	Debug Messages Revealing Unnecessary Information
-1296	Incomplete	Incorrect Chaining or Granularity of Debug Components
-1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors
-1298	Draft	Hardware Logic Contains Race Conditions
-1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface
-1300	Stable	Improper Protection of Physical Side Channels
-1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component
-1302	Incomplete	Missing Security Identifier
-1303	Draft	Non-Transparent Sharing of Microarchitectural Resources
-1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation
-1310	Draft	Missing Ability to Patch ROM Code
-1311	Draft	Improper Translation of Security Attributes by Fabric Bridge
-1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall
-1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime
-1314	Draft	Missing Write Protection for Parametric Data Values
-1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point
-1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges
-1317	Draft	Improper Access Control in Fabric Bridge
-1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses
-1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)
-1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals
-1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
-1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context
-1323	Draft	Improper Management of Sensitive Trace Data
-1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface
-1325	Incomplete	Improperly Controlled Sequential Memory Allocation
-1326	Draft	Missing Immutable Root of Trust in Hardware
-1327	Incomplete	Binding to an Unrestricted IP Address
-1328	Draft	Security Version Number Mutable to Older Versions
-1329	Incomplete	Reliance on Component That is Not Updateable
-1330	Draft	Remanent Data Readable after Memory Erase
-1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)
-1332	Stable	Improper Handling of Faults that Lead to Instruction Skips
-1333	Draft	Inefficient Regular Expression Complexity
-1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy
-1335	Draft	Incorrect Bitwise Shift of Integer
-1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine
-1338	Draft	Improper Protections Against Hardware Overheating
-1339	Draft	Insufficient Precision or Accuracy of a Real Number
-1341	Incomplete	Multiple Releases of Same Resource or Handle
-1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution
-1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments
-1357	Incomplete	Reliance on Uncontrolled Component
-1384	Incomplete	Improper Handling of Physical or Environmental Conditions
-1385	Incomplete	Missing Origin Validation in WebSockets
-1386	Incomplete	Insecure Operation on Windows Junction / Mount Point
-1389	Incomplete	Incorrect Parsing of Numbers with Different Radices
-1390	Incomplete	Weak Authentication
-1391	Incomplete	Use of Weak Credentials
-1392	Incomplete	Use of Default Credentials
-1393	Incomplete	Use of Default Password
-1394	Incomplete	Use of Default Cryptographic Key
+5	Draft	J2EE Misconfiguration: Data Transmission Without Encryption	0	
+6	Incomplete	J2EE Misconfiguration: Insufficient Session-ID Length	0	
+7	Incomplete	J2EE Misconfiguration: Missing Custom Error Page	0	
+8	Incomplete	J2EE Misconfiguration: Entity Bean Declared Remote	0	
+9	Draft	J2EE Misconfiguration: Weak Access Permissions for EJB Methods	0	
+11	Draft	ASP.NET Misconfiguration: Creating Debug Binary	0	
+12	Draft	ASP.NET Misconfiguration: Missing Custom Error Page	0	
+13	Draft	ASP.NET Misconfiguration: Password in Configuration File	0	
+14	Draft	Compiler Removal of Code to Clear Buffers	0	
+15	Incomplete	External Control of System or Configuration Setting	0	
+20	Stable	Improper Input Validation	0	
+22	Stable	Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')	0	
+23	Draft	Relative Path Traversal	0	
+24	Incomplete	Path Traversal: '../filedir'	0	
+25	Incomplete	Path Traversal: '/../filedir'	0	
+26	Draft	Path Traversal: '/dir/../filename'	0	
+27	Draft	Path Traversal: 'dir/../../filename'	0	
+28	Incomplete	Path Traversal: '..\filedir'	0	
+29	Incomplete	Path Traversal: '\..\filename'	0	
+30	Draft	Path Traversal: '\dir\..\filename'	0	
+31	Draft	Path Traversal: 'dir\..\..\filename'	0	
+32	Incomplete	Path Traversal: '...' (Triple Dot)	0	
+33	Incomplete	Path Traversal: '....' (Multiple Dot)	0	
+34	Incomplete	Path Traversal: '....//'	0	
+35	Incomplete	Path Traversal: '.../...//'	0	
+36	Draft	Absolute Path Traversal	0	
+37	Draft	Path Traversal: '/absolute/pathname/here'	0	
+38	Draft	Path Traversal: '\absolute\pathname\here'	0	
+39	Draft	Path Traversal: 'C:dirname'	0	
+40	Draft	Path Traversal: '\\UNC\share\name\' (Windows UNC Share)	0	
+41	Incomplete	Improper Resolution of Path Equivalence	0	
+42	Incomplete	Path Equivalence: 'filename.' (Trailing Dot)	0	
+43	Incomplete	Path Equivalence: 'filename....' (Multiple Trailing Dot)	0	
+44	Incomplete	Path Equivalence: 'file.name' (Internal Dot)	0	
+45	Incomplete	Path Equivalence: 'file...name' (Multiple Internal Dot)	0	
+46	Incomplete	Path Equivalence: 'filename ' (Trailing Space)	0	
+47	Incomplete	Path Equivalence: ' filename' (Leading Space)	0	
+48	Incomplete	Path Equivalence: 'file name' (Internal Whitespace)	0	
+49	Incomplete	Path Equivalence: 'filename/' (Trailing Slash)	0	
+50	Incomplete	Path Equivalence: '//multiple/leading/slash'	0	
+51	Incomplete	Path Equivalence: '/multiple//internal/slash'	0	
+52	Incomplete	Path Equivalence: '/multiple/trailing/slash//'	0	
+53	Incomplete	Path Equivalence: '\multiple\\internal\backslash'	0	
+54	Incomplete	Path Equivalence: 'filedir\' (Trailing Backslash)	0	
+55	Incomplete	Path Equivalence: '/./' (Single Dot Directory)	0	
+56	Incomplete	Path Equivalence: 'filedir*' (Wildcard)	0	
+57	Incomplete	Path Equivalence: 'fakedir/../realdir/filename'	0	
+58	Incomplete	Path Equivalence: Windows 8.3 Filename	0	
+59	Draft	Improper Link Resolution Before File Access ('Link Following')	0	
+61	Incomplete	UNIX Symbolic Link (Symlink) Following	0	
+62	Incomplete	UNIX Hard Link	0	
+64	Incomplete	Windows Shortcut Following (.LNK)	0	
+65	Incomplete	Windows Hard Link	0	
+66	Draft	Improper Handling of File Names that Identify Virtual Resources	0	
+67	Incomplete	Improper Handling of Windows Device Names	0	
+69	Incomplete	Improper Handling of Windows ::DATA Alternate Data Stream	0	
+71	Deprecated	DEPRECATED: Apple '.DS_Store'	0	
+72	Incomplete	Improper Handling of Apple HFS+ Alternate Data Stream Path	0	
+73	Draft	External Control of File Name or Path	0	
+74	Incomplete	Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')	0	
+75	Draft	Failure to Sanitize Special Elements into a Different Plane (Special Element Injection)	0	
+76	Draft	Improper Neutralization of Equivalent Special Elements	0	
+77	Draft	Improper Neutralization of Special Elements used in a Command ('Command Injection')	0	
+78	Stable	Improper Neutralization of Special Elements used in an OS Command ('OS Command Injection')	0	
+79	Stable	Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')	0	
+80	Incomplete	Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)	0	
+81	Incomplete	Improper Neutralization of Script in an Error Message Web Page	0	
+82	Incomplete	Improper Neutralization of Script in Attributes of IMG Tags in a Web Page	0	
+83	Draft	Improper Neutralization of Script in Attributes in a Web Page	0	
+84	Draft	Improper Neutralization of Encoded URI Schemes in a Web Page	0	
+85	Draft	Doubled Character XSS Manipulations	0	
+86	Draft	Improper Neutralization of Invalid Characters in Identifiers in Web Pages	0	
+87	Draft	Improper Neutralization of Alternate XSS Syntax	0	
+88	Draft	Improper Neutralization of Argument Delimiters in a Command ('Argument Injection')	0	
+89	Stable	Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')	0	
+90	Draft	Improper Neutralization of Special Elements used in an LDAP Query ('LDAP Injection')	0	
+91	Draft	XML Injection (aka Blind XPath Injection)	0	
+92	Deprecated	DEPRECATED: Improper Sanitization of Custom Special Characters	0	
+93	Draft	Improper Neutralization of CRLF Sequences ('CRLF Injection')	0	
+94	Draft	Improper Control of Generation of Code ('Code Injection')	0	
+95	Incomplete	Improper Neutralization of Directives in Dynamically Evaluated Code ('Eval Injection')	0	
+96	Draft	Improper Neutralization of Directives in Statically Saved Code ('Static Code Injection')	0	
+97	Draft	Improper Neutralization of Server-Side Includes (SSI) Within a Web Page	0	
+98	Draft	Improper Control of Filename for Include/Require Statement in PHP Program ('PHP Remote File Inclusion')	0	
+99	Draft	Improper Control of Resource Identifiers ('Resource Injection')	0	
+102	Incomplete	Struts: Duplicate Validation Forms	0	
+103	Draft	Struts: Incomplete validate() Method Definition	0	
+104	Draft	Struts: Form Bean Does Not Extend Validation Class	0	
+105	Draft	Struts: Form Field Without Validator	0	
+106	Draft	Struts: Plug-in Framework not in Use	0	
+107	Draft	Struts: Unused Validation Form	0	
+108	Incomplete	Struts: Unvalidated Action Form	0	
+109	Draft	Struts: Validator Turned Off	0	
+110	Draft	Struts: Validator Without Form Field	0	
+111	Draft	Direct Use of Unsafe JNI	0	
+112	Draft	Missing XML Validation	0	
+113	Incomplete	Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Request/Response Splitting')	0	
+114	Incomplete	Process Control	0	
+115	Incomplete	Misinterpretation of Input	0	
+116	Draft	Improper Encoding or Escaping of Output	0	
+117	Draft	Improper Output Neutralization for Logs	0	
+118	Incomplete	Incorrect Access of Indexable Resource ('Range Error')	0	
+119	Stable	Improper Restriction of Operations within the Bounds of a Memory Buffer	0	
+120	Incomplete	Buffer Copy without Checking Size of Input ('Classic Buffer Overflow')	0	
+121	Draft	Stack-based Buffer Overflow	0	
+122	Draft	Heap-based Buffer Overflow	0	
+123	Draft	Write-what-where Condition	0	
+124	Incomplete	Buffer Underwrite ('Buffer Underflow')	0	
+125	Draft	Out-of-bounds Read	0	
+126	Draft	Buffer Over-read	0	
+127	Draft	Buffer Under-read	0	
+128	Incomplete	Wrap-around Error	0	
+129	Draft	Improper Validation of Array Index	0	
+130	Incomplete	Improper Handling of Length Parameter Inconsistency	0	
+131	Draft	Incorrect Calculation of Buffer Size	0	
+132	Deprecated	DEPRECATED: Miscalculated Null Termination	0	
+134	Draft	Use of Externally-Controlled Format String	0	
+135	Draft	Incorrect Calculation of Multi-Byte String Length	0	
+138	Draft	Improper Neutralization of Special Elements	0	
+140	Draft	Improper Neutralization of Delimiters	0	
+141	Draft	Improper Neutralization of Parameter/Argument Delimiters	0	
+142	Draft	Improper Neutralization of Value Delimiters	0	
+143	Draft	Improper Neutralization of Record Delimiters	0	
+144	Draft	Improper Neutralization of Line Delimiters	0	
+145	Incomplete	Improper Neutralization of Section Delimiters	0	
+146	Incomplete	Improper Neutralization of Expression/Command Delimiters	0	
+147	Draft	Improper Neutralization of Input Terminators	0	
+148	Draft	Improper Neutralization of Input Leaders	0	
+149	Draft	Improper Neutralization of Quoting Syntax	0	
+150	Incomplete	Improper Neutralization of Escape, Meta, or Control Sequences	0	
+151	Draft	Improper Neutralization of Comment Delimiters	0	
+152	Draft	Improper Neutralization of Macro Symbols	0	
+153	Draft	Improper Neutralization of Substitution Characters	0	
+154	Incomplete	Improper Neutralization of Variable Name Delimiters	0	
+155	Draft	Improper Neutralization of Wildcards or Matching Symbols	0	
+156	Draft	Improper Neutralization of Whitespace	0	
+157	Draft	Failure to Sanitize Paired Delimiters	0	
+158	Incomplete	Improper Neutralization of Null Byte or NUL Character	0	
+159	Draft	Improper Handling of Invalid Use of Special Elements	0	
+160	Incomplete	Improper Neutralization of Leading Special Elements	0	
+161	Incomplete	Improper Neutralization of Multiple Leading Special Elements	0	
+162	Incomplete	Improper Neutralization of Trailing Special Elements	0	
+163	Incomplete	Improper Neutralization of Multiple Trailing Special Elements	0	
+164	Incomplete	Improper Neutralization of Internal Special Elements	0	
+165	Incomplete	Improper Neutralization of Multiple Internal Special Elements	0	
+166	Draft	Improper Handling of Missing Special Element	0	
+167	Draft	Improper Handling of Additional Special Element	0	
+168	Draft	Improper Handling of Inconsistent Special Elements	0	
+170	Incomplete	Improper Null Termination	0	
+172	Draft	Encoding Error	0	
+173	Draft	Improper Handling of Alternate Encoding	0	
+174	Draft	Double Decoding of the Same Data	0	
+175	Draft	Improper Handling of Mixed Encoding	0	
+176	Draft	Improper Handling of Unicode Encoding	0	
+177	Draft	Improper Handling of URL Encoding (Hex Encoding)	0	
+178	Incomplete	Improper Handling of Case Sensitivity	0	
+179	Incomplete	Incorrect Behavior Order: Early Validation	0	
+180	Draft	Incorrect Behavior Order: Validate Before Canonicalize	0	
+181	Draft	Incorrect Behavior Order: Validate Before Filter	0	
+182	Draft	Collapse of Data into Unsafe Value	0	
+183	Draft	Permissive List of Allowed Inputs	0	
+184	Draft	Incomplete List of Disallowed Inputs	0	
+185	Draft	Incorrect Regular Expression	0	
+186	Draft	Overly Restrictive Regular Expression	0	
+187	Incomplete	Partial String Comparison	0	
+188	Draft	Reliance on Data/Memory Layout	0	
+190	Stable	Integer Overflow or Wraparound	0	
+191	Draft	Integer Underflow (Wrap or Wraparound)	0	
+192	Incomplete	Integer Coercion Error	0	
+193	Draft	Off-by-one Error	0	
+194	Incomplete	Unexpected Sign Extension	0	
+195	Draft	Signed to Unsigned Conversion Error	0	
+196	Draft	Unsigned to Signed Conversion Error	0	
+197	Incomplete	Numeric Truncation Error	0	
+198	Draft	Use of Incorrect Byte Ordering	0	
+200	Draft	Exposure of Sensitive Information to an Unauthorized Actor	0	
+201	Draft	Insertion of Sensitive Information Into Sent Data	0	
+202	Draft	Exposure of Sensitive Information Through Data Queries	0	
+203	Incomplete	Observable Discrepancy	0	
+204	Incomplete	Observable Response Discrepancy	0	
+205	Incomplete	Observable Behavioral Discrepancy	0	
+206	Incomplete	Observable Internal Behavioral Discrepancy	0	
+207	Draft	Observable Behavioral Discrepancy With Equivalent Products	0	
+208	Incomplete	Observable Timing Discrepancy	0	
+209	Draft	Generation of Error Message Containing Sensitive Information	0	
+210	Draft	Self-generated Error Message Containing Sensitive Information	0	
+211	Incomplete	Externally-Generated Error Message Containing Sensitive Information	0	
+212	Incomplete	Improper Removal of Sensitive Information Before Storage or Transfer	0	
+213	Draft	Exposure of Sensitive Information Due to Incompatible Policies	0	
+214	Incomplete	Invocation of Process Using Visible Sensitive Information	0	
+215	Draft	Insertion of Sensitive Information Into Debugging Code	0	
+216	Deprecated	DEPRECATED: Containment Errors (Container Errors)	0	
+217	Deprecated	DEPRECATED: Failure to Protect Stored Data from Modification	0	
+218	Deprecated	DEPRECATED: Failure to provide confidentiality for stored data	0	
+219	Draft	Storage of File with Sensitive Data Under Web Root	0	
+220	Draft	Storage of File With Sensitive Data Under FTP Root	0	
+221	Incomplete	Information Loss or Omission	0	
+222	Draft	Truncation of Security-relevant Information	0	
+223	Draft	Omission of Security-relevant Information	0	
+224	Incomplete	Obscured Security-relevant Information by Alternate Name	0	
+225	Deprecated	DEPRECATED: General Information Management Problems	0	
+226	Draft	Sensitive Information in Resource Not Removed Before Reuse	0	
+228	Incomplete	Improper Handling of Syntactically Invalid Structure	0	
+229	Incomplete	Improper Handling of Values	0	
+230	Draft	Improper Handling of Missing Values	0	
+231	Draft	Improper Handling of Extra Values	0	
+232	Draft	Improper Handling of Undefined Values	0	
+233	Incomplete	Improper Handling of Parameters	0	
+234	Incomplete	Failure to Handle Missing Parameter	0	
+235	Draft	Improper Handling of Extra Parameters	0	
+236	Draft	Improper Handling of Undefined Parameters	0	
+237	Incomplete	Improper Handling of Structural Elements	0	
+238	Draft	Improper Handling of Incomplete Structural Elements	0	
+239	Draft	Failure to Handle Incomplete Element	0	
+240	Draft	Improper Handling of Inconsistent Structural Elements	0	
+241	Draft	Improper Handling of Unexpected Data Type	0	
+242	Draft	Use of Inherently Dangerous Function	0	
+243	Draft	Creation of chroot Jail Without Changing Working Directory	0	
+244	Draft	Improper Clearing of Heap Memory Before Release ('Heap Inspection')	0	
+245	Draft	J2EE Bad Practices: Direct Management of Connections	0	
+246	Draft	J2EE Bad Practices: Direct Use of Sockets	0	
+247	Deprecated	DEPRECATED: Reliance on DNS Lookups in a Security Decision	0	
+248	Draft	Uncaught Exception	0	
+249	Deprecated	DEPRECATED: Often Misused: Path Manipulation	0	
+250	Draft	Execution with Unnecessary Privileges	0	
+252	Draft	Unchecked Return Value	0	
+253	Incomplete	Incorrect Check of Function Return Value	0	
+256	Incomplete	Plaintext Storage of a Password	0	
+257	Incomplete	Storing Passwords in a Recoverable Format	0	
+258	Incomplete	Empty Password in Configuration File	0	
+259	Draft	Use of Hard-coded Password	0	
+260	Incomplete	Password in Configuration File	0	
+261	Incomplete	Weak Encoding for Password	0	
+262	Draft	Not Using Password Aging	0	
+263	Draft	Password Aging with Long Expiration	0	
+266	Draft	Incorrect Privilege Assignment	0	
+267	Incomplete	Privilege Defined With Unsafe Actions	0	
+268	Draft	Privilege Chaining	0	
+269	Draft	Improper Privilege Management	0	
+270	Draft	Privilege Context Switching Error	0	
+271	Incomplete	Privilege Dropping / Lowering Errors	0	
+272	Incomplete	Least Privilege Violation	0	
+273	Incomplete	Improper Check for Dropped Privileges	0	
+274	Draft	Improper Handling of Insufficient Privileges	0	
+276	Draft	Incorrect Default Permissions	0	
+277	Draft	Insecure Inherited Permissions	0	
+278	Incomplete	Insecure Preserved Inherited Permissions	0	
+279	Draft	Incorrect Execution-Assigned Permissions	0	
+280	Draft	Improper Handling of Insufficient Permissions or Privileges 	0	
+281	Draft	Improper Preservation of Permissions	0	
+282	Draft	Improper Ownership Management	0	
+283	Draft	Unverified Ownership	0	
+284	Incomplete	Improper Access Control	0	
+285	Draft	Improper Authorization	0	
+286	Incomplete	Incorrect User Management	0	
+287	Draft	Improper Authentication	0	
+288	Incomplete	Authentication Bypass Using an Alternate Path or Channel	0	
+289	Incomplete	Authentication Bypass by Alternate Name	0	
+290	Incomplete	Authentication Bypass by Spoofing	0	
+291	Incomplete	Reliance on IP Address for Authentication	0	
+292	Deprecated	DEPRECATED: Trusting Self-reported DNS Name	0	
+293	Draft	Using Referer Field for Authentication	0	
+294	Incomplete	Authentication Bypass by Capture-replay	0	
+295	Draft	Improper Certificate Validation	0	
+296	Draft	Improper Following of a Certificate's Chain of Trust	0	
+297	Incomplete	Improper Validation of Certificate with Host Mismatch	0	
+298	Draft	Improper Validation of Certificate Expiration	0	
+299	Draft	Improper Check for Certificate Revocation	0	
+300	Draft	Channel Accessible by Non-Endpoint	0	
+301	Draft	Reflection Attack in an Authentication Protocol	0	
+302	Incomplete	Authentication Bypass by Assumed-Immutable Data	0	
+303	Draft	Incorrect Implementation of Authentication Algorithm	0	
+304	Draft	Missing Critical Step in Authentication	0	
+305	Draft	Authentication Bypass by Primary Weakness	0	
+306	Draft	Missing Authentication for Critical Function	0	
+307	Draft	Improper Restriction of Excessive Authentication Attempts	0	
+308	Draft	Use of Single-factor Authentication	0	
+309	Draft	Use of Password System for Primary Authentication	0	
+311	Draft	Missing Encryption of Sensitive Data	0	
+312	Draft	Cleartext Storage of Sensitive Information	0	
+313	Draft	Cleartext Storage in a File or on Disk	0	
+314	Draft	Cleartext Storage in the Registry	0	
+315	Draft	Cleartext Storage of Sensitive Information in a Cookie	0	
+316	Draft	Cleartext Storage of Sensitive Information in Memory	0	
+317	Draft	Cleartext Storage of Sensitive Information in GUI	0	
+318	Draft	Cleartext Storage of Sensitive Information in Executable	0	
+319	Draft	Cleartext Transmission of Sensitive Information	0	
+321	Draft	Use of Hard-coded Cryptographic Key	0	
+322	Draft	Key Exchange without Entity Authentication	0	
+323	Incomplete	Reusing a Nonce, Key Pair in Encryption	0	
+324	Draft	Use of a Key Past its Expiration Date	0	
+325	Draft	Missing Cryptographic Step	0	
+326	Draft	Inadequate Encryption Strength	0	
+327	Draft	Use of a Broken or Risky Cryptographic Algorithm	0	
+328	Draft	Use of Weak Hash	0	
+329	Draft	Generation of Predictable IV with CBC Mode	0	
+330	Stable	Use of Insufficiently Random Values	0	
+331	Draft	Insufficient Entropy	0	
+332	Draft	Insufficient Entropy in PRNG	0	
+333	Draft	Improper Handling of Insufficient Entropy in TRNG	0	
+334	Draft	Small Space of Random Values	0	
+335	Draft	Incorrect Usage of Seeds in Pseudo-Random Number Generator (PRNG)	0	
+336	Draft	Same Seed in Pseudo-Random Number Generator (PRNG)	0	
+337	Draft	Predictable Seed in Pseudo-Random Number Generator (PRNG)	0	
+338	Draft	Use of Cryptographically Weak Pseudo-Random Number Generator (PRNG)	0	
+339	Draft	Small Seed Space in PRNG	0	
+340	Incomplete	Generation of Predictable Numbers or Identifiers	0	
+341	Draft	Predictable from Observable State	0	
+342	Draft	Predictable Exact Value from Previous Values	0	
+343	Draft	Predictable Value Range from Previous Values	0	
+344	Draft	Use of Invariant Value in Dynamically Changing Context	0	
+345	Draft	Insufficient Verification of Data Authenticity	0	
+346	Draft	Origin Validation Error	0	
+347	Draft	Improper Verification of Cryptographic Signature	0	
+348	Draft	Use of Less Trusted Source	0	
+349	Draft	Acceptance of Extraneous Untrusted Data With Trusted Data	0	
+350	Draft	Reliance on Reverse DNS Resolution for a Security-Critical Action	0	
+351	Draft	Insufficient Type Distinction	0	
+352	Stable	Cross-Site Request Forgery (CSRF)	0	
+353	Draft	Missing Support for Integrity Check	0	
+354	Draft	Improper Validation of Integrity Check Value	0	
+356	Incomplete	Product UI does not Warn User of Unsafe Actions	0	
+357	Draft	Insufficient UI Warning of Dangerous Operations	0	
+358	Draft	Improperly Implemented Security Check for Standard	0	
+359	Incomplete	Exposure of Private Personal Information to an Unauthorized Actor	0	
+360	Incomplete	Trust of System Event Data	0	
+362	Draft	Concurrent Execution using Shared Resource with Improper Synchronization ('Race Condition')	0	
+363	Draft	Race Condition Enabling Link Following	0	
+364	Incomplete	Signal Handler Race Condition	0	
+365	Deprecated	DEPRECATED: Race Condition in Switch	0	
+366	Draft	Race Condition within a Thread	0	
+367	Incomplete	Time-of-check Time-of-use (TOCTOU) Race Condition	0	
+368	Draft	Context Switching Race Condition	0	
+369	Draft	Divide By Zero	0	
+370	Draft	Missing Check for Certificate Revocation after Initial Check	0	
+372	Draft	Incomplete Internal State Distinction	0	
+373	Deprecated	DEPRECATED: State Synchronization Error	0	
+374	Draft	Passing Mutable Objects to an Untrusted Method	0	
+375	Draft	Returning a Mutable Object to an Untrusted Caller	0	
+377	Incomplete	Insecure Temporary File	0	
+378	Draft	Creation of Temporary File With Insecure Permissions	0	
+379	Incomplete	Creation of Temporary File in Directory with Insecure Permissions	0	
+382	Draft	J2EE Bad Practices: Use of System.exit()	0	
+383	Draft	J2EE Bad Practices: Direct Use of Threads	0	
+384	Incomplete	Session Fixation	0	
+385	Incomplete	Covert Timing Channel	0	
+386	Draft	Symbolic Name not Mapping to Correct Object	0	
+390	Draft	Detection of Error Condition Without Action	0	
+391	Incomplete	Unchecked Error Condition	0	
+392	Draft	Missing Report of Error Condition	0	
+393	Draft	Return of Wrong Status Code	0	
+394	Draft	Unexpected Status Code or Return Value	0	
+395	Draft	Use of NullPointerException Catch to Detect NULL Pointer Dereference	0	
+396	Draft	Declaration of Catch for Generic Exception	0	
+397	Draft	Declaration of Throws for Generic Exception	0	
+400	Draft	Uncontrolled Resource Consumption	0	
+401	Draft	Missing Release of Memory after Effective Lifetime	0	
+402	Draft	Transmission of Private Resources into a New Sphere ('Resource Leak')	0	
+403	Draft	Exposure of File Descriptor to Unintended Control Sphere ('File Descriptor Leak')	0	
+404	Draft	Improper Resource Shutdown or Release	0	
+405	Incomplete	Asymmetric Resource Consumption (Amplification)	0	
+406	Incomplete	Insufficient Control of Network Message Volume (Network Amplification)	0	
+407	Incomplete	Inefficient Algorithmic Complexity	0	
+408	Draft	Incorrect Behavior Order: Early Amplification	0	
+409	Incomplete	Improper Handling of Highly Compressed Data (Data Amplification)	0	
+410	Incomplete	Insufficient Resource Pool	0	
+412	Incomplete	Unrestricted Externally Accessible Lock	0	
+413	Draft	Improper Resource Locking	0	
+414	Draft	Missing Lock Check	0	
+415	Draft	Double Free	0	
+416	Stable	Use After Free	0	
+419	Draft	Unprotected Primary Channel	0	
+420	Draft	Unprotected Alternate Channel	0	
+421	Draft	Race Condition During Access to Alternate Channel	0	
+422	Draft	Unprotected Windows Messaging Channel ('Shatter')	0	
+423	Deprecated	DEPRECATED: Proxied Trusted Channel	0	
+424	Draft	Improper Protection of Alternate Path	0	
+425	Incomplete	Direct Request ('Forced Browsing')	0	
+426	Stable	Untrusted Search Path	0	
+427	Draft	Uncontrolled Search Path Element	0	
+428	Draft	Unquoted Search Path or Element	0	
+430	Incomplete	Deployment of Wrong Handler	0	
+431	Draft	Missing Handler	0	
+432	Draft	Dangerous Signal Handler not Disabled During Sensitive Operations	0	
+433	Incomplete	Unparsed Raw Web Content Delivery	0	
+434	Draft	Unrestricted Upload of File with Dangerous Type	0	
+435	Draft	Improper Interaction Between Multiple Correctly-Behaving Entities	0	
+436	Incomplete	Interpretation Conflict	0	
+437	Incomplete	Incomplete Model of Endpoint Features	0	
+439	Draft	Behavioral Change in New Version or Environment	0	
+440	Draft	Expected Behavior Violation	0	
+441	Draft	Unintended Proxy or Intermediary ('Confused Deputy')	0	
+443	Deprecated	DEPRECATED: HTTP response splitting	0	
+444	Incomplete	Inconsistent Interpretation of HTTP Requests ('HTTP Request/Response Smuggling')	0	
+446	Incomplete	UI Discrepancy for Security Feature	0	
+447	Draft	Unimplemented or Unsupported Feature in UI	0	
+448	Draft	Obsolete Feature in UI	0	
+449	Incomplete	The UI Performs the Wrong Action	0	
+450	Draft	Multiple Interpretations of UI Input	0	
+451	Draft	User Interface (UI) Misrepresentation of Critical Information	0	
+453	Draft	Insecure Default Variable Initialization	0	
+454	Draft	External Initialization of Trusted Variables or Data Stores	0	
+455	Draft	Non-exit on Failed Initialization	0	
+456	Draft	Missing Initialization of a Variable	0	
+457	Draft	Use of Uninitialized Variable	0	
+458	Deprecated	DEPRECATED: Incorrect Initialization	0	
+459	Draft	Incomplete Cleanup	0	
+460	Draft	Improper Cleanup on Thrown Exception	0	
+462	Incomplete	Duplicate Key in Associative List (Alist)	0	
+463	Incomplete	Deletion of Data Structure Sentinel	0	
+464	Incomplete	Addition of Data Structure Sentinel	0	
+466	Draft	Return of Pointer Value Outside of Expected Range	0	
+467	Draft	Use of sizeof() on a Pointer Type	0	
+468	Incomplete	Incorrect Pointer Scaling	0	
+469	Draft	Use of Pointer Subtraction to Determine Size	0	
+470	Draft	Use of Externally-Controlled Input to Select Classes or Code ('Unsafe Reflection')	0	
+471	Draft	Modification of Assumed-Immutable Data (MAID)	0	
+472	Draft	External Control of Assumed-Immutable Web Parameter	0	
+473	Draft	PHP External Variable Modification	0	
+474	Draft	Use of Function with Inconsistent Implementations	0	
+475	Incomplete	Undefined Behavior for Input to API	0	
+476	Stable	NULL Pointer Dereference	0	
+477	Draft	Use of Obsolete Function	0	
+478	Draft	Missing Default Case in Multiple Condition Expression	0	
+479	Draft	Signal Handler Use of a Non-reentrant Function	0	
+480	Draft	Use of Incorrect Operator	0	
+481	Draft	Assigning instead of Comparing	0	
+482	Draft	Comparing instead of Assigning	0	
+483	Draft	Incorrect Block Delimitation	0	
+484	Draft	Omitted Break Statement in Switch	0	
+486	Draft	Comparison of Classes by Name	0	
+487	Incomplete	Reliance on Package-level Scope	0	
+488	Draft	Exposure of Data Element to Wrong Session	0	
+489	Draft	Active Debug Code	0	
+491	Draft	Public cloneable() Method Without Final ('Object Hijack')	0	
+492	Draft	Use of Inner Class Containing Sensitive Data	0	
+493	Draft	Critical Public Variable Without Final Modifier	0	
+494	Draft	Download of Code Without Integrity Check	0	
+495	Draft	Private Data Structure Returned From A Public Method	0	
+496	Incomplete	Public Data Assigned to Private Array-Typed Field	0	
+497	Incomplete	Exposure of Sensitive System Information to an Unauthorized Control Sphere	0	
+498	Draft	Cloneable Class Containing Sensitive Information	0	
+499	Draft	Serializable Class Containing Sensitive Data	0	
+500	Draft	Public Static Field Not Marked Final	0	
+501	Draft	Trust Boundary Violation	0	
+502	Draft	Deserialization of Untrusted Data	0	
+506	Incomplete	Embedded Malicious Code	0	
+507	Incomplete	Trojan Horse	0	
+508	Incomplete	Non-Replicating Malicious Code	0	
+509	Incomplete	Replicating Malicious Code (Virus or Worm)	0	
+510	Incomplete	Trapdoor	0	
+511	Incomplete	Logic/Time Bomb	0	
+512	Incomplete	Spyware	0	
+514	Incomplete	Covert Channel	0	
+515	Incomplete	Covert Storage Channel	0	
+516	Deprecated	DEPRECATED: Covert Timing Channel	0	
+520	Incomplete	.NET Misconfiguration: Use of Impersonation	0	
+521	Draft	Weak Password Requirements	0	
+522	Incomplete	Insufficiently Protected Credentials	0	
+523	Incomplete	Unprotected Transport of Credentials	0	
+524	Incomplete	Use of Cache Containing Sensitive Information	0	
+525	Incomplete	Use of Web Browser Cache Containing Sensitive Information	0	
+526	Incomplete	Exposure of Sensitive Information Through Environmental Variables	0	
+527	Incomplete	Exposure of Version-Control Repository to an Unauthorized Control Sphere	0	
+528	Draft	Exposure of Core Dump File to an Unauthorized Control Sphere	0	
+529	Incomplete	Exposure of Access Control List Files to an Unauthorized Control Sphere	0	
+530	Incomplete	Exposure of Backup File to an Unauthorized Control Sphere	0	
+531	Incomplete	Inclusion of Sensitive Information in Test Code	0	
+532	Incomplete	Insertion of Sensitive Information into Log File	0	
+533	Deprecated	DEPRECATED: Information Exposure Through Server Log Files	0	
+534	Deprecated	DEPRECATED: Information Exposure Through Debug Log Files	0	
+535	Incomplete	Exposure of Information Through Shell Error Message	0	
+536	Incomplete	Servlet Runtime Error Message Containing Sensitive Information	0	
+537	Incomplete	Java Runtime Error Message Containing Sensitive Information	0	
+538	Draft	Insertion of Sensitive Information into Externally-Accessible File or Directory	0	
+539	Incomplete	Use of Persistent Cookies Containing Sensitive Information	0	
+540	Incomplete	Inclusion of Sensitive Information in Source Code	0	
+541	Incomplete	Inclusion of Sensitive Information in an Include File	0	
+542	Deprecated	DEPRECATED: Information Exposure Through Cleanup Log Files	0	
+543	Incomplete	Use of Singleton Pattern Without Synchronization in a Multithreaded Context	0	
+544	Draft	Missing Standardized Error Handling Mechanism	0	
+545	Deprecated	DEPRECATED: Use of Dynamic Class Loading	0	
+546	Draft	Suspicious Comment	0	
+547	Draft	Use of Hard-coded, Security-relevant Constants	0	
+548	Draft	Exposure of Information Through Directory Listing	0	
+549	Draft	Missing Password Field Masking	0	
+550	Incomplete	Server-generated Error Message Containing Sensitive Information	0	
+551	Incomplete	Incorrect Behavior Order: Authorization Before Parsing and Canonicalization	0	
+552	Draft	Files or Directories Accessible to External Parties	0	
+553	Incomplete	Command Shell in Externally Accessible Directory	0	
+554	Draft	ASP.NET Misconfiguration: Not Using Input Validation Framework	0	
+555	Draft	J2EE Misconfiguration: Plaintext Password in Configuration File	0	
+556	Incomplete	ASP.NET Misconfiguration: Use of Identity Impersonation	0	
+558	Draft	Use of getlogin() in Multithreaded Application	0	
+560	Draft	Use of umask() with chmod-style Argument	0	
+561	Draft	Dead Code	0	
+562	Draft	Return of Stack Variable Address	0	
+563	Draft	Assignment to Variable without Use	0	
+564	Incomplete	SQL Injection: Hibernate	0	
+565	Incomplete	Reliance on Cookies without Validation and Integrity Checking	0	
+566	Incomplete	Authorization Bypass Through User-Controlled SQL Primary Key	0	
+567	Draft	Unsynchronized Access to Shared Data in a Multithreaded Context	0	
+568	Draft	finalize() Method Without super.finalize()	0	
+570	Draft	Expression is Always False	0	
+571	Draft	Expression is Always True	0	
+572	Draft	Call to Thread run() instead of start()	0	
+573	Draft	Improper Following of Specification by Caller	0	
+574	Draft	EJB Bad Practices: Use of Synchronization Primitives	0	
+575	Draft	EJB Bad Practices: Use of AWT Swing	0	
+576	Draft	EJB Bad Practices: Use of Java I/O	0	
+577	Draft	EJB Bad Practices: Use of Sockets	0	
+578	Draft	EJB Bad Practices: Use of Class Loader	0	
+579	Draft	J2EE Bad Practices: Non-serializable Object Stored in Session	0	
+580	Draft	clone() Method Without super.clone()	0	
+581	Draft	Object Model Violation: Just One of Equals and Hashcode Defined	0	
+582	Draft	Array Declared Public, Final, and Static	0	
+583	Incomplete	finalize() Method Declared Public	0	
+584	Draft	Return Inside Finally Block	0	
+585	Draft	Empty Synchronized Block	0	
+586	Draft	Explicit Call to Finalize()	0	
+587	Draft	Assignment of a Fixed Address to a Pointer	0	
+588	Incomplete	Attempt to Access Child of a Non-structure Pointer	0	
+589	Incomplete	Call to Non-ubiquitous API	0	
+590	Incomplete	Free of Memory not on the Heap	0	
+591	Draft	Sensitive Data Storage in Improperly Locked Memory	0	
+592	Deprecated	DEPRECATED: Authentication Bypass Issues	0	
+593	Draft	Authentication Bypass: OpenSSL CTX Object Modified after SSL Objects are Created	0	
+594	Incomplete	J2EE Framework: Saving Unserializable Objects to Disk	0	
+595	Incomplete	Comparison of Object References Instead of Object Contents	0	
+596	Deprecated	DEPRECATED: Incorrect Semantic Object Comparison	0	
+597	Draft	Use of Wrong Operator in String Comparison	0	
+598	Draft	Use of GET Request Method With Sensitive Query Strings	0	
+599	Incomplete	Missing Validation of OpenSSL Certificate	0	
+600	Draft	Uncaught Exception in Servlet 	0	
+601	Draft	URL Redirection to Untrusted Site ('Open Redirect')	0	
+602	Draft	Client-Side Enforcement of Server-Side Security	0	
+603	Draft	Use of Client-Side Authentication	0	
+605	Draft	Multiple Binds to the Same Port	0	
+606	Draft	Unchecked Input for Loop Condition	0	
+607	Draft	Public Static Final Field References Mutable Object	0	
+608	Draft	Struts: Non-private Field in ActionForm Class	0	
+609	Draft	Double-Checked Locking	0	
+610	Draft	Externally Controlled Reference to a Resource in Another Sphere	0	
+611	Draft	Improper Restriction of XML External Entity Reference	0	
+612	Draft	Improper Authorization of Index Containing Sensitive Information	0	
+613	Incomplete	Insufficient Session Expiration	0	
+614	Draft	Sensitive Cookie in HTTPS Session Without 'Secure' Attribute	0	
+615	Incomplete	Inclusion of Sensitive Information in Source Code Comments	0	
+616	Incomplete	Incomplete Identification of Uploaded File Variables (PHP)	0	
+617	Draft	Reachable Assertion	0	
+618	Incomplete	Exposed Unsafe ActiveX Method	0	
+619	Incomplete	Dangling Database Cursor ('Cursor Injection')	0	
+620	Draft	Unverified Password Change	0	
+621	Incomplete	Variable Extraction Error	0	
+622	Draft	Improper Validation of Function Hook Arguments	0	
+623	Draft	Unsafe ActiveX Control Marked Safe For Scripting	0	
+624	Incomplete	Executable Regular Expression Error	0	
+625	Draft	Permissive Regular Expression	0	
+626	Draft	Null Byte Interaction Error (Poison Null Byte)	0	
+627	Incomplete	Dynamic Variable Evaluation	0	
+628	Draft	Function Call with Incorrectly Specified Arguments	0	
+636	Draft	Not Failing Securely ('Failing Open')	0	
+637	Draft	Unnecessary Complexity in Protection Mechanism (Not Using 'Economy of Mechanism')	0	
+638	Draft	Not Using Complete Mediation	0	
+639	Incomplete	Authorization Bypass Through User-Controlled Key	0	
+640	Incomplete	Weak Password Recovery Mechanism for Forgotten Password	0	
+641	Incomplete	Improper Restriction of Names for Files and Other Resources	0	
+642	Draft	External Control of Critical State Data	0	
+643	Incomplete	Improper Neutralization of Data within XPath Expressions ('XPath Injection')	0	
+644	Incomplete	Improper Neutralization of HTTP Headers for Scripting Syntax	0	
+645	Incomplete	Overly Restrictive Account Lockout Mechanism	0	
+646	Incomplete	Reliance on File Name or Extension of Externally-Supplied File	0	
+647	Incomplete	Use of Non-Canonical URL Paths for Authorization Decisions	0	
+648	Incomplete	Incorrect Use of Privileged APIs	0	
+649	Incomplete	Reliance on Obfuscation or Encryption of Security-Relevant Inputs without Integrity Checking	0	
+650	Incomplete	Trusting HTTP Permission Methods on the Server Side	0	
+651	Incomplete	Exposure of WSDL File Containing Sensitive Information	0	
+652	Incomplete	Improper Neutralization of Data within XQuery Expressions ('XQuery Injection')	0	
+653	Draft	Improper Isolation or Compartmentalization	0	
+654	Draft	Reliance on a Single Factor in a Security Decision	0	
+655	Draft	Insufficient Psychological Acceptability	0	
+656	Draft	Reliance on Security Through Obscurity	0	
+657	Draft	Violation of Secure Design Principles	0	
+662	Draft	Improper Synchronization	0	
+663	Draft	Use of a Non-reentrant Function in a Concurrent Context	0	
+664	Draft	Improper Control of a Resource Through its Lifetime	0	
+665	Draft	Improper Initialization	0	
+666	Draft	Operation on Resource in Wrong Phase of Lifetime	0	
+667	Draft	Improper Locking	0	
+668	Draft	Exposure of Resource to Wrong Sphere	0	
+669	Draft	Incorrect Resource Transfer Between Spheres	0	
+670	Draft	Always-Incorrect Control Flow Implementation	0	
+671	Draft	Lack of Administrator Control over Security	0	
+672	Draft	Operation on a Resource after Expiration or Release	0	
+673	Draft	External Influence of Sphere Definition	0	
+674	Draft	Uncontrolled Recursion	0	
+675	Draft	Multiple Operations on Resource in Single-Operation Context	0	
+676	Draft	Use of Potentially Dangerous Function	0	
+680	Draft	Integer Overflow to Buffer Overflow	0	
+681	Draft	Incorrect Conversion between Numeric Types	0	
+682	Draft	Incorrect Calculation	0	
+683	Draft	Function Call With Incorrect Order of Arguments	0	
+684	Draft	Incorrect Provision of Specified Functionality	0	
+685	Draft	Function Call With Incorrect Number of Arguments	0	
+686	Draft	Function Call With Incorrect Argument Type	0	
+687	Draft	Function Call With Incorrectly Specified Argument Value	0	
+688	Draft	Function Call With Incorrect Variable or Reference as Argument	0	
+689	Draft	Permission Race Condition During Resource Copy	0	
+690	Draft	Unchecked Return Value to NULL Pointer Dereference	0	
+691	Draft	Insufficient Control Flow Management	0	
+692	Draft	Incomplete Denylist to Cross-Site Scripting	0	
+693	Draft	Protection Mechanism Failure	0	
+694	Incomplete	Use of Multiple Resources with Duplicate Identifier	0	
+695	Incomplete	Use of Low-Level Functionality	0	
+696	Incomplete	Incorrect Behavior Order	0	
+697	Incomplete	Incorrect Comparison	0	
+698	Incomplete	Execution After Redirect (EAR)	0	
+703	Incomplete	Improper Check or Handling of Exceptional Conditions	0	
+704	Incomplete	Incorrect Type Conversion or Cast	0	
+705	Incomplete	Incorrect Control Flow Scoping	0	
+706	Incomplete	Use of Incorrectly-Resolved Name or Reference	0	
+707	Incomplete	Improper Neutralization	0	
+708	Incomplete	Incorrect Ownership Assignment	0	
+710	Incomplete	Improper Adherence to Coding Standards	0	
+732	Draft	Incorrect Permission Assignment for Critical Resource	0	
+733	Incomplete	Compiler Optimization Removal or Modification of Security-critical Code	0	
+749	Incomplete	Exposed Dangerous Method or Function	0	
+754	Incomplete	Improper Check for Unusual or Exceptional Conditions	0	
+755	Incomplete	Improper Handling of Exceptional Conditions	0	
+756	Incomplete	Missing Custom Error Page	0	
+757	Incomplete	Selection of Less-Secure Algorithm During Negotiation ('Algorithm Downgrade')	0	
+758	Incomplete	Reliance on Undefined, Unspecified, or Implementation-Defined Behavior	0	
+759	Incomplete	Use of a One-Way Hash without a Salt	0	
+760	Incomplete	Use of a One-Way Hash with a Predictable Salt	0	
+761	Incomplete	Free of Pointer not at Start of Buffer	0	
+762	Incomplete	Mismatched Memory Management Routines	0	
+763	Incomplete	Release of Invalid Pointer or Reference	0	
+764	Incomplete	Multiple Locks of a Critical Resource	0	
+765	Incomplete	Multiple Unlocks of a Critical Resource	0	
+766	Incomplete	Critical Data Element Declared Public	0	
+767	Incomplete	Access to Critical Private Variable via Public Method	0	
+768	Incomplete	Incorrect Short Circuit Evaluation	0	
+769	Deprecated	DEPRECATED: Uncontrolled File Descriptor Consumption	0	
+770	Incomplete	Allocation of Resources Without Limits or Throttling	0	
+771	Incomplete	Missing Reference to Active Allocated Resource	0	
+772	Draft	Missing Release of Resource after Effective Lifetime	0	
+773	Incomplete	Missing Reference to Active File Descriptor or Handle	0	
+774	Incomplete	Allocation of File Descriptors or Handles Without Limits or Throttling	0	
+775	Incomplete	Missing Release of File Descriptor or Handle after Effective Lifetime	0	
+776	Draft	Improper Restriction of Recursive Entity References in DTDs ('XML Entity Expansion')	0	
+777	Incomplete	Regular Expression without Anchors	0	
+778	Draft	Insufficient Logging	0	
+779	Draft	Logging of Excessive Data	0	
+780	Incomplete	Use of RSA Algorithm without OAEP	0	
+781	Draft	Improper Address Validation in IOCTL with METHOD_NEITHER I/O Control Code	0	
+782	Draft	Exposed IOCTL with Insufficient Access Control	0	
+783	Draft	Operator Precedence Logic Error	0	
+784	Draft	Reliance on Cookies without Validation and Integrity Checking in a Security Decision	0	
+785	Incomplete	Use of Path Manipulation Function without Maximum-sized Buffer	0	
+786	Incomplete	Access of Memory Location Before Start of Buffer	0	
+787	Draft	Out-of-bounds Write	0	
+788	Incomplete	Access of Memory Location After End of Buffer	0	
+789	Draft	Memory Allocation with Excessive Size Value	0	
+790	Incomplete	Improper Filtering of Special Elements	0	
+791	Incomplete	Incomplete Filtering of Special Elements	0	
+792	Incomplete	Incomplete Filtering of One or More Instances of Special Elements	0	
+793	Incomplete	Only Filtering One Instance of a Special Element	0	
+794	Incomplete	Incomplete Filtering of Multiple Instances of Special Elements	0	
+795	Incomplete	Only Filtering Special Elements at a Specified Location	0	
+796	Incomplete	Only Filtering Special Elements Relative to a Marker	0	
+797	Incomplete	Only Filtering Special Elements at an Absolute Position	0	
+798	Draft	Use of Hard-coded Credentials	0	
+799	Incomplete	Improper Control of Interaction Frequency	0	
+804	Incomplete	Guessable CAPTCHA	0	
+805	Incomplete	Buffer Access with Incorrect Length Value	0	
+806	Incomplete	Buffer Access Using Size of Source Buffer	0	
+807	Incomplete	Reliance on Untrusted Inputs in a Security Decision	0	
+820	Incomplete	Missing Synchronization	0	
+821	Incomplete	Incorrect Synchronization	0	
+822	Incomplete	Untrusted Pointer Dereference	0	
+823	Incomplete	Use of Out-of-range Pointer Offset	0	
+824	Incomplete	Access of Uninitialized Pointer	0	
+825	Incomplete	Expired Pointer Dereference	0	
+826	Incomplete	Premature Release of Resource During Expected Lifetime	0	
+827	Incomplete	Improper Control of Document Type Definition	0	
+828	Incomplete	Signal Handler with Functionality that is not Asynchronous-Safe	0	
+829	Incomplete	Inclusion of Functionality from Untrusted Control Sphere	0	
+830	Incomplete	Inclusion of Web Functionality from an Untrusted Source	0	
+831	Incomplete	Signal Handler Function Associated with Multiple Signals	0	
+832	Incomplete	Unlock of a Resource that is not Locked	0	
+833	Incomplete	Deadlock	0	
+834	Incomplete	Excessive Iteration	0	
+835	Incomplete	Loop with Unreachable Exit Condition ('Infinite Loop')	0	
+836	Incomplete	Use of Password Hash Instead of Password for Authentication	0	
+837	Incomplete	Improper Enforcement of a Single, Unique Action	0	
+838	Incomplete	Inappropriate Encoding for Output Context	0	
+839	Incomplete	Numeric Range Comparison Without Minimum Check	0	
+841	Incomplete	Improper Enforcement of Behavioral Workflow	0	
+842	Incomplete	Placement of User into Incorrect Group	0	
+843	Incomplete	Access of Resource Using Incompatible Type ('Type Confusion')	0	
+862	Incomplete	Missing Authorization	0	
+863	Incomplete	Incorrect Authorization	0	
+908	Incomplete	Use of Uninitialized Resource	0	
+909	Incomplete	Missing Initialization of Resource	0	
+910	Incomplete	Use of Expired File Descriptor	0	
+911	Incomplete	Improper Update of Reference Count	0	
+912	Incomplete	Hidden Functionality	0	
+913	Incomplete	Improper Control of Dynamically-Managed Code Resources	0	
+914	Incomplete	Improper Control of Dynamically-Identified Variables	0	
+915	Incomplete	Improperly Controlled Modification of Dynamically-Determined Object Attributes	0	
+916	Incomplete	Use of Password Hash With Insufficient Computational Effort	0	
+917	Incomplete	Improper Neutralization of Special Elements used in an Expression Language Statement ('Expression Language Injection')	0	
+918	Incomplete	Server-Side Request Forgery (SSRF)	0	
+920	Incomplete	Improper Restriction of Power Consumption	0	
+921	Incomplete	Storage of Sensitive Data in a Mechanism without Access Control	0	
+922	Incomplete	Insecure Storage of Sensitive Information	0	
+923	Incomplete	Improper Restriction of Communication Channel to Intended Endpoints	0	
+924	Incomplete	Improper Enforcement of Message Integrity During Transmission in a Communication Channel	0	
+925	Incomplete	Improper Verification of Intent by Broadcast Receiver	0	
+926	Incomplete	Improper Export of Android Application Components	0	
+927	Incomplete	Use of Implicit Intent for Sensitive Communication	0	
+939	Incomplete	Improper Authorization in Handler for Custom URL Scheme	0	
+940	Incomplete	Improper Verification of Source of a Communication Channel	0	
+941	Incomplete	Incorrectly Specified Destination in a Communication Channel	0	
+942	Incomplete	Permissive Cross-domain Policy with Untrusted Domains	0	
+943	Incomplete	Improper Neutralization of Special Elements in Data Query Logic	0	
+1004	Incomplete	Sensitive Cookie Without 'HttpOnly' Flag	0	
+1007	Incomplete	Insufficient Visual Distinction of Homoglyphs Presented to User	0	
+1021	Incomplete	Improper Restriction of Rendered UI Layers or Frames	0	
+1022	Incomplete	Use of Web Link to Untrusted Target with window.opener Access	0	
+1023	Incomplete	Incomplete Comparison with Missing Factors	0	
+1024	Incomplete	Comparison of Incompatible Types	0	
+1025	Incomplete	Comparison Using Wrong Factors	0	
+1037	Incomplete	Processor Optimization Removal or Modification of Security-critical Code	0	
+1038	Draft	Insecure Automated Optimizations	0	
+1039	Incomplete	Automated Recognition Mechanism with Inadequate Detection or Handling of Adversarial Input Perturbations	0	
+1041	Incomplete	Use of Redundant Code	0	
+1042	Incomplete	Static Member Data Element outside of a Singleton Class Element	0	
+1043	Incomplete	Data Element Aggregating an Excessively Large Number of Non-Primitive Elements	0	
+1044	Incomplete	Architecture with Number of Horizontal Layers Outside of Expected Range	0	
+1045	Incomplete	Parent Class with a Virtual Destructor and a Child Class without a Virtual Destructor	0	
+1046	Incomplete	Creation of Immutable Text Using String Concatenation	0	
+1047	Incomplete	Modules with Circular Dependencies	0	
+1048	Incomplete	Invokable Control Element with Large Number of Outward Calls	0	
+1049	Incomplete	Excessive Data Query Operations in a Large Data Table	0	
+1050	Incomplete	Excessive Platform Resource Consumption within a Loop	0	
+1051	Incomplete	Initialization with Hard-Coded Network Resource Configuration Data	0	
+1052	Incomplete	Excessive Use of Hard-Coded Literals in Initialization	0	
+1053	Incomplete	Missing Documentation for Design	0	
+1054	Incomplete	Invocation of a Control Element at an Unnecessarily Deep Horizontal Layer	0	
+1055	Incomplete	Multiple Inheritance from Concrete Classes	0	
+1056	Incomplete	Invokable Control Element with Variadic Parameters	0	
+1057	Incomplete	Data Access Operations Outside of Expected Data Manager Component	0	
+1058	Incomplete	Invokable Control Element in Multi-Thread Context with non-Final Static Storable or Member Element	0	
+1059	Incomplete	Insufficient Technical Documentation	0	
+1060	Incomplete	Excessive Number of Inefficient Server-Side Data Accesses	0	
+1061	Incomplete	Insufficient Encapsulation	0	
+1062	Incomplete	Parent Class with References to Child Class	0	
+1063	Incomplete	Creation of Class Instance within a Static Code Block	0	
+1064	Incomplete	Invokable Control Element with Signature Containing an Excessive Number of Parameters	0	
+1065	Incomplete	Runtime Resource Management Control Element in a Component Built to Run on Application Servers	0	
+1066	Incomplete	Missing Serialization Control Element	0	
+1067	Incomplete	Excessive Execution of Sequential Searches of Data Resource	0	
+1068	Incomplete	Inconsistency Between Implementation and Documented Design	0	
+1069	Incomplete	Empty Exception Block	0	
+1070	Incomplete	Serializable Data Element Containing non-Serializable Item Elements	0	
+1071	Incomplete	Empty Code Block	0	
+1072	Incomplete	Data Resource Access without Use of Connection Pooling	0	
+1073	Incomplete	Non-SQL Invokable Control Element with Excessive Number of Data Resource Accesses	0	
+1074	Incomplete	Class with Excessively Deep Inheritance	0	
+1075	Incomplete	Unconditional Control Flow Transfer outside of Switch Block	0	
+1076	Incomplete	Insufficient Adherence to Expected Conventions	0	
+1077	Incomplete	Floating Point Comparison with Incorrect Operator	0	
+1078	Incomplete	Inappropriate Source Code Style or Formatting	0	
+1079	Incomplete	Parent Class without Virtual Destructor Method	0	
+1080	Incomplete	Source Code File with Excessive Number of Lines of Code	0	
+1082	Incomplete	Class Instance Self Destruction Control Element	0	
+1083	Incomplete	Data Access from Outside Expected Data Manager Component	0	
+1084	Incomplete	Invokable Control Element with Excessive File or Data Access Operations	0	
+1085	Incomplete	Invokable Control Element with Excessive Volume of Commented-out Code	0	
+1086	Incomplete	Class with Excessive Number of Child Classes	0	
+1087	Incomplete	Class with Virtual Method without a Virtual Destructor	0	
+1088	Incomplete	Synchronous Access of Remote Resource without Timeout	0	
+1089	Incomplete	Large Data Table with Excessive Number of Indices	0	
+1090	Incomplete	Method Containing Access of a Member Element from Another Class	0	
+1091	Incomplete	Use of Object without Invoking Destructor Method	0	
+1092	Incomplete	Use of Same Invokable Control Element in Multiple Architectural Layers	0	
+1093	Incomplete	Excessively Complex Data Representation	0	
+1094	Incomplete	Excessive Index Range Scan for a Data Resource	0	
+1095	Incomplete	Loop Condition Value Update within the Loop	0	
+1096	Incomplete	Singleton Class Instance Creation without Proper Locking or Synchronization	0	
+1097	Incomplete	Persistent Storable Data Element without Associated Comparison Control Element	0	
+1098	Incomplete	Data Element containing Pointer Item without Proper Copy Control Element	0	
+1099	Incomplete	Inconsistent Naming Conventions for Identifiers	0	
+1100	Incomplete	Insufficient Isolation of System-Dependent Functions	0	
+1101	Incomplete	Reliance on Runtime Component in Generated Code	0	
+1102	Incomplete	Reliance on Machine-Dependent Data Representation	0	
+1103	Incomplete	Use of Platform-Dependent Third Party Components	0	
+1104	Incomplete	Use of Unmaintained Third Party Components	0	
+1105	Incomplete	Insufficient Encapsulation of Machine-Dependent Functionality	0	
+1106	Incomplete	Insufficient Use of Symbolic Constants	0	
+1107	Incomplete	Insufficient Isolation of Symbolic Constant Definitions	0	
+1108	Incomplete	Excessive Reliance on Global Variables	0	
+1109	Incomplete	Use of Same Variable for Multiple Purposes	0	
+1110	Incomplete	Incomplete Design Documentation	0	
+1111	Incomplete	Incomplete I/O Documentation	0	
+1112	Incomplete	Incomplete Documentation of Program Execution	0	
+1113	Incomplete	Inappropriate Comment Style	0	
+1114	Incomplete	Inappropriate Whitespace Style	0	
+1115	Incomplete	Source Code Element without Standard Prologue	0	
+1116	Incomplete	Inaccurate Comments	0	
+1117	Incomplete	Callable with Insufficient Behavioral Summary	0	
+1118	Incomplete	Insufficient Documentation of Error Handling Techniques	0	
+1119	Incomplete	Excessive Use of Unconditional Branching	0	
+1120	Incomplete	Excessive Code Complexity	0	
+1121	Incomplete	Excessive McCabe Cyclomatic Complexity	0	
+1122	Incomplete	Excessive Halstead Complexity	0	
+1123	Incomplete	Excessive Use of Self-Modifying Code	0	
+1124	Incomplete	Excessively Deep Nesting	0	
+1125	Incomplete	Excessive Attack Surface	0	
+1126	Incomplete	Declaration of Variable with Unnecessarily Wide Scope	0	
+1127	Incomplete	Compilation with Insufficient Warnings or Errors	0	
+1164	Incomplete	Irrelevant Code	0	
+1173	Draft	Improper Use of Validation Framework	0	
+1174	Draft	ASP.NET Misconfiguration: Improper Model Validation	0	
+1176	Incomplete	Inefficient CPU Computation	0	
+1177	Incomplete	Use of Prohibited Code	0	
+1187	Deprecated	DEPRECATED: Use of Uninitialized Resource	0	
+1188	Incomplete	Insecure Default Initialization of Resource	0	
+1189	Stable	Improper Isolation of Shared Resources on System-on-a-Chip (SoC)	0	
+1190	Draft	DMA Device Enabled Too Early in Boot Phase	0	
+1191	Stable	On-Chip Debug and Test Interface With Improper Access Control	0	
+1192	Draft	System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers	0	
+1193	Draft	Power-On of Untrusted Execution Core Before Enabling Fabric Access Control	0	
+1204	Incomplete	Generation of Weak Initialization Vector (IV)	0	
+1209	Incomplete	Failure to Disable Reserved Bits	0	
+1220	Incomplete	Insufficient Granularity of Access Control	0	
+1221	Incomplete	Incorrect Register Defaults or Module Parameters	0	
+1222	Incomplete	Insufficient Granularity of Address Regions Protected by Register Locks	0	
+1223	Incomplete	Race Condition for Write-Once Attributes	0	
+1224	Incomplete	Improper Restriction of Write-Once Bit Fields	0	
+1229	Incomplete	Creation of Emergent Resource	0	
+1230	Incomplete	Exposure of Sensitive Information Through Metadata	0	
+1231	Stable	Improper Prevention of Lock Bit Modification	0	
+1232	Incomplete	Improper Lock Behavior After Power State Transition	0	
+1233	Stable	Security-Sensitive Hardware Controls with Missing Lock Bit Protection	0	
+1234	Incomplete	Hardware Internal or Debug Modes Allow Override of Locks	0	
+1235	Incomplete	Incorrect Use of Autoboxing and Unboxing for Performance Critical Operations	0	
+1236	Incomplete	Improper Neutralization of Formula Elements in a CSV File	0	
+1239	Draft	Improper Zeroization of Hardware Register	0	
+1240	Draft	Use of a Cryptographic Primitive with a Risky Implementation	0	
+1241	Draft	Use of Predictable Algorithm in Random Number Generator	0	
+1242	Incomplete	Inclusion of Undocumented Features or Chicken Bits	0	
+1243	Incomplete	Sensitive Non-Volatile Information Not Protected During Debug	0	
+1244	Stable	Internal Asset Exposed to Unsafe Debug Access Level or State	0	
+1245	Incomplete	Improper Finite State Machines (FSMs) in Hardware Logic	0	
+1246	Incomplete	Improper Write Handling in Limited-write Non-Volatile Memories	0	
+1247	Stable	Improper Protection Against Voltage and Clock Glitches	0	
+1248	Incomplete	Semiconductor Defects in Hardware Logic with Security-Sensitive Implications	0	
+1249	Incomplete	Application-Level Admin Tool with Inconsistent View of Underlying Operating System	0	
+1250	Incomplete	Improper Preservation of Consistency Between Independent Representations of Shared State	0	
+1251	Incomplete	Mirrored Regions with Different Values	0	
+1252	Incomplete	CPU Hardware Not Configured to Support Exclusivity of Write and Execute Operations	0	
+1253	Draft	Incorrect Selection of Fuse Values	0	
+1254	Draft	Incorrect Comparison Logic Granularity	0	
+1255	Draft	Comparison Logic is Vulnerable to Power Side-Channel Attacks	0	
+1256	Stable	Improper Restriction of Software Interfaces to Hardware Features	0	
+1257	Incomplete	Improper Access Control Applied to Mirrored or Aliased Memory Regions	0	
+1258	Draft	Exposure of Sensitive System Information Due to Uncleared Debug Information	0	
+1259	Incomplete	Improper Restriction of Security Token Assignment	0	
+1260	Stable	Improper Handling of Overlap Between Protected Memory Ranges	0	
+1261	Draft	Improper Handling of Single Event Upsets	0	
+1262	Stable	Improper Access Control for Register Interface	0	
+1263	Incomplete	Improper Physical Access Control	0	
+1264	Incomplete	Hardware Logic with Insecure De-Synchronization between Control and Data Channels	0	
+1265	Draft	Unintended Reentrant Invocation of Non-reentrant Code Via Nested Calls	0	
+1266	Incomplete	Improper Scrubbing of Sensitive Data from Decommissioned Device	0	
+1267	Draft	Policy Uses Obsolete Encoding	0	
+1268	Draft	Policy Privileges are not Assigned Consistently Between Control and Data Agents	0	
+1269	Incomplete	Product Released in Non-Release Configuration	0	
+1270	Incomplete	Generation of Incorrect Security Tokens	0	
+1271	Incomplete	Uninitialized Value on Reset for Registers Holding Security Settings	0	
+1272	Stable	Sensitive Information Uncleared Before Debug/Power State Transition	0	
+1273	Incomplete	Device Unlock Credential Sharing	0	
+1274	Stable	Improper Access Control for Volatile Memory Containing Boot Code	0	
+1275	Incomplete	Sensitive Cookie with Improper SameSite Attribute	0	
+1276	Incomplete	Hardware Child Block Incorrectly Connected to Parent System	0	
+1277	Draft	Firmware Not Updateable	0	
+1278	Incomplete	Missing Protection Against Hardware Reverse Engineering Using Integrated Circuit (IC) Imaging Techniques	0	
+1279	Incomplete	Cryptographic Operations are run Before Supporting Units are Ready	0	
+1280	Incomplete	Access Control Check Implemented After Asset is Accessed	0	
+1281	Incomplete	Sequence of Processor Instructions Leads to Unexpected Behavior	0	
+1282	Incomplete	Assumed-Immutable Data is Stored in Writable Memory	0	
+1283	Incomplete	Mutable Attestation or Measurement Reporting Data	0	
+1284	Incomplete	Improper Validation of Specified Quantity in Input	0	
+1285	Incomplete	Improper Validation of Specified Index, Position, or Offset in Input	0	
+1286	Incomplete	Improper Validation of Syntactic Correctness of Input	0	
+1287	Incomplete	Improper Validation of Specified Type of Input	0	
+1288	Incomplete	Improper Validation of Consistency within Input	0	
+1289	Incomplete	Improper Validation of Unsafe Equivalence in Input	0	
+1290	Incomplete	Incorrect Decoding of Security Identifiers 	0	
+1291	Draft	Public Key Re-Use for Signing both Debug and Production Code	0	
+1292	Draft	Incorrect Conversion of Security Identifiers	0	
+1293	Draft	Missing Source Correlation of Multiple Independent Data	0	
+1294	Incomplete	Insecure Security Identifier Mechanism	0	
+1295	Incomplete	Debug Messages Revealing Unnecessary Information	0	
+1296	Incomplete	Incorrect Chaining or Granularity of Debug Components	0	
+1297	Incomplete	Unprotected Confidential Information on Device is Accessible by OSAT Vendors	0	
+1298	Draft	Hardware Logic Contains Race Conditions	0	
+1299	Draft	Missing Protection Mechanism for Alternate Hardware Interface	0	
+1300	Stable	Improper Protection of Physical Side Channels	0	
+1301	Incomplete	Insufficient or Incomplete Data Removal within Hardware Component	0	
+1302	Incomplete	Missing Security Identifier	0	
+1303	Draft	Non-Transparent Sharing of Microarchitectural Resources	0	
+1304	Draft	Improperly Preserved Integrity of Hardware Configuration State During a Power Save/Restore Operation	0	
+1310	Draft	Missing Ability to Patch ROM Code	0	
+1311	Draft	Improper Translation of Security Attributes by Fabric Bridge	0	
+1312	Draft	Missing Protection for Mirrored Regions in On-Chip Fabric Firewall	0	
+1313	Draft	Hardware Allows Activation of Test or Debug Logic at Runtime	0	
+1314	Draft	Missing Write Protection for Parametric Data Values	0	
+1315	Incomplete	Improper Setting of Bus Controlling Capability in Fabric End-point	0	
+1316	Draft	Fabric-Address Map Allows Programming of Unwarranted Overlaps of Protected and Unprotected Ranges	0	
+1317	Draft	Improper Access Control in Fabric Bridge	0	
+1318	Incomplete	Missing Support for Security Features in On-chip Fabrics or Buses	0	
+1319	Incomplete	Improper Protection against Electromagnetic Fault Injection (EM-FI)	0	
+1320	Draft	Improper Protection for Outbound Error Messages and Alert Signals	0	
+1321	Incomplete	Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')	0	
+1322	Incomplete	Use of Blocking Code in Single-threaded, Non-blocking Context	0	
+1323	Draft	Improper Management of Sensitive Trace Data	0	
+1324	Draft	Sensitive Information Accessible by Physical Probing of JTAG Interface	0	
+1325	Incomplete	Improperly Controlled Sequential Memory Allocation	0	
+1326	Draft	Missing Immutable Root of Trust in Hardware	0	
+1327	Incomplete	Binding to an Unrestricted IP Address	0	
+1328	Draft	Security Version Number Mutable to Older Versions	0	
+1329	Incomplete	Reliance on Component That is Not Updateable	0	
+1330	Draft	Remanent Data Readable after Memory Erase	0	
+1331	Stable	Improper Isolation of Shared Resources in Network On Chip (NoC)	0	
+1332	Stable	Improper Handling of Faults that Lead to Instruction Skips	0	
+1333	Draft	Inefficient Regular Expression Complexity	0	
+1334	Draft	Unauthorized Error Injection Can Degrade Hardware Redundancy	0	
+1335	Draft	Incorrect Bitwise Shift of Integer	0	
+1336	Incomplete	Improper Neutralization of Special Elements Used in a Template Engine	0	
+1338	Draft	Improper Protections Against Hardware Overheating	0	
+1339	Draft	Insufficient Precision or Accuracy of a Real Number	0	
+1341	Incomplete	Multiple Releases of Same Resource or Handle	0	
+1342	Incomplete	Information Exposure through Microarchitectural State after Transient Execution	0	
+1351	Incomplete	Improper Handling of Hardware Behavior in Exceptionally Cold Environments	0	
+1357	Incomplete	Reliance on Uncontrolled Component	0	
+1384	Incomplete	Improper Handling of Physical or Environmental Conditions	0	
+1385	Incomplete	Missing Origin Validation in WebSockets	0	
+1386	Incomplete	Insecure Operation on Windows Junction / Mount Point	0	
+1389	Incomplete	Incorrect Parsing of Numbers with Different Radices	0	
+1390	Incomplete	Weak Authentication	0	
+1391	Incomplete	Use of Weak Credentials	0	
+1392	Incomplete	Use of Default Credentials	0	
+1393	Incomplete	Use of Default Password	0	
+1394	Incomplete	Use of Default Cryptographic Key	0	

--- a/scripts/update/convert-cwe-to-csv.xslt
+++ b/scripts/update/convert-cwe-to-csv.xslt
@@ -1,9 +1,28 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     <xsl:output method="text" />
     <xsl:template match="/">
+        <!-- filename extract: version + underscore + date -->
         <xsl:value-of select="//*[local-name()='Weakness_Catalog']/@Version|//*[local-name()='Weakness_Catalog']/@Catalog_Version" /><xsl:text>_</xsl:text><xsl:value-of select="//*[local-name()='Weakness_Catalog']/@Date|//*[local-name()='Weakness_Catalog']/@Catalog_Date" /><xsl:text>&#10;</xsl:text>
+        <!-- cwe entry extract -->
         <xsl:for-each select="//*[local-name()='Weakness']">
-            <xsl:value-of select="@ID" /><xsl:text>&#09;</xsl:text><xsl:value-of select="@Status" /><xsl:text>&#09;</xsl:text><xsl:value-of select="@Name" /><xsl:text>&#10;</xsl:text>
+            <!-- weakness id -->
+            <xsl:value-of select="@ID" />
+            <xsl:text>&#09;</xsl:text>
+            <!-- weakness status -->
+            <xsl:value-of select="@Status" />
+            <xsl:text>&#09;</xsl:text>
+            <!-- weakness name -->
+            <xsl:value-of select="@Name" />
+            <xsl:text>&#09;</xsl:text>
+            <!-- does weakness have Mapping_Notes/Usage field (bool), should be 0 before / 1 after version 4.12 -->
+            <xsl:choose>
+                <xsl:when test="./*[local-name()='Mapping_Notes']/*[local-name()='Usage']/text()">1</xsl:when>
+                <xsl:otherwise>0</xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>&#09;</xsl:text>
+            <!-- weakness usage (empty if unavailable) -->
+            <xsl:value-of select="./*[local-name()='Mapping_Notes']/*[local-name()='Usage']" />
+            <xsl:text>&#10;</xsl:text>
         </xsl:for-each> 
     </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
This PR:
* extends the cwe xslt to add two fields to the generated csv
    * 3rd field: is Mapping_Notes/Usage available for this entry
    * 4th field: Mapping_Notes/Usage, empty if unavailable
* reruns the xslt for all cwes

The 4th field would have technically been enough, as we can expect the field to be filled if present, but this should make importing a bit quicker.

This should make implementation of 6.2.25/26 easier, as only extending the helpers.rs section and implementing the check is necessary.

