### PR TITLE
chore: improve 6.1.5, 8, 27.12, 27.19, 55 and 6.2.13, 20, 23, 24 error handling

### DIFF
--- a/csaf-rs/src/validations/test_6_1_05.rs
+++ b/csaf-rs/src/validations/test_6_1_05.rs
@@ -36,18 +36,18 @@ pub fn test_6_1_05_multiple_definition_of_product_group_id(doc: &impl CsafTrait)
     }
 
     // Generate an error for each product group ID that is defined more than once
-    let errors: Vec<ValidationError> = product_group_ids_with_paths
-        .iter()
-        .filter(|(_, paths)| paths.len() > 1)
-        .flat_map(|(group_id, paths)| {
-            paths
-                .iter()
-                .map(move |path| generate_multiple_group_id_definition_error(group_id, path))
-        })
-        .collect();
+    let mut errors: Option<Vec<ValidationError>> = None;
+    for (group_id, paths) in &product_group_ids_with_paths {
+        if paths.len() > 1 {
+            for path in paths {
+                errors
+                    .get_or_insert_default()
+                    .push(generate_multiple_group_id_definition_error(group_id, path));
+            }
+        }
+    }
 
-    // If there are no errors, the test passes, otherwise return the errors
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    errors.map_or(Ok(()), Err)
 }
 
 crate::test_validation::impl_validator!(

--- a/csaf-rs/src/validations/test_6_1_08.rs
+++ b/csaf-rs/src/validations/test_6_1_08.rs
@@ -21,7 +21,7 @@ static CVSS40_VALIDATOR: LazyLock<Validator> =
 /// 6.1.8 Invalid CVSS
 /// Invalid CVSS object according to scheme
 pub fn test_6_1_08_invalid_cvss(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Vec<ValidationError> = Vec::new();
+    let mut errors: Option<Vec<ValidationError>> = None;
 
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {
@@ -61,7 +61,7 @@ pub fn test_6_1_08_invalid_cvss(doc: &impl CsafTrait) -> Result<(), Vec<Validati
         }
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    errors.map_or(Ok(()), Err)
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_8, test_6_1_08_invalid_cvss);
@@ -81,11 +81,13 @@ fn evaluate_cvss(
     validator: &Validator,
     base_path: &str,
     metric: CsafVulnerabilityMetric,
-    errors: &mut Vec<ValidationError>,
+    errors: &mut Option<Vec<ValidationError>>,
 ) {
     let value = serde_json::to_value(cvss_value).unwrap();
     for error in validator.iter_errors(&value) {
-        errors.push(create_validation_error(error.to_string(), base_path, metric.clone()));
+        errors
+            .get_or_insert_default()
+            .push(create_validation_error(error.to_string(), base_path, metric.clone()));
     }
 }
 

--- a/csaf-rs/src/validations/test_6_1_27_12.rs
+++ b/csaf-rs/src/validations/test_6_1_27_12.rs
@@ -27,7 +27,7 @@ pub fn test_6_1_27_12_affected_products(doc: &impl CsafTrait) -> Result<(), Vec<
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Vec<ValidationError> = Vec::new();
+    let mut errors: Option<Vec<ValidationError>> = None;
     let vulnerabilities = doc.get_vulnerabilities();
     for (v_i, vulnerability) in vulnerabilities.iter().enumerate() {
         if vulnerability
@@ -35,11 +35,13 @@ pub fn test_6_1_27_12_affected_products(doc: &impl CsafTrait) -> Result<(), Vec<
             .and_then(|ps| ps.get_known_affected())
             .is_none()
         {
-            errors.push(create_missing_affected_products_error(&doc_category, v_i));
+            errors
+                .get_or_insert_default()
+                .push(create_missing_affected_products_error(&doc_category, v_i));
         }
     }
 
-    if !errors.is_empty() { Err(errors) } else { Ok(()) }
+    errors.map_or(Ok(()), Err)
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -61,8 +61,8 @@ pub fn test_6_1_27_19_reference_to_superseding_document(doc: &impl CsafTrait) ->
     // the document is not valid, even if there is also a reference with correct summary and correct category.
     // So the incorrect category has precedence over the missing reference. This way the error message is more specific and hints more
     // directly to the wrong instance.
-    if errors.clone().is_some_and(|e| !e.is_empty()) {
-        return Err(errors.unwrap());
+    if let Some(errs) = errors {
+        return Err(errs);
     }
 
     // completely missing reference with correct summary and category has second precedence

--- a/csaf-rs/src/validations/test_6_1_55.rs
+++ b/csaf-rs/src/validations/test_6_1_55.rs
@@ -1,4 +1,5 @@
 use spdx::Expression;
+use std::sync::LazyLock;
 
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
@@ -7,19 +8,15 @@ use crate::schema::csaf2_1::schema::LicenseExpression;
 use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::ValidationError;
 
-fn create_missing_license_text_error() -> ValidationError {
-    ValidationError {
-        message: "Missing license text (document note with title 'License') for non-standard license.".to_string(),
-        instance_path: "/document/license_expression".to_string(),
-    }
-}
+static MISSING_LICENSE_TEXT_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
+    message: "Missing license text (document note with title 'License') for non-standard license.".to_string(),
+    instance_path: "/document/license_expression".to_string(),
+});
 
-fn create_multiple_license_text_error() -> ValidationError {
-    ValidationError {
-        message: "Multiple license texts (document notes with title 'License') for non-standard license.".to_string(),
-        instance_path: "/document/license_expression".to_string(),
-    }
-}
+static MULTIPLE_LICENSE_TEXT_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
+    message: "Multiple license texts (document notes with title 'License') for non-standard license.".to_string(),
+    instance_path: "/document/license_expression".to_string(),
+});
 
 fn create_incorrect_license_text_category_error(
     license_expression_path: &str,
@@ -54,17 +51,19 @@ fn is_english_or_default(doc: &impl CsafTrait) -> bool {
 
 fn expect_exactly_one_license_text(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     if let Some(notes) = doc.get_document().get_notes() {
-        let mut errors: Vec<ValidationError> = Vec::new();
+        let mut errors: Option<Vec<ValidationError>> = None;
         let license_notes = notes
             .iter()
             .enumerate()
             .filter(|(note_index, note)| {
                 if note.get_title().is_some_and(|title| title == "License") {
                     if note.get_category() != NoteCategory::LegalDisclaimer {
-                        errors.push(create_incorrect_license_text_category_error(
-                            &format!("/document/notes/{note_index}/category"),
-                            &note.get_category(),
-                        ));
+                        errors
+                            .get_or_insert_default()
+                            .push(create_incorrect_license_text_category_error(
+                                &format!("/document/notes/{note_index}/category"),
+                                &note.get_category(),
+                            ));
                     }
                     true
                 } else {
@@ -73,14 +72,14 @@ fn expect_exactly_one_license_text(doc: &impl CsafTrait) -> Result<(), Vec<Valid
             })
             .count();
         if license_notes > 1 {
-            errors.push(create_multiple_license_text_error());
+            errors.get_or_insert_default().push(MULTIPLE_LICENSE_TEXT_ERROR.clone());
         } else if license_notes < 1 {
-            errors.push(create_missing_license_text_error());
+            errors.get_or_insert_default().push(MISSING_LICENSE_TEXT_ERROR.clone());
         }
 
-        if errors.is_empty() { Ok(()) } else { Err(errors) }
+        errors.map_or(Ok(()), Err)
     } else {
-        Err(vec![create_missing_license_text_error()])
+        Err(vec![MISSING_LICENSE_TEXT_ERROR.clone()])
     }
 }
 
@@ -125,7 +124,7 @@ mod tests {
             "/document/notes/0/category",
             &NoteCategory::General,
         )]);
-        let case_s01_multiple = Err(vec![create_multiple_license_text_error()]);
+        let case_s01_multiple = Err(vec![MULTIPLE_LICENSE_TEXT_ERROR.clone()]);
 
         TESTS_2_1.test_6_1_55.expect(
             case_01_category_other,

--- a/csaf-rs/src/validations/test_6_2_13.rs
+++ b/csaf-rs/src/validations/test_6_2_13.rs
@@ -16,7 +16,9 @@ fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<Val
             // object -> check if keys are sorted
             let keys_ok = map.keys().zip(map.keys().skip(1)).all(|(a, b)| {
                 if a > b {
-                    errors.get_or_insert_default().push(create_unsorted_keys_error(format!("{path}/{a}").as_str()));
+                    errors
+                        .get_or_insert_default()
+                        .push(create_unsorted_keys_error(format!("{path}/{a}").as_str()));
                     false
                 } else {
                     true

--- a/csaf-rs/src/validations/test_6_2_13.rs
+++ b/csaf-rs/src/validations/test_6_2_13.rs
@@ -5,20 +5,18 @@ use serde_json::Value;
 ///
 /// All keys in a CSAF document must be sorted alphabetically.
 pub fn test_6_2_13_sorting(json: &Value) -> Result<(), Vec<ValidationError>> {
-    let mut errors = Vec::new();
-    match check_sorted_recursive(json, "", &mut errors) {
-        true => Ok(()),
-        false => Err(errors),
-    }
+    let mut errors: Option<Vec<ValidationError>> = None;
+    check_sorted_recursive(json, "", &mut errors);
+    errors.map_or(Ok(()), Err)
 }
 
-fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Vec<ValidationError>) -> bool {
+fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<ValidationError>>) -> bool {
     match value {
         Value::Object(map) => {
             // object -> check if keys are sorted
             let keys_ok = map.keys().zip(map.keys().skip(1)).all(|(a, b)| {
                 if a > b {
-                    errors.push(create_unsorted_keys_error(format!("{path}/{a}").as_str()));
+                    errors.get_or_insert_default().push(create_unsorted_keys_error(format!("{path}/{a}").as_str()));
                     false
                 } else {
                     true

--- a/csaf-rs/src/validations/test_6_2_13.rs
+++ b/csaf-rs/src/validations/test_6_2_13.rs
@@ -10,40 +10,31 @@ pub fn test_6_2_13_sorting(json: &Value) -> Result<(), Vec<ValidationError>> {
     errors.map_or(Ok(()), Err)
 }
 
-fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<ValidationError>>) -> bool {
+fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<ValidationError>>) {
     match value {
         Value::Object(map) => {
             // object -> check if keys are sorted
-            let keys_ok = map.keys().zip(map.keys().skip(1)).all(|(a, b)| {
+            for (a, b) in map.keys().zip(map.keys().skip(1)) {
                 if a > b {
                     errors
                         .get_or_insert_default()
                         .push(create_unsorted_keys_error(format!("{path}/{a}").as_str()));
-                    false
-                } else {
-                    true
                 }
-            });
+            }
 
             // check all children recursively
-            let children_ok = map
-                .iter()
-                .filter(|(key, value)| !check_sorted_recursive(value, format!("{path}/{key}").as_str(), errors))
-                .count()
-                == 0;
-
-            keys_ok && children_ok
+            for (key, value) in map {
+                check_sorted_recursive(value, format!("{path}/{key}").as_str(), errors);
+            }
         },
         Value::Array(arr) => {
             // array -> check for each item
-            arr.iter()
-                .enumerate()
-                .filter(|(key, value)| !check_sorted_recursive(value, format!("{path}/{key}").as_str(), errors))
-                .count()
-                == 0
+            for (key, value) in arr.iter().enumerate() {
+                check_sorted_recursive(value, format!("{path}/{key}").as_str(), errors);
+            }
         },
         // primitive types are always sorted
-        _ => true,
+        _ => {},
     }
 }
 

--- a/csaf-rs/src/validations/test_6_2_20.rs
+++ b/csaf-rs/src/validations/test_6_2_20.rs
@@ -108,8 +108,11 @@ pub fn test_6_2_20_additional_properties(
     let mut errors: Option<Vec<ValidationError>> = None;
     for error in validator.iter_errors(json) {
         if let ValidationErrorKind::UnevaluatedProperties { unexpected } = error.kind() {
-            for property in unexpected.iter() {
-                errors.get_or_insert_default().push(create_additional_properties_error(property, error.instance_path().as_str()));
+            for property in unexpected {
+                errors.get_or_insert_default().push(create_additional_properties_error(
+                    property,
+                    error.instance_path().as_str(),
+                ));
             }
         }
     }

--- a/csaf-rs/src/validations/test_6_2_20.rs
+++ b/csaf-rs/src/validations/test_6_2_20.rs
@@ -105,18 +105,16 @@ pub fn test_6_2_20_additional_properties(
     json: &Value,
     validator: &jsonschema::Validator,
 ) -> Result<(), Vec<ValidationError>> {
-    let results: Vec<_> = validator
-        .iter_errors(json)
-        .flat_map(|error| match error.kind() {
-            ValidationErrorKind::UnevaluatedProperties { unexpected } => unexpected
-                .iter()
-                .map(|property| create_additional_properties_error(property, error.instance_path().as_str()))
-                .collect(),
-            _ => vec![],
-        })
-        .collect();
+    let mut errors: Option<Vec<ValidationError>> = None;
+    for error in validator.iter_errors(json) {
+        if let ValidationErrorKind::UnevaluatedProperties { unexpected } = error.kind() {
+            for property in unexpected.iter() {
+                errors.get_or_insert_default().push(create_additional_properties_error(property, error.instance_path().as_str()));
+            }
+        }
+    }
 
-    if results.is_empty() { Ok(()) } else { Err(results) }
+    errors.map_or(Ok(()), Err)
 }
 
 fn create_additional_properties_error(key: &str, path: &str) -> ValidationError {

--- a/csaf-rs/src/validations/test_6_2_23.rs
+++ b/csaf-rs/src/validations/test_6_2_23.rs
@@ -14,7 +14,7 @@ fn create_deprecated_cwe_error(cwe: &str, version: &str, i_r: usize, i_cwe: usiz
 /// For each item in the CWE array it MUST be tested that the CWE is not deprecated in the given version.
 pub fn test_6_2_23_usage_of_deprecated_cwe(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Vec<ValidationError> = Vec::new();
+    let mut errors: Option<Vec<ValidationError>> = None;
 
     for (i_r, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(cwes) = vulnerability.get_cwes() {
@@ -34,13 +34,15 @@ pub fn test_6_2_23_usage_of_deprecated_cwe(doc: &impl CsafTrait) -> Result<(), V
                 if let Some((status, _)) = CWE_ENTRIES[version].1.get(&cwe_item.id)
                     && status == "Deprecated"
                 {
-                    errors.push(create_deprecated_cwe_error(&cwe_item.id, version, i_r, i_cwe));
+                    errors
+                        .get_or_insert_default()
+                        .push(create_deprecated_cwe_error(&cwe_item.id, version, i_r, i_cwe));
                 }
             }
         }
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    errors.map_or(Ok(()), Err)
 }
 
 crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_23, test_6_2_23_usage_of_deprecated_cwe);

--- a/csaf-rs/src/validations/test_6_2_24.rs
+++ b/csaf-rs/src/validations/test_6_2_24.rs
@@ -2,11 +2,17 @@ use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait, VulnerabilityT
 use crate::helpers::get_latest_cwe_version_for_date;
 use crate::validation::ValidationError;
 use semver::Version;
+use std::sync::LazyLock;
 
 enum VersionMissmatch {
     NonLatest,
     Future,
 }
+
+static CWE_VERSION_UNAVAILABLE_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
+    message: "CWE version information is not available for the current release date.".to_string(),
+    instance_path: "/document/tracking/current_release_date".to_string(),
+});
 
 fn check_for_non_latest_cwe_version(
     cwe: &str,
@@ -104,7 +110,7 @@ fn normalize_to_semver_str(s: &str) -> String {
 /// most recent CWE version as of the document's current_release_date).
 pub fn test_6_2_24_usage_of_non_latest_cwe_version(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Vec<ValidationError> = Vec::new();
+    let mut errors: Option<Vec<ValidationError>> = None;
 
     let tracking = doc.get_document().get_tracking();
     let current_release_date = tracking.get_current_release_date();
@@ -125,19 +131,18 @@ pub fn test_6_2_24_usage_of_non_latest_cwe_version(doc: &impl CsafTrait) -> Resu
                     };
 
                     if let Some(error) = check_for_non_latest_cwe_version(&cwe_item.id, version, latest, i_r, i_cwe) {
-                        errors.push(error);
+                        errors.get_or_insert_default().push(error);
                     }
                 }
             }
         }
     } else {
-        errors.push(ValidationError {
-            message: "CWE version information is not available for the current release date.".to_string(),
-            instance_path: "/document/tracking/current_release_date".to_string(),
-        });
+        errors
+            .get_or_insert_default()
+            .push(CWE_VERSION_UNAVAILABLE_ERROR.clone());
     }
 
-    if errors.is_empty() { Ok(()) } else { Err(errors) }
+    errors.map_or(Ok(()), Err)
 }
 
 crate::test_validation::impl_validator!(


### PR DESCRIPTION
Use Option<Vec<ValidationError>> instead of Vec<ValidationError>

Also wrapped some static error messages in LazyLocks

part of #769 