### PR TITLE
refactor: move basic Display impls to strum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,6 +515,7 @@ dependencies = [
  "serde_json",
  "spdx",
  "ssvc",
+ "strum",
  "tempfile",
  "uuid",
 ]
@@ -2060,6 +2061,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "strum",
  "syn 3.0.3",
  "thiserror 2.0.19",
  "typify",

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -36,6 +36,7 @@ jsonschema = { version = "0.49.1", default-features = false }
 spdx = "0.13.4"
 oxilangtag = "0.1.5"
 ssvc = "0.2.1"
+strum = { version = "0.28", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.17.0", features = ["v7", "serde", "js"] }

--- a/csaf-rs/src/csaf/enums/category_of_the_branch.rs
+++ b/csaf-rs/src/csaf/enums/category_of_the_branch.rs
@@ -1,42 +1,35 @@
-use std::fmt::{Display, Formatter};
+use strum::{AsRefStr, Display};
 
 /// Enum representing the category of a branch in a product tree.
 /// We need a shared type on the trait, as CSAF version 2.0 have fully divergent definitions.
 /// CSAF 2.0 has legacy, which 2.1 has not.
 /// CSAF 2.1 has platform, which 2.0 has not.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, AsRefStr)]
 pub enum CategoryOfTheBranch {
+    #[strum(serialize = "architecture")]
     Architecture,
+    #[strum(serialize = "host_name")]
     HostName,
+    #[strum(serialize = "language")]
     Language,
+    #[strum(serialize = "legacy")]
     Legacy,
+    #[strum(serialize = "patch_level")]
     PatchLevel,
+    #[strum(serialize = "platform")]
     Platform,
+    #[strum(serialize = "product_family")]
     ProductFamily,
+    #[strum(serialize = "product_name")]
     ProductName,
+    #[strum(serialize = "product_version")]
     ProductVersion,
+    #[strum(serialize = "product_version_range")]
     ProductVersionRange,
+    #[strum(serialize = "service_pack")]
     ServicePack,
+    #[strum(serialize = "specification")]
     Specification,
+    #[strum(serialize = "vendor")]
     Vendor,
-}
-
-impl Display for CategoryOfTheBranch {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CategoryOfTheBranch::Architecture => write!(f, "architecture"),
-            CategoryOfTheBranch::HostName => write!(f, "host_name"),
-            CategoryOfTheBranch::Language => write!(f, "language"),
-            CategoryOfTheBranch::Legacy => write!(f, "legacy"),
-            CategoryOfTheBranch::PatchLevel => write!(f, "patch_level"),
-            CategoryOfTheBranch::Platform => write!(f, "platform"),
-            CategoryOfTheBranch::ProductFamily => write!(f, "product_family"),
-            CategoryOfTheBranch::ProductName => write!(f, "product_name"),
-            CategoryOfTheBranch::ProductVersion => write!(f, "product_version"),
-            CategoryOfTheBranch::ProductVersionRange => write!(f, "product_version_range"),
-            CategoryOfTheBranch::ServicePack => write!(f, "service_pack"),
-            CategoryOfTheBranch::Specification => write!(f, "specification"),
-            CategoryOfTheBranch::Vendor => write!(f, "vendor"),
-        }
-    }
 }

--- a/csaf-rs/src/csaf/enums/product_status.rs
+++ b/csaf-rs/src/csaf/enums/product_status.rs
@@ -1,31 +1,24 @@
-use std::fmt::{Display, Formatter};
+use strum::{AsRefStr, Display};
 
 /// Enum representing individual product statuses in a CSAF document.
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd, Display, AsRefStr)]
 pub enum ProductStatus {
+    #[strum(serialize = "first_affected")]
     FirstAffected,
+    #[strum(serialize = "first_fixed")]
     FirstFixed,
+    #[strum(serialize = "fixed")]
     Fixed,
+    #[strum(serialize = "known_affected")]
     KnownAffected,
+    #[strum(serialize = "known_not_affected")]
     KnownNotAffected,
+    #[strum(serialize = "last_affected")]
     LastAffected,
+    #[strum(serialize = "recommended")]
     Recommended,
+    #[strum(serialize = "under_investigation")]
     UnderInvestigation,
+    #[strum(serialize = "unknown")]
     Unknown,
-}
-
-impl Display for ProductStatus {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ProductStatus::FirstAffected => write!(f, "first_affected"),
-            ProductStatus::FirstFixed => write!(f, "first_fixed"),
-            ProductStatus::Fixed => write!(f, "fixed"),
-            ProductStatus::KnownAffected => write!(f, "known_affected"),
-            ProductStatus::KnownNotAffected => write!(f, "known_not_affected"),
-            ProductStatus::LastAffected => write!(f, "last_affected"),
-            ProductStatus::Recommended => write!(f, "recommended"),
-            ProductStatus::UnderInvestigation => write!(f, "under_investigation"),
-            ProductStatus::Unknown => write!(f, "unknown"),
-        }
-    }
 }

--- a/csaf-rs/src/csaf/enums/product_status_group.rs
+++ b/csaf-rs/src/csaf/enums/product_status_group.rs
@@ -1,35 +1,28 @@
-use std::fmt::{Display, Formatter};
+use strum::{AsRefStr, Display};
 
 use crate::csaf::enums::product_status::ProductStatus;
 
 /// Enum representing product status groups
-#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Ord, PartialOrd, Display, AsRefStr)]
 pub enum ProductStatusGroup {
     // first_affected, known_affected, last_affected
+    #[strum(serialize = "affected")]
     Affected,
     // known_not_affected
+    #[strum(serialize = "not affected")]
     NotAffected,
     // first_fixed, fixed
+    #[strum(serialize = "fixed")]
     Fixed,
     // under_investigation
+    #[strum(serialize = "under investigation")]
     UnderInvestigation,
     // unknown
+    #[strum(serialize = "unknown")]
     Unknown,
     // recommended
+    #[strum(serialize = "recommended")]
     Recommended,
-}
-
-impl Display for ProductStatusGroup {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ProductStatusGroup::Affected => write!(f, "affected"),
-            ProductStatusGroup::NotAffected => write!(f, "not affected"),
-            ProductStatusGroup::Fixed => write!(f, "fixed"),
-            ProductStatusGroup::UnderInvestigation => write!(f, "under investigation"),
-            ProductStatusGroup::Unknown => write!(f, "unknown"),
-            ProductStatusGroup::Recommended => write!(f, "recommended"),
-        }
-    }
 }
 
 impl From<&ProductStatus> for ProductStatusGroup {

--- a/csaf-rs/src/cvss/mod.rs
+++ b/csaf-rs/src/cvss/mod.rs
@@ -2,8 +2,6 @@ pub mod v2;
 pub mod v3;
 pub mod v4;
 
-use std::fmt;
-
 use crate::csaf_traits::ContentTrait;
 use crate::validation::ValidationError;
 use cvss_rs::Cvss;
@@ -11,6 +9,7 @@ use cvss_rs::Severity;
 use cvss_rs::Version;
 use serde::Deserialize;
 use serde_json::Value;
+use strum::{AsRefStr, Display};
 
 /// Validates CVSS scores for all CVSS versions present.
 pub fn validate_content_scores(
@@ -118,21 +117,11 @@ fn validate_consistency(
 }
 
 /// The type of CVSS score being validated, use for error messages.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, AsRefStr)]
 pub enum ScoreType {
     Base,
     Temporal,
     Environmental,
-}
-
-impl fmt::Display for ScoreType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            ScoreType::Base => write!(f, "Base"),
-            ScoreType::Temporal => write!(f, "Temporal"),
-            ScoreType::Environmental => write!(f, "Environmental"),
-        }
-    }
 }
 
 pub fn create_deserialization_error(error_message: String, instance_path: String) -> ValidationError {

--- a/csaf-rs/src/validations/test_6_1_17.rs
+++ b/csaf-rs/src/validations/test_6_1_17.rs
@@ -2,22 +2,16 @@ use crate::csaf::types::version_number::CsafVersionNumber;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
 use crate::schema::csaf2_1::schema::DocumentStatus;
 use crate::validation::ValidationError;
-use std::fmt::{Display, Formatter};
+use strum::{AsRefStr, Display};
 
+#[derive(Display, AsRefStr)]
 pub enum DocumentStatusDraftErrorReason {
+    #[strum(serialize = "Version 0 is")]
     IntVerZero,
+    #[strum(serialize = "Versions 0.y.z are")]
     SemVerMajorZero,
+    #[strum(serialize = "Versions with prerelease are")]
     SemVerHasPre,
-}
-
-impl Display for DocumentStatusDraftErrorReason {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match &self {
-            DocumentStatusDraftErrorReason::IntVerZero => write!(f, "Version 0 is"),
-            DocumentStatusDraftErrorReason::SemVerMajorZero => write!(f, "Versions 0.y.z are"),
-            DocumentStatusDraftErrorReason::SemVerHasPre => write!(f, "Versions with prerelease are"),
-        }
-    }
 }
 
 fn generate_status_version_error(

--- a/csaf-rs/src/validations/test_6_1_35.rs
+++ b/csaf-rs/src/validations/test_6_1_35.rs
@@ -2,20 +2,14 @@ use crate::csaf_traits::{CsafTrait, RemediationTrait, VulnerabilityTrait};
 use crate::schema::csaf2_1::schema::CategoryOfTheRemediation;
 use crate::validation::ValidationError;
 use std::collections::BTreeMap;
-use std::fmt::{Display, Formatter};
+use strum::{AsRefStr, Display};
 
+#[derive(Display, AsRefStr)]
 enum ExclusivityKind {
+    #[strum(serialize = "exclusive")]
     Exclusive,
+    #[strum(serialize = "mutually exclusive")]
     MutuallyExclusive,
-}
-
-impl Display for ExclusivityKind {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ExclusivityKind::Exclusive => write!(f, "exclusive"),
-            ExclusivityKind::MutuallyExclusive => write!(f, "mutually exclusive"),
-        }
-    }
 }
 
 fn generate_category_contradiction_error(

--- a/csaf-rs/src/validations/test_6_1_52.rs
+++ b/csaf-rs/src/validations/test_6_1_52.rs
@@ -6,20 +6,14 @@ use crate::csaf_traits::{
 };
 use crate::schema::csaf2_1::schema::DocumentStatus;
 use crate::validation::ValidationError;
-use std::fmt;
+use strum::{AsRefStr, Display};
 
+#[derive(Display, AsRefStr)]
 enum DateProperty {
+    #[strum(serialize = "date")]
     Date,
+    #[strum(serialize = "exploitation_date")]
     ExploitationDate,
-}
-
-impl fmt::Display for DateProperty {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DateProperty::Date => write!(f, "date"),
-            DateProperty::ExploitationDate => write!(f, "exploitation_date"),
-        }
-    }
 }
 
 fn create_date_too_new_error(

--- a/type-generator/Cargo.toml
+++ b/type-generator/Cargo.toml
@@ -26,6 +26,7 @@ prettyplease = "0.3"
 quote = "1"
 proc-macro2 = "1"
 regress = "0.11"
+strum = { version = "0.28", features = ["derive"] }
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/type-generator/src/language_tags/mod.rs
+++ b/type-generator/src/language_tags/mod.rs
@@ -15,15 +15,19 @@ use crate::utils::read_write_fs::{read_file_to_string, write_generated_file};
 use generate::generate_kind_section;
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::fmt;
 use std::path::Path;
+use strum::{AsRefStr, Display};
 
 /// The kinds of subtags we extract from the language subtag registry.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, AsRefStr)]
 pub(crate) enum SubtagKind {
+    #[strum(serialize = "language")]
     Language,
+    #[strum(serialize = "region")]
     Region,
+    #[strum(serialize = "script")]
     Script,
+    #[strum(serialize = "grandfathered")]
     Grandfathered,
 }
 
@@ -37,19 +41,8 @@ impl SubtagKind {
     ];
 
     /// Returns the registry `Type:` value that corresponds to this kind.
-    pub fn registry_key(self) -> &'static str {
-        match self {
-            SubtagKind::Language => "language",
-            SubtagKind::Region => "region",
-            SubtagKind::Script => "script",
-            SubtagKind::Grandfathered => "grandfathered",
-        }
-    }
-}
-
-impl fmt::Display for SubtagKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.registry_key())
+    pub fn registry_key(&self) -> &str {
+        self.as_ref()
     }
 }
 


### PR DESCRIPTION
This PR:
* introduces `strum` as a dependency
* moves some of our basic Display impls to strum, reducing code verbosity