### PR TITLE
chore: pass chars.rs char by value

### DIFF
--- a/csaf-rs/src/csaf/consts/chars.rs
+++ b/csaf-rs/src/csaf/consts/chars.rs
@@ -70,14 +70,14 @@ const INVISIBLE_CHARACTERS: &[char] = &[
     '\u{FEFF}', // Zero-Width No-Break Space (BOM)
 ];
 
-pub fn is_invisible_char(c: &char) -> bool {
-    INVISIBLE_CHARACTERS.contains(c)
+pub fn is_invisible_char(c: char) -> bool {
+    INVISIBLE_CHARACTERS.contains(&c)
 }
 
-pub fn is_underscore_char(c: &char) -> bool {
-    UNDERSCORE_CHARACTERS.contains(c)
+pub fn is_underscore_char(c: char) -> bool {
+    UNDERSCORE_CHARACTERS.contains(&c)
 }
 
-pub fn is_hyphen_dash_char(c: &char) -> bool {
-    HYPHEN_DASH_CHARACTERS.contains(c)
+pub fn is_hyphen_dash_char(c: char) -> bool {
+    HYPHEN_DASH_CHARACTERS.contains(&c)
 }

--- a/csaf-rs/src/csaf/types/csaf_document_category.rs
+++ b/csaf-rs/src/csaf/types/csaf_document_category.rs
@@ -132,7 +132,9 @@ impl CsafDocumentCategory {
     /// We additionally cover some zero-width / invisible characters which would also break validation.
     fn get_with_ignored_chars_removed(s: &str) -> String {
         s.chars()
-            .filter(|c| !(c.is_whitespace() || is_invisible_char(*c) || is_hyphen_dash_char(*c) || is_underscore_char(*c)))
+            .filter(|c| {
+                !(c.is_whitespace() || is_invisible_char(*c) || is_hyphen_dash_char(*c) || is_underscore_char(*c))
+            })
             .collect()
     }
 
@@ -151,7 +153,7 @@ impl CsafDocumentCategory {
                 if !Self::get_with_ignored_chars_removed(prefix).is_empty() {
                     return false;
                 }
-                postfix.chars().next().is_some_and(|c| is_underscore_char(c))
+                postfix.chars().next().is_some_and(is_underscore_char)
             },
         }
     }

--- a/csaf-rs/src/csaf/types/csaf_document_category.rs
+++ b/csaf-rs/src/csaf/types/csaf_document_category.rs
@@ -132,8 +132,8 @@ impl CsafDocumentCategory {
     /// We additionally cover some zero-width / invisible characters which would also break validation.
     fn get_with_ignored_chars_removed(s: &str) -> String {
         s.chars()
-            .filter(|c| {
-                !(c.is_whitespace() || is_invisible_char(*c) || is_hyphen_dash_char(*c) || is_underscore_char(*c))
+            .filter(|&c| {
+                !(c.is_whitespace() || is_invisible_char(c) || is_hyphen_dash_char(c) || is_underscore_char(c))
             })
             .collect()
     }

--- a/csaf-rs/src/csaf/types/csaf_document_category.rs
+++ b/csaf-rs/src/csaf/types/csaf_document_category.rs
@@ -132,7 +132,7 @@ impl CsafDocumentCategory {
     /// We additionally cover some zero-width / invisible characters which would also break validation.
     fn get_with_ignored_chars_removed(s: &str) -> String {
         s.chars()
-            .filter(|c| !(c.is_whitespace() || is_invisible_char(c) || is_hyphen_dash_char(c) || is_underscore_char(c)))
+            .filter(|c| !(c.is_whitespace() || is_invisible_char(*c) || is_hyphen_dash_char(*c) || is_underscore_char(*c)))
             .collect()
     }
 
@@ -151,7 +151,7 @@ impl CsafDocumentCategory {
                 if !Self::get_with_ignored_chars_removed(prefix).is_empty() {
                     return false;
                 }
-                postfix.chars().next().is_some_and(|c| is_underscore_char(&c))
+                postfix.chars().next().is_some_and(|c| is_underscore_char(c))
             },
         }
     }

--- a/csaf-rs/src/validations/test_6_2_48.rs
+++ b/csaf-rs/src/validations/test_6_2_48.rs
@@ -20,7 +20,7 @@ fn create_misuse_at_vendor_name_error(vendor_name: &str, path: &str) -> Validati
 fn is_open_source(name: &str) -> bool {
     let normalized: String = name
         .chars()
-        .filter(|c| !c.is_whitespace() && !is_invisible_char(c))
+        .filter(|c| !c.is_whitespace() && !is_invisible_char(*c))
         .collect::<String>()
         .to_lowercase();
     normalized == "opensource"

--- a/csaf-rs/src/validations/test_6_2_48.rs
+++ b/csaf-rs/src/validations/test_6_2_48.rs
@@ -20,7 +20,7 @@ fn create_misuse_at_vendor_name_error(vendor_name: &str, path: &str) -> Validati
 fn is_open_source(name: &str) -> bool {
     let normalized: String = name
         .chars()
-        .filter(|c| !c.is_whitespace() && !is_invisible_char(*c))
+        .filter(|&c| !c.is_whitespace() && !is_invisible_char(c))
         .collect::<String>()
         .to_lowercase();
     normalized == "opensource"


### PR DESCRIPTION
chars.rs now accepts chars by value with a size of 4 byte, the ref was 8 byte.

also removed one level of indirection