### PR TITLE
chore: improve 6.1.14, 27.17, 27.18 error handling

### DIFF
--- a/csaf-rs/src/validations/test_6_1_14.rs
+++ b/csaf-rs/src/validations/test_6_1_14.rs
@@ -23,23 +23,17 @@ pub fn test_6_1_14_sorted_revision_history(doc: &impl CsafTrait) -> Result<(), V
     rev_history_tuples_sort_by_date.inplace_sort_by_date_then_number();
     rev_history_tuples_sort_by_number.inplace_sort_by_number();
 
-    // Generate errors if revision history items are sorted differently between sort by date and sort by number
-    let mut errors = Vec::new();
+    // Generate an error if revision history items are sorted differently between sort by date and sort by number
     for i in 0..rev_history_tuples_sort_by_date.len() {
         if let Some(by_date) = rev_history_tuples_sort_by_date.get(i)
             && let Some(by_number) = rev_history_tuples_sort_by_number.get(i)
         {
             if by_date.date != by_number.date {
-                errors.push(create_revision_history_error());
-                break;
+                return Err(vec![create_revision_history_error()]);
             }
         } else {
             unreachable!("Both arrays should have same length, this looks like a dev error.")
         }
-    }
-
-    if !errors.is_empty() {
-        return Err(errors);
     }
 
     Ok(())

--- a/csaf-rs/src/validations/test_6_1_27_17.rs
+++ b/csaf-rs/src/validations/test_6_1_27_17.rs
@@ -49,7 +49,7 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
         None => {},    // no language set
     }
 
-    let mut errors = Vec::new();
+    let mut errors: Option<Vec<ValidationError>> = None;
     let mut withdrawals = Vec::new();
 
     if let Some(notes) = doc.get_document().get_notes() {
@@ -58,7 +58,9 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
                 && title == "Reasoning for Withdrawal"
             {
                 if note.get_category() != NoteCategory::Description {
-                    errors.push(create_incorrect_category_error(i_n));
+                    errors
+                        .get_or_insert_default()
+                        .push(create_incorrect_category_error(i_n));
                 }
                 withdrawals.push(i_n);
             }
@@ -66,7 +68,7 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
     }
 
     // The fact that there is none or more than one note with the required title is the primary error and we ignore the category check, which is
-    // only relevant if there is exactly one occurence.
+    // only relevant if there is exactly one occurrence.
     if withdrawals.is_empty() {
         return Err(vec![create_missing_reasoning_error(&doc_category)]);
     } else if withdrawals.len() > 1 {
@@ -75,10 +77,7 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
             .map(|f| create_duplicated_reasoning_error(&doc_category, *f))
             .collect::<Vec<_>>());
     }
-    if !errors.is_empty() {
-        return Err(errors);
-    }
-    Ok(())
+    errors.map_or(Ok(()), Err)
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =

--- a/csaf-rs/src/validations/test_6_1_27_18.rs
+++ b/csaf-rs/src/validations/test_6_1_27_18.rs
@@ -49,7 +49,7 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
         None => {},    // no language set
     }
 
-    let mut errors = Vec::new();
+    let mut errors: Option<Vec<ValidationError>> = None;
     let mut supersessions = Vec::new();
 
     if let Some(notes) = doc.get_document().get_notes() {
@@ -58,7 +58,9 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
                 && title == "Reasoning for Supersession"
             {
                 if note.get_category() != NoteCategory::Description {
-                    errors.push(create_incorrect_category_error(i_n));
+                    errors
+                        .get_or_insert_default()
+                        .push(create_incorrect_category_error(i_n));
                 }
                 supersessions.push(i_n);
             }
@@ -66,7 +68,7 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
     }
 
     // The fact that there is none or more than one note with the required title is the primary error and we ignore the category check, which is
-    // only relevant if there is exactly one occurence.
+    // only relevant if there is exactly one occurrence.
     if supersessions.is_empty() {
         return Err(vec![create_missing_reasoning_error(&doc_category)]);
     } else if supersessions.len() > 1 {
@@ -75,10 +77,7 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
             .map(|f| create_duplicated_reasoning_error(&doc_category, *f))
             .collect::<Vec<_>>());
     }
-    if !errors.is_empty() {
-        return Err(errors);
-    }
-    Ok(())
+    errors.map_or(Ok(()), Err)
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =


### PR DESCRIPTION
Part of #769 

6.1.14 was refactored to only return an error, in any case

6.1.27.17/18 were intializing their errors vec instead of using an Option<> wrapper

also two typs in 6.1.27.17/18