### PR TITLE
perf: parse each document once on the version-detection path

### DIFF
--- a/csaf-ffi/src/document.rs
+++ b/csaf-ffi/src/document.rs
@@ -53,8 +53,8 @@ impl CsafDocument {
             .to_string();
 
         match version.as_str() {
-            "2.0" => Self::from_json_2_0(json_str),
-            "2.1" => Self::from_json_2_1(json_str),
+            "2.0" => Self::from_value_2_0(value, json_str),
+            "2.1" => Self::from_value_2_1(value, json_str),
             other => Err(CsafError::UnsupportedVersion {
                 version: other.to_string(),
             }),
@@ -172,5 +172,27 @@ impl CsafDocument {
     /// The original JSON string used to create this document.
     pub fn to_json(&self) -> String {
         self.raw_json.clone()
+    }
+}
+
+impl CsafDocument {
+    /// Build a 2.0 document from the already parsed JSON value, keeping the original string.
+    fn from_value_2_0(value: serde_json::Value, json_str: String) -> Result<Arc<Self>, CsafError> {
+        let raw = load_2_0(value).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+        Ok(Arc::new(Self {
+            inner: Mutex::new(DocumentInner::V20(raw)),
+            version_string: "2.0".into(),
+            raw_json: json_str,
+        }))
+    }
+
+    /// Build a 2.1 document from the already parsed JSON value, keeping the original string.
+    fn from_value_2_1(value: serde_json::Value, json_str: String) -> Result<Arc<Self>, CsafError> {
+        let raw = load_2_1(value).map_err(|e| CsafError::LoadError { message: e.to_string() })?;
+        Ok(Arc::new(Self {
+            inner: Mutex::new(DocumentInner::V21(raw)),
+            version_string: "2.1".into(),
+            raw_json: json_str,
+        }))
     }
 }

--- a/csaf-result-json/src/main.rs
+++ b/csaf-result-json/src/main.rs
@@ -173,9 +173,6 @@ fn main() -> Result<(), anyhow::Error> {
     }
 }
 
-/// Validate a CSAF document of the specified version with the provided arguments.
-///
-/// This prints the results of the tests on stdout.
 /// Load a document of the given version from any JSON source and validate it.
 fn load_and_validate<S: JsonSource>(source: S, version: &str, tests: &[&str]) -> Result<ValidationResult> {
     match version {
@@ -185,6 +182,9 @@ fn load_and_validate<S: JsonSource>(source: S, version: &str, tests: &[&str]) ->
     }
 }
 
+/// Validate a CSAF document of the specified version with the provided arguments.
+///
+/// This prints the results of the tests on stdout.
 fn validate_document<T>(document: T, version: &str, tests: &[&str]) -> ValidationResult
 where
     T: Validatable,

--- a/csaf-result-json/src/main.rs
+++ b/csaf-result-json/src/main.rs
@@ -8,9 +8,10 @@ use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 use compare::compare_result_jsons;
 use convert::build_testresult_json;
-use csaf::csaf::loader::detect_version;
+use csaf::csaf::loader::detect_version_with;
 use csaf::csaf2_0::loader::load_document as load_document_2_0;
 use csaf::csaf2_1::loader::load_document as load_document_2_1;
+use csaf::json::JsonSource;
 use csaf::validation::{Validatable, ValidationResult, validate_by_tests};
 use result::ResultJson;
 
@@ -80,21 +81,12 @@ fn main() -> Result<(), anyhow::Error> {
 
             let file_path = Path::new(&path);
 
-            let version = match args.csaf_version.as_str() {
-                "auto" => detect_version(file_path)?,
-                other => other.to_string(),
-            };
-
-            let result = match version.as_str() {
-                "2.0" => {
-                    let document = load_document_2_0(file_path)?;
-                    validate_document(document, "2.0", &tests)
+            let result = match args.csaf_version.as_str() {
+                "auto" => {
+                    let detected = detect_version_with(file_path)?;
+                    load_and_validate(detected.data, &detected.version, &tests)?
                 },
-                "2.1" => {
-                    let document = load_document_2_1(file_path)?;
-                    validate_document(document, "2.1", &tests)
-                },
-                _ => bail!(format!("Invalid CSAF version: {version}")),
+                other => load_and_validate(file_path, other, &tests)?,
             };
 
             let test_result = build_testresult_json(&result, test_id.as_str())?;
@@ -127,21 +119,12 @@ fn main() -> Result<(), anyhow::Error> {
 
             let file_path = Path::new(&path);
 
-            let version = match args.csaf_version.as_str() {
-                "auto" => detect_version(file_path)?,
-                other => other.to_string(),
-            };
-
-            let result = match version.as_str() {
-                "2.0" => {
-                    let document = load_document_2_0(file_path)?;
-                    validate_document(document, "2.0", &tests)
+            let result = match args.csaf_version.as_str() {
+                "auto" => {
+                    let detected = detect_version_with(file_path)?;
+                    load_and_validate(detected.data, &detected.version, &tests)?
                 },
-                "2.1" => {
-                    let document = load_document_2_1(file_path)?;
-                    validate_document(document, "2.1", &tests)
-                },
-                _ => bail!(format!("Invalid CSAF version: {version}")),
+                other => load_and_validate(file_path, other, &tests)?,
             };
 
             let actual = build_testresult_json(&result, expected.primary_result.id.as_str())?;
@@ -193,6 +176,15 @@ fn main() -> Result<(), anyhow::Error> {
 /// Validate a CSAF document of the specified version with the provided arguments.
 ///
 /// This prints the results of the tests on stdout.
+/// Load a document of the given version from any JSON source and validate it.
+fn load_and_validate<S: JsonSource>(source: S, version: &str, tests: &[&str]) -> Result<ValidationResult> {
+    match version {
+        "2.0" => Ok(validate_document(load_document_2_0(source)?, "2.0", tests)),
+        "2.1" => Ok(validate_document(load_document_2_1(source)?, "2.1", tests)),
+        _ => bail!(format!("Invalid CSAF version: {version}")),
+    }
+}
+
 fn validate_document<T>(document: T, version: &str, tests: &[&str]) -> ValidationResult
 where
     T: Validatable,

--- a/csaf-result-json/src/main.rs
+++ b/csaf-result-json/src/main.rs
@@ -181,7 +181,7 @@ fn load_and_validate<S: JsonSource>(source: S, version: &str, tests: &[&str]) ->
     match version {
         "2.0" => Ok(validate_document(load_document_2_0(source)?, "2.0", tests)),
         "2.1" => Ok(validate_document(load_document_2_1(source)?, "2.1", tests)),
-        _ => bail!(format!("Invalid CSAF version: {version}")),
+        _ => bail!("Invalid CSAF version: {version}"),
     }
 }
 

--- a/csaf-validator/src/main.rs
+++ b/csaf-validator/src/main.rs
@@ -84,7 +84,7 @@ fn load_and_validate<S: JsonSource>(source: S, version: &str, args: &Args) -> Re
             let document = load_document_2_1(source)?;
             Ok(validate_document(document, "2.1", args))
         },
-        _ => bail!(format!("Invalid CSAF version: {version}")),
+        _ => bail!("Invalid CSAF version: {version}"),
     }
 }
 

--- a/csaf-validator/src/main.rs
+++ b/csaf-validator/src/main.rs
@@ -1,9 +1,10 @@
 use anstream::println;
 use anyhow::{Result, bail};
 use clap::{CommandFactory, Parser};
-use csaf::csaf::loader::detect_version;
+use csaf::csaf::loader::detect_version_with;
 use csaf::csaf2_0::loader::load_document as load_document_2_0;
 use csaf::csaf2_1::loader::load_document as load_document_2_1;
+use csaf::json::JsonSource;
 use csaf::validation::ValidationError;
 use csaf::validation::{
     TestResult,
@@ -63,17 +64,24 @@ fn main() -> Result<(), anyhow::Error> {
 fn validate_file(path: &Path, args: &Args) -> Result<ValidationResult> {
     let file_color = anstyle::Style::new().fg_color(Some(anstyle::AnsiColor::Cyan.into()));
     println!("Validating file: {file_color}{}{file_color:#}", path.display());
-    let version = match args.csaf_version.as_str() {
-        "auto" => detect_version(path)?,
-        other => other.to_string(),
-    };
-    match version.as_str() {
+    match args.csaf_version.as_str() {
+        "auto" => {
+            let detected = detect_version_with(path)?;
+            load_and_validate(detected.data, &detected.version, args)
+        },
+        other => load_and_validate(path, other, args),
+    }
+}
+
+/// Load a document of the given version from any JSON source and validate it.
+fn load_and_validate<S: JsonSource>(source: S, version: &str, args: &Args) -> Result<ValidationResult> {
+    match version {
         "2.0" => {
-            let document = load_document_2_0(path)?;
+            let document = load_document_2_0(source)?;
             Ok(validate_document(document, "2.0", args))
         },
         "2.1" => {
-            let document = load_document_2_1(path)?;
+            let document = load_document_2_1(source)?;
             Ok(validate_document(document, "2.1", args))
         },
         _ => bail!(format!("Invalid CSAF version: {version}")),


### PR DESCRIPTION
Implements the double-parse finding from the #742 survey.

Auto mode in csaf-validator and csaf-result-json read and parsed every document twice - `detect_version` and `load_document` each did the full file read plus string→`Value` parse - and csaf-ffi's `from_json` parsed the identical string twice (the path wasm and Go consumers take). The enabling API already existed: `detect_version_with` returns `VersionAndData` for exactly this reuse, and `JsonSource` is implemented for `serde_json::Value`, so the fix is wiring the call sites - no csaf-rs changes at all.

- Both CLIs gain a small `load_and_validate(source: impl JsonSource, version, …)` helper; auto mode feeds it `detected.data`, explicit mode the path as before (one parse either way now).
- The FFI keeps its public constructors unchanged and routes `from_json` through private `from_value_2_0/2_1` helpers that keep the original string for `to_json()`.

Measured end to end (release csaf-validator, auto mode, one cheap test over the 902-file CSAF 2.1 corpus ×10, local and directional): wall time 0.61 s → 0.48 s (−22%), user CPU −20%.
The share grows with document size and the fixture corpus averages ~1 KB, real advisories are much larger.

Out of scope, per the survey: caching the reference accessors (needs API design) and jsonschema schema-test visibility; the stale 6.1.14 bench skip is separate hygiene.
