### PR TITLE
feat: models-only build behind a default-on validation feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,6 +180,9 @@ jobs:
       - name: Build with --no-default-features
         run: cargo build --locked --target=${{ matrix.target.arch }} --no-default-features --verbose
         if: ${{ matrix.target.skip-test != true }}
+      - name: Test the models-only build
+        run: cargo test --locked --target=${{ matrix.target.arch }} -p csaf-rs --no-default-features --verbose
+        if: ${{ matrix.target.skip-test != true }}
       - name: Archive csaf-validator (${{ matrix.target.arch }})
         if: matrix.version == needs.prepare.outputs.stable-version
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ let test_ids_in_basic_preset = CommonSecurityAdvisoryFramework::tests_in_preset(
 
 `validation` (default) — the validation framework: the 6.x test implementations, the trait and rich-type layer, and the document loaders.
 Disabling it leaves a models-only build: the generated `schema::csaf2_0`/`schema::csaf2_1` serde types, with `serde`, `serde_json`, `regress`, and `uuid` as the only dependencies.
+The generated types enforce the structural schema — required fields, enums, string patterns, length bounds — on deserialization and on every constructor; the semantic tests require `validation`.
 
 ```toml
 csaf-rs = { version = "0.5", default-features = false }

--- a/README.md
+++ b/README.md
@@ -72,6 +72,23 @@ let single_test_result = validate_by_test(&document, "6.1.13");
 let test_ids_in_basic_preset = CommonSecurityAdvisoryFramework::tests_in_preset("basic");
 ```
 
+#### Cargo features
+
+`validation` (default) — the validation framework: the 6.x test implementations, the trait and rich-type layer, and the document loaders.
+Disabling it leaves a models-only build: the generated `schema::csaf2_0`/`schema::csaf2_1` serde types, with `serde`, `serde_json`, `regress`, and `uuid` as the only dependencies.
+
+```toml
+csaf-rs = { version = "0.5", default-features = false }
+```
+
+```rust
+use csaf::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework;
+
+let document: CommonSecurityAdvisoryFramework = serde_json::from_str(&json)?;
+```
+
+`converter` — the document conversion helpers; implies `validation`.
+
 ### Go 
 
 To use this library you have to download the binaries for your specific operating system and platform. A download script is provided to help you with that.

--- a/csaf-ffi/Cargo.toml
+++ b/csaf-ffi/Cargo.toml
@@ -15,7 +15,7 @@ name = "csaf_ffi"
 crate-type = ["cdylib", "staticlib", "lib"]
 
 [dependencies]
-csaf = { package = "csaf-rs", path = "../csaf-rs", default-features = false }
+csaf = { package = "csaf-rs", path = "../csaf-rs", default-features = false, features = ["validation"] }
 uniffi = { version = "0.31.0", features = ["scaffolding-ffi-buffer-fns"] }
 serde_json = "1"
 thiserror = "2"

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -18,24 +18,36 @@ name = "csaf"
 crate-type = ["rlib"]
 
 [features]
-default = []
-converter = []
+default = ["validation"]
+validation = [
+    "dep:chrono",
+    "dep:cvss-rs",
+    "dep:jsonschema",
+    "dep:oxilangtag",
+    "dep:packageurl",
+    "dep:regex",
+    "dep:rust-embed",
+    "dep:semver",
+    "dep:spdx",
+    "dep:ssvc",
+]
+converter = ["validation"]
 
 [dependencies]
-cvss-rs = "0.4.0"
+cvss-rs = { version = "0.4.0", optional = true }
 regress = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.131", features = ["preserve_order"] }
-chrono = { version = "0.4", features = ["serde"] }
-regex = "1"
-rust-embed = { version = "8", features = ["include-exclude"] }
-packageurl = "0.7"
+chrono = { version = "0.4", features = ["serde"], optional = true }
+regex = { version = "1", optional = true }
+rust-embed = { version = "8", features = ["include-exclude"], optional = true }
+packageurl = { version = "0.7", optional = true }
 uuid = { version = "1.17.0", features = ["v7", "serde"] }
-semver = { version = "1" }
-jsonschema = { version = "0.49.1", default-features = false }
-spdx = "0.13.4"
-oxilangtag = "0.1.5"
-ssvc = "0.1.0"
+semver = { version = "1", optional = true }
+jsonschema = { version = "0.49.1", default-features = false, optional = true }
+spdx = { version = "0.13.4", optional = true }
+oxilangtag = { version = "0.1.5", optional = true }
+ssvc = { version = "0.1.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.17.0", features = ["v7", "serde", "js"] }
@@ -52,4 +64,5 @@ tempfile = "3"
 [[bench]]
 name = "validation_benchmark"
 harness = false
+required-features = ["validation"]
 

--- a/csaf-rs/src/lib.rs
+++ b/csaf-rs/src/lib.rs
@@ -1,25 +1,37 @@
 #[cfg(feature = "converter")]
 pub mod converter;
+#[cfg(feature = "validation")]
 pub mod csaf;
+#[cfg(feature = "validation")]
 pub mod csaf2_0;
+#[cfg(feature = "validation")]
 pub mod csaf2_1;
+#[cfg(feature = "validation")]
 pub mod csaf_traits;
+#[cfg(feature = "validation")]
 pub(crate) mod cvss;
+#[cfg(feature = "validation")]
 pub mod helpers;
 pub mod json;
 pub(crate) mod macros;
 pub mod schema;
-#[cfg(test)]
+#[cfg(all(test, feature = "validation"))]
 pub mod test_result_comparison;
 #[cfg(test)]
 pub mod test_structure;
+#[cfg(feature = "validation")]
 pub mod test_validation;
+#[cfg(feature = "validation")]
 pub mod validation;
+#[cfg(feature = "validation")]
 pub mod validation_result;
+#[cfg(feature = "validation")]
 pub mod validations;
 
 /// The CVSS metric types returned by `ContentTrait`'s typed accessors
 /// (`get_cvss_v2_typed`, `get_cvss_v3_typed`, `get_cvss_v4_typed`).
+#[cfg(feature = "validation")]
 pub use cvss_rs;
 /// The SSVC selection types returned by `ContentTrait::get_ssvc_v2`.
+#[cfg(feature = "validation")]
 pub use ssvc;

--- a/csaf-rs/src/macros/mod.rs
+++ b/csaf-rs/src/macros/mod.rs
@@ -1,6 +1,11 @@
 mod string_newtype;
-mod test_gen;
 
 pub(crate) use string_newtype::impl_string_newtype_ergonomics;
+
+#[cfg(feature = "validation")]
+mod test_gen;
+
+#[cfg(feature = "validation")]
 pub(crate) use test_gen::define_csaf_test;
+#[cfg(feature = "validation")]
 pub(crate) use test_gen::define_test_cases_aggregate;


### PR DESCRIPTION
The demonstration PR for csaf-rs/csaf#733: `validation` is a default-on feature; disabling it builds the generated schema types plus the JSON plumbing with `serde`, `serde_json`, `regress`, and `uuid` as the only dependencies.

Design, matching the module graph:

- Every gate is a module-root `#[cfg(feature = "validation")]` - 12 in `lib.rs`, 3 in `macros/mod.rs`; zero function-level cfg. The `converter` gate at `lib.rs:1` was the precedent.
- The `csaf` umbrella (traits, rich types, `RawDocument`, loaders) gates with validation, as the issue sketched; models-only consumers deserialize via `serde_json` or the ungated `JsonSource`. Keeping `RawDocument`/`detect_version` models-side is possible later by moving two impl blocks out of `raw.rs` - left out to keep this diff minimal.
- `converter = ["validation"]` (it builds on the trait layer). The bench declares `required-features = ["validation"]`.
- The macro gate sits inside `macros/mod.rs` rather than on the module declaration, so the string-newtype macro from #717 lands ungated beside it without conflict.

Two discoveries the issue text did not know:

- csaf-ffi already sets `default-features = false` and imports `csaf::validation`; it compiled only because `validation` was unconditional. Its isolated `-p csaf-ffi` builds (the wasm/go binding scripts and the CI wasm job) see no feature unification, so the manifest now pins `features = ["validation"]`.
- The existing workspace-level `--no-default-features` CI step never disables csaf-rs defaults - the other members re-enable them through resolver-2 unification. The second commit adds the `-p csaf-rs --no-default-features` test step that actually exercises models-only.

Numbers (local, directional): resolved dependency graph:
152 → 25 crates; cold debug build 32.7 s → 17.7 s wall, 193 s → 79 s CPU.