### PR TITLE
docs: document go install req for generate_go_bindings.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Bindings for other languages are created through the `csaf-ffi` crate, which is 
 
 The Go bindings are generated via [uniffi-bindgen-go](https://github.com/NordSecurity/uniffi-bindgen-go).
 
+> **Note:** The `generate_go_bindings.sh` script invokes `go fmt`, `go env GOOS` and `go env GOARCH` 
+> to autoformat the output and detect the target platform, which is used to name the generated file.
+> This requires Go to be installed and available on `PATH`, instructions can be found [here](https://go.dev/).
+
 ```bash
 # Install the Go binding generator (one-time)
 cargo install uniffi-bindgen-go \

--- a/scripts/publish/generate_go_bindings.sh
+++ b/scripts/publish/generate_go_bindings.sh
@@ -20,6 +20,14 @@ cd "$REPO_ROOT"
 # Ensure cargo-installed tools are on PATH
 export PATH="$HOME/.cargo/bin:$PATH"
 
+if ! command -v go >/dev/null 2>&1; then
+  echo "ERROR: Go is not installed or not on PATH." >&2
+  echo "       This script requires Go to autoformat (via 'go fmt')" >&2
+  echo "       and to determine the target platform (via 'go env GOOS' and 'go env GOARCH')" >&2
+  echo "       to correctly name the file. Install it from https://go.dev/ and rerun." >&2
+  exit 1
+fi
+
 if [[ "${1:-}" != "--skip-build" ]]; then
   echo "Building csaf-ffi (native release)..."
   cargo build -p csaf-ffi --release --locked
@@ -28,7 +36,7 @@ fi
 echo "Generating Go bindings..."
 uniffi-bindgen-go \
   --library "$REPO_ROOT/target/release/libcsaf_ffi.dylib" \
-  --out-dir "$REPO_ROOT/go/" 
+  --out-dir "$REPO_ROOT/go/"
 
 # Copy the static archive into the per-platform lib directory so CGo can find
 # it without needing CGO_LDFLAGS to be set manually.
@@ -39,4 +47,4 @@ mkdir -p "$LIB_DIR"
 cp "$REPO_ROOT/target/release/libcsaf_ffi.a" "$LIB_DIR/"
 echo "Copied libcsaf_ffi.a → $LIB_DIR/"
 
-echo "Done! Output in $REPO_ROOT/go/csaf_ffi/"
+echo "Done! Output in $REPO_ROOT/go/csaf_ffi/ (static lib copied to $LIB_DIR/)"


### PR DESCRIPTION
Resolves #773 

Added error / README note for the requirement for go to be installed to run the go ffi script.

Before, it failed more-or-less gracefully, resulting a genericly named, unformatted go output file.