### PR TITLE
chore: use `Self::` instead of `Type::`

### DIFF
--- a/csaf-rs/src/csaf/aggregation/revision_history/unvalidated_csaf_revision_history.rs
+++ b/csaf-rs/src/csaf/aggregation/revision_history/unvalidated_csaf_revision_history.rs
@@ -66,7 +66,7 @@ impl<T: RevisionTrait> From<&Vec<T>> for UnvalidatedCsafRevisionHistory {
                 number: revision.get_number(),
             });
         }
-        UnvalidatedCsafRevisionHistory(items)
+        Self(items)
     }
 }
 

--- a/csaf-rs/src/csaf/enums/product_status_group.rs
+++ b/csaf-rs/src/csaf/enums/product_status_group.rs
@@ -28,9 +28,7 @@ pub enum ProductStatusGroup {
 impl From<&ProductStatus> for ProductStatusGroup {
     fn from(status: &ProductStatus) -> Self {
         match status {
-            ProductStatus::FirstAffected | ProductStatus::KnownAffected | ProductStatus::LastAffected => {
-                Self::Affected
-            },
+            ProductStatus::FirstAffected | ProductStatus::KnownAffected | ProductStatus::LastAffected => Self::Affected,
             ProductStatus::KnownNotAffected => Self::NotAffected,
             ProductStatus::Fixed | ProductStatus::FirstFixed => Self::Fixed,
             ProductStatus::UnderInvestigation => Self::UnderInvestigation,

--- a/csaf-rs/src/csaf/enums/product_status_group.rs
+++ b/csaf-rs/src/csaf/enums/product_status_group.rs
@@ -29,13 +29,13 @@ impl From<&ProductStatus> for ProductStatusGroup {
     fn from(status: &ProductStatus) -> Self {
         match status {
             ProductStatus::FirstAffected | ProductStatus::KnownAffected | ProductStatus::LastAffected => {
-                ProductStatusGroup::Affected
+                Self::Affected
             },
-            ProductStatus::KnownNotAffected => ProductStatusGroup::NotAffected,
-            ProductStatus::Fixed | ProductStatus::FirstFixed => ProductStatusGroup::Fixed,
-            ProductStatus::UnderInvestigation => ProductStatusGroup::UnderInvestigation,
-            ProductStatus::Unknown => ProductStatusGroup::Unknown,
-            ProductStatus::Recommended => ProductStatusGroup::Recommended,
+            ProductStatus::KnownNotAffected => Self::NotAffected,
+            ProductStatus::Fixed | ProductStatus::FirstFixed => Self::Fixed,
+            ProductStatus::UnderInvestigation => Self::UnderInvestigation,
+            ProductStatus::Unknown => Self::Unknown,
+            ProductStatus::Recommended => Self::Recommended,
         }
     }
 }

--- a/csaf-rs/src/csaf/types/csaf_cwe.rs
+++ b/csaf-rs/src/csaf/types/csaf_cwe.rs
@@ -12,7 +12,7 @@ pub struct Cwe {
 
 impl From<&Cwe21> for Cwe {
     fn from(cwe: &Cwe21) -> Self {
-        Cwe {
+        Self {
             id: cwe.id.to_string(),
             name: cwe.name.to_string(),
             version: Some(cwe.version.to_string()),
@@ -22,7 +22,7 @@ impl From<&Cwe21> for Cwe {
 
 impl From<&Cwe20> for Cwe {
     fn from(cwe: &Cwe20) -> Self {
-        Cwe {
+        Self {
             id: cwe.id.to_string(),
             name: cwe.name.to_string(),
             version: None,

--- a/csaf-rs/src/csaf/types/csaf_datetime.rs
+++ b/csaf-rs/src/csaf/types/csaf_datetime.rs
@@ -17,22 +17,22 @@ pub enum CsafDateTime {
 impl CsafDateTime {
     /// Returns `true` if the date was successfully parsed.
     pub fn is_valid(&self) -> bool {
-        matches!(self, CsafDateTime::Valid(_))
+        matches!(self, Self::Valid(_))
     }
 }
 
 impl From<&str> for CsafDateTime {
     fn from(s: &str) -> Self {
         match s.parse() {
-            Ok(valid) => CsafDateTime::Valid(valid),
-            Err(err) => CsafDateTime::Invalid(err),
+            Ok(valid) => Self::Valid(valid),
+            Err(err) => Self::Invalid(err),
         }
     }
 }
 
 impl From<&String> for CsafDateTime {
     fn from(s: &String) -> Self {
-        CsafDateTime::from(s.as_str())
+        Self::from(s.as_str())
     }
 }
 
@@ -46,7 +46,7 @@ impl From<&String> for CsafDateTime {
 impl PartialEq for CsafDateTime {
     fn eq(&self, other: &Self) -> bool {
         match (&self, &other) {
-            (CsafDateTime::Valid(a), CsafDateTime::Valid(b)) => a == b,
+            (Self::Valid(a), Self::Valid(b)) => a == b,
             _ => false,
         }
     }
@@ -65,7 +65,7 @@ impl PartialOrd for CsafDateTime {
 impl Ord for CsafDateTime {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (&self, &other) {
-            (CsafDateTime::Valid(a), CsafDateTime::Valid(b)) => a.cmp(b),
+            (Self::Valid(a), Self::Valid(b)) => a.cmp(b),
             // Invalid cannot be ordered; comparing them is treated as a developer error and panics.
             _ => {
                 panic!("Cannot compare CsafDateTime values if either or both are invalid. This looks like a dev error.")
@@ -104,7 +104,7 @@ pub struct CsafDateTimeParseError {
 impl CsafDateTimeParseError {
     /// Creates a new CsafDateTimeParseError.
     pub fn new(raw_string: &str, source: ParseError) -> Self {
-        CsafDateTimeParseError {
+        Self {
             raw_string: raw_string.to_owned(),
             source,
         }
@@ -149,7 +149,7 @@ pub struct ValidCsafDateTime {
 impl ValidCsafDateTime {
     /// Creates a new ValidCsafDateTime from a parsed DateTime.
     fn new(raw_string: &str, parsed: DateTime<FixedOffset>) -> Self {
-        ValidCsafDateTime {
+        Self {
             raw_string: raw_string.to_owned(),
             parsed,
         }
@@ -175,7 +175,7 @@ impl FromStr for ValidCsafDateTime {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let parsed = DateTime::parse_from_rfc3339(s).map_err(|e| CsafDateTimeParseError::new(s, e))?;
-        Ok(ValidCsafDateTime::new(s, parsed))
+        Ok(Self::new(s, parsed))
     }
 }
 

--- a/csaf-rs/src/csaf/types/csaf_document_category.rs
+++ b/csaf-rs/src/csaf/types/csaf_document_category.rs
@@ -82,10 +82,7 @@ impl CsafDocumentCategory {
 
     /// Checks if the category is DocumentCategory::CsafBase or DocumentCategory::CsafBaseOther
     pub fn is_base(&self) -> bool {
-        matches!(
-            self,
-            Self::CsafBase | Self::CsafBaseOther(_)
-        )
+        matches!(self, Self::CsafBase | Self::CsafBaseOther(_))
     }
 
     /// Checks if the document category is a known profile for the given CSAF version

--- a/csaf-rs/src/csaf/types/csaf_document_category.rs
+++ b/csaf-rs/src/csaf/types/csaf_document_category.rs
@@ -28,63 +28,63 @@ pub enum CsafDocumentCategory {
 impl From<&str> for CsafDocumentCategory {
     fn from(category: &str) -> Self {
         match category {
-            "csaf_base" => CsafDocumentCategory::CsafBase,
-            "csaf_informational_advisory" => CsafDocumentCategory::CsafInformationalAdvisory,
-            "csaf_security_incident_response" => CsafDocumentCategory::CsafSecurityIncidentResponse,
-            "csaf_security_advisory" => CsafDocumentCategory::CsafSecurityAdvisory,
-            "csaf_vex" => CsafDocumentCategory::CsafVex,
-            "csaf_deprecated_security_advisory" => CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
-            "csaf_withdrawn" => CsafDocumentCategory::CsafWithdrawn,
-            "csaf_superseded" => CsafDocumentCategory::CsafSuperseded,
-            default => CsafDocumentCategory::CsafBaseOther(default.to_string()),
+            "csaf_base" => Self::CsafBase,
+            "csaf_informational_advisory" => Self::CsafInformationalAdvisory,
+            "csaf_security_incident_response" => Self::CsafSecurityIncidentResponse,
+            "csaf_security_advisory" => Self::CsafSecurityAdvisory,
+            "csaf_vex" => Self::CsafVex,
+            "csaf_deprecated_security_advisory" => Self::CsafDeprecatedSecurityAdvisory,
+            "csaf_withdrawn" => Self::CsafWithdrawn,
+            "csaf_superseded" => Self::CsafSuperseded,
+            default => Self::CsafBaseOther(default.to_string()),
         }
     }
 }
 
 impl From<&DocumentCategory20> for CsafDocumentCategory {
     fn from(value: &DocumentCategory20) -> Self {
-        CsafDocumentCategory::from(value.as_str())
+        Self::from(value.as_str())
     }
 }
 
 impl From<&DocumentCategory21> for CsafDocumentCategory {
     fn from(value: &DocumentCategory21) -> Self {
-        CsafDocumentCategory::from(value.as_str())
+        Self::from(value.as_str())
     }
 }
 
 impl CsafDocumentCategory {
     /// Well-known CSAF 2.0 profiles
     const CSAF_20_KNOWN_PROFILES: [CsafDocumentCategory; 5] = [
-        CsafDocumentCategory::CsafBase,
-        CsafDocumentCategory::CsafSecurityIncidentResponse,
-        CsafDocumentCategory::CsafInformationalAdvisory,
-        CsafDocumentCategory::CsafSecurityAdvisory,
-        CsafDocumentCategory::CsafVex,
+        Self::CsafBase,
+        Self::CsafSecurityIncidentResponse,
+        Self::CsafInformationalAdvisory,
+        Self::CsafSecurityAdvisory,
+        Self::CsafVex,
     ];
 
     /// Well-known CSAF 2.1 profiles
     const CSAF_21_KNOWN_PROFILES: [CsafDocumentCategory; 8] = [
-        CsafDocumentCategory::CsafBase,
-        CsafDocumentCategory::CsafSecurityIncidentResponse,
-        CsafDocumentCategory::CsafInformationalAdvisory,
-        CsafDocumentCategory::CsafSecurityAdvisory,
-        CsafDocumentCategory::CsafVex,
-        CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
-        CsafDocumentCategory::CsafWithdrawn,
-        CsafDocumentCategory::CsafSuperseded,
+        Self::CsafBase,
+        Self::CsafSecurityIncidentResponse,
+        Self::CsafInformationalAdvisory,
+        Self::CsafSecurityAdvisory,
+        Self::CsafVex,
+        Self::CsafDeprecatedSecurityAdvisory,
+        Self::CsafWithdrawn,
+        Self::CsafSuperseded,
     ];
 
     /// Checks if the category is DocumentCategory::CsafBaseOther
     pub fn is_base_other(&self) -> bool {
-        matches!(self, CsafDocumentCategory::CsafBaseOther(_))
+        matches!(self, Self::CsafBaseOther(_))
     }
 
     /// Checks if the category is DocumentCategory::CsafBase or DocumentCategory::CsafBaseOther
     pub fn is_base(&self) -> bool {
         matches!(
             self,
-            CsafDocumentCategory::CsafBase | CsafDocumentCategory::CsafBaseOther(_)
+            Self::CsafBase | Self::CsafBaseOther(_)
         )
     }
 
@@ -211,15 +211,15 @@ impl CsafDocumentCategory {
 impl Display for CsafDocumentCategory {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            CsafDocumentCategory::CsafBase => write!(f, "csaf_base"),
-            CsafDocumentCategory::CsafInformationalAdvisory => write!(f, "csaf_informational_advisory"),
-            CsafDocumentCategory::CsafSecurityIncidentResponse => write!(f, "csaf_security_incident_response"),
-            CsafDocumentCategory::CsafSecurityAdvisory => write!(f, "csaf_security_advisory"),
-            CsafDocumentCategory::CsafVex => write!(f, "csaf_vex"),
-            CsafDocumentCategory::CsafDeprecatedSecurityAdvisory => write!(f, "csaf_deprecated_security_advisory"),
-            CsafDocumentCategory::CsafWithdrawn => write!(f, "csaf_withdrawn"),
-            CsafDocumentCategory::CsafSuperseded => write!(f, "csaf_superseded"),
-            CsafDocumentCategory::CsafBaseOther(other) => write!(f, "{other}"),
+            Self::CsafBase => write!(f, "csaf_base"),
+            Self::CsafInformationalAdvisory => write!(f, "csaf_informational_advisory"),
+            Self::CsafSecurityIncidentResponse => write!(f, "csaf_security_incident_response"),
+            Self::CsafSecurityAdvisory => write!(f, "csaf_security_advisory"),
+            Self::CsafVex => write!(f, "csaf_vex"),
+            Self::CsafDeprecatedSecurityAdvisory => write!(f, "csaf_deprecated_security_advisory"),
+            Self::CsafWithdrawn => write!(f, "csaf_withdrawn"),
+            Self::CsafSuperseded => write!(f, "csaf_superseded"),
+            Self::CsafBaseOther(other) => write!(f, "{other}"),
         }
     }
 }

--- a/csaf-rs/src/csaf/types/csaf_hash_algo.rs
+++ b/csaf-rs/src/csaf/types/csaf_hash_algo.rs
@@ -37,7 +37,7 @@ pub enum CsafHashAlgorithm {
 impl CsafHashAlgorithm {
     /// Checks if the original algorithm string is lowercase
     pub fn is_lowercase(&self) -> bool {
-        if let CsafHashAlgorithm::Other(algo) = self {
+        if let Self::Other(algo) = self {
             // these could be not lowercase, so we need to check
             algo.chars().all(|c| !c.is_alphabetic() || c.is_lowercase())
         } else {
@@ -56,7 +56,7 @@ impl CsafHashAlgorithm {
     /// CSAF 2.0 as 2.1 has not been implemented, we do not need to make that distinction (yet).
     pub fn is_mentioned_in_spec(&self) -> bool {
         match self {
-            CsafHashAlgorithm::Other(_) => !matches!(self.normalize(), CsafHashAlgorithm::Other(_)),
+            Self::Other(_) => !matches!(self.normalize(), Self::Other(_)),
             _ => true,
         }
     }
@@ -93,8 +93,8 @@ impl CsafHashAlgorithm {
     #[allow(dead_code)]
     fn checked_lowercase_algorithm(original: &CsafHashAlgorithm) -> Option<CsafHashAlgorithm> {
         match original {
-            CsafHashAlgorithm::Other(original_str) => {
-                let lowercased = CsafHashAlgorithm::from_str(original_str.to_lowercase().as_str());
+            Self::Other(original_str) => {
+                let lowercased = Self::from_str(original_str.to_lowercase().as_str());
                 (original != &lowercased).then_some(lowercased)
             },
             _ => None,
@@ -114,7 +114,7 @@ impl CsafHashAlgorithm {
     /// This might be needed for the converter.
     fn lowercase_algorithm(original: &CsafHashAlgorithm) -> CsafHashAlgorithm {
         match original {
-            CsafHashAlgorithm::Other(s) => CsafHashAlgorithm::from_str(s.to_lowercase().as_str()),
+            Self::Other(s) => Self::from_str(s.to_lowercase().as_str()),
             _ => original.clone(),
         }
     }
@@ -127,46 +127,46 @@ impl CsafHashAlgorithm {
     /// from using it. Use the `From<&AlgorithmOfTheCryptographicHash*>` impls instead.
     pub(crate) fn from_str(algo: &str) -> Self {
         match algo {
-            "blake2b512" => CsafHashAlgorithm::Blake2b512,
-            "blake2s256" => CsafHashAlgorithm::Blake2s256,
-            "md4" => CsafHashAlgorithm::Md4,
-            "md5" => CsafHashAlgorithm::Md5,
-            "md5-sha1" => CsafHashAlgorithm::Md5Sha1,
-            "mdc2" => CsafHashAlgorithm::Mdc2,
-            "ripemd" => CsafHashAlgorithm::Ripemd,
-            "ripemd160" => CsafHashAlgorithm::Ripemd160,
-            "rmd160" => CsafHashAlgorithm::Rmd160,
-            "sha1" => CsafHashAlgorithm::Sha1,
-            "sha224" => CsafHashAlgorithm::Sha224,
-            "sha256" => CsafHashAlgorithm::Sha256,
-            "sha3-224" => CsafHashAlgorithm::Sha3_224,
-            "sha3-256" => CsafHashAlgorithm::Sha3_256,
-            "sha3-384" => CsafHashAlgorithm::Sha3_384,
-            "sha3-512" => CsafHashAlgorithm::Sha3_512,
-            "sha384" => CsafHashAlgorithm::Sha384,
-            "sha512" => CsafHashAlgorithm::Sha512,
-            "sha512-224" => CsafHashAlgorithm::Sha512_224,
-            "sha512-256" => CsafHashAlgorithm::Sha512_256,
-            "shake128" => CsafHashAlgorithm::Shake128,
-            "shake256" => CsafHashAlgorithm::Shake256,
-            "sm3" => CsafHashAlgorithm::Sm3,
-            "ssl3-md5" => CsafHashAlgorithm::Ssl3Md5,
-            "ssl3-sha1" => CsafHashAlgorithm::Ssl3Sha1,
-            "whirlpool" => CsafHashAlgorithm::Whirlpool,
-            other => CsafHashAlgorithm::Other(other.to_string()),
+            "blake2b512" => Self::Blake2b512,
+            "blake2s256" => Self::Blake2s256,
+            "md4" => Self::Md4,
+            "md5" => Self::Md5,
+            "md5-sha1" => Self::Md5Sha1,
+            "mdc2" => Self::Mdc2,
+            "ripemd" => Self::Ripemd,
+            "ripemd160" => Self::Ripemd160,
+            "rmd160" => Self::Rmd160,
+            "sha1" => Self::Sha1,
+            "sha224" => Self::Sha224,
+            "sha256" => Self::Sha256,
+            "sha3-224" => Self::Sha3_224,
+            "sha3-256" => Self::Sha3_256,
+            "sha3-384" => Self::Sha3_384,
+            "sha3-512" => Self::Sha3_512,
+            "sha384" => Self::Sha384,
+            "sha512" => Self::Sha512,
+            "sha512-224" => Self::Sha512_224,
+            "sha512-256" => Self::Sha512_256,
+            "shake128" => Self::Shake128,
+            "shake256" => Self::Shake256,
+            "sm3" => Self::Sm3,
+            "ssl3-md5" => Self::Ssl3Md5,
+            "ssl3-sha1" => Self::Ssl3Sha1,
+            "whirlpool" => Self::Whirlpool,
+            other => Self::Other(other.to_string()),
         }
     }
 }
 
 impl From<&AlgorithmOfTheCryptographicHash20> for CsafHashAlgorithm {
     fn from(algo: &AlgorithmOfTheCryptographicHash20) -> Self {
-        CsafHashAlgorithm::from_str(algo.as_str())
+        Self::from_str(algo.as_str())
     }
 }
 
 impl From<&AlgorithmOfTheCryptographicHash21> for CsafHashAlgorithm {
     fn from(algo: &AlgorithmOfTheCryptographicHash21) -> Self {
-        CsafHashAlgorithm::from_str(algo.as_str())
+        Self::from_str(algo.as_str())
     }
 }
 
@@ -176,33 +176,33 @@ impl Display for CsafHashAlgorithm {
             f,
             "{}",
             match self {
-                CsafHashAlgorithm::Blake2b512 => "blake2b512",
-                CsafHashAlgorithm::Blake2s256 => "blake2s256",
-                CsafHashAlgorithm::Md4 => "md4",
-                CsafHashAlgorithm::Md5 => "md5",
-                CsafHashAlgorithm::Md5Sha1 => "md5-sha1",
-                CsafHashAlgorithm::Mdc2 => "mdc2",
-                CsafHashAlgorithm::Ripemd => "ripemd",
-                CsafHashAlgorithm::Ripemd160 => "ripemd160",
-                CsafHashAlgorithm::Rmd160 => "rmd160",
-                CsafHashAlgorithm::Sha1 => "sha1",
-                CsafHashAlgorithm::Sha224 => "sha224",
-                CsafHashAlgorithm::Sha256 => "sha256",
-                CsafHashAlgorithm::Sha3_224 => "sha3-224",
-                CsafHashAlgorithm::Sha3_256 => "sha3-256",
-                CsafHashAlgorithm::Sha3_384 => "sha3-384",
-                CsafHashAlgorithm::Sha3_512 => "sha3-512",
-                CsafHashAlgorithm::Sha384 => "sha384",
-                CsafHashAlgorithm::Sha512 => "sha512",
-                CsafHashAlgorithm::Sha512_224 => "sha512-224",
-                CsafHashAlgorithm::Sha512_256 => "sha512-256",
-                CsafHashAlgorithm::Shake128 => "shake128",
-                CsafHashAlgorithm::Shake256 => "shake256",
-                CsafHashAlgorithm::Sm3 => "sm3",
-                CsafHashAlgorithm::Ssl3Md5 => "ssl3-md5",
-                CsafHashAlgorithm::Ssl3Sha1 => "ssl3-sha1",
-                CsafHashAlgorithm::Whirlpool => "whirlpool",
-                CsafHashAlgorithm::Other(other) => other.as_str(),
+                Self::Blake2b512 => "blake2b512",
+                Self::Blake2s256 => "blake2s256",
+                Self::Md4 => "md4",
+                Self::Md5 => "md5",
+                Self::Md5Sha1 => "md5-sha1",
+                Self::Mdc2 => "mdc2",
+                Self::Ripemd => "ripemd",
+                Self::Ripemd160 => "ripemd160",
+                Self::Rmd160 => "rmd160",
+                Self::Sha1 => "sha1",
+                Self::Sha224 => "sha224",
+                Self::Sha256 => "sha256",
+                Self::Sha3_224 => "sha3-224",
+                Self::Sha3_256 => "sha3-256",
+                Self::Sha3_384 => "sha3-384",
+                Self::Sha3_512 => "sha3-512",
+                Self::Sha384 => "sha384",
+                Self::Sha512 => "sha512",
+                Self::Sha512_224 => "sha512-224",
+                Self::Sha512_256 => "sha512-256",
+                Self::Shake128 => "shake128",
+                Self::Shake256 => "shake256",
+                Self::Sm3 => "sm3",
+                Self::Ssl3Md5 => "ssl3-md5",
+                Self::Ssl3Sha1 => "ssl3-sha1",
+                Self::Whirlpool => "whirlpool",
+                Self::Other(other) => other.as_str(),
             }
         )
     }

--- a/csaf-rs/src/csaf/types/csaf_product_id_helper_number.rs
+++ b/csaf-rs/src/csaf/types/csaf_product_id_helper_number.rs
@@ -58,19 +58,19 @@ impl Display for CsafStockKeepingUnit {
 
 impl From<&StockKeepingUnit20> for CsafStockKeepingUnit {
     fn from(value: &StockKeepingUnit20) -> Self {
-        CsafStockKeepingUnit(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
 impl From<&StockKeepingUnit21> for CsafStockKeepingUnit {
     fn from(value: &StockKeepingUnit21) -> Self {
-        CsafStockKeepingUnit(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
 impl From<&str> for CsafStockKeepingUnit {
     fn from(value: &str) -> Self {
-        CsafStockKeepingUnit(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
@@ -91,19 +91,19 @@ impl Display for CsafModelNumber {
 
 impl From<&ModelNumber20> for CsafModelNumber {
     fn from(value: &ModelNumber20) -> Self {
-        CsafModelNumber(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
 impl From<&ModelNumber21> for CsafModelNumber {
     fn from(value: &ModelNumber21) -> Self {
-        CsafModelNumber(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
 impl From<&str> for CsafModelNumber {
     fn from(value: &str) -> Self {
-        CsafModelNumber(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
@@ -124,19 +124,19 @@ impl CsafSerialNumber {
 
 impl From<&SerialNumber20> for CsafSerialNumber {
     fn from(value: &SerialNumber20) -> Self {
-        CsafSerialNumber(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
 impl From<&SerialNumber21> for CsafSerialNumber {
     fn from(value: &SerialNumber21) -> Self {
-        CsafSerialNumber(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 
 impl From<&str> for CsafSerialNumber {
     fn from(value: &str) -> Self {
-        CsafSerialNumber(ProductIdentificationHelperNumber(value.to_string()))
+        Self(ProductIdentificationHelperNumber(value.to_string()))
     }
 }
 

--- a/csaf-rs/src/csaf/types/csaf_vuln_metric.rs
+++ b/csaf-rs/src/csaf/types/csaf_vuln_metric.rs
@@ -15,12 +15,12 @@ impl CsafVulnerabilityMetric {
     /// Returns the property name for the metric, which is used in the JSON representation.
     pub fn get_metric_prop_name(&self) -> &'static str {
         match self {
-            CsafVulnerabilityMetric::SsvcV2 => "ssvc_v2",
-            CsafVulnerabilityMetric::CvssV2(_) => "cvss_v2",
-            CsafVulnerabilityMetric::CvssV3(_) => "cvss_v3",
-            CsafVulnerabilityMetric::CvssV4(_) => "cvss_v4",
-            CsafVulnerabilityMetric::Epss => "epss",
-            CsafVulnerabilityMetric::QualitativeSeverityRating => "qualitative_severity_rating",
+            Self::SsvcV2 => "ssvc_v2",
+            Self::CvssV2(_) => "cvss_v2",
+            Self::CvssV3(_) => "cvss_v3",
+            Self::CvssV4(_) => "cvss_v4",
+            Self::Epss => "epss",
+            Self::QualitativeSeverityRating => "qualitative_severity_rating",
         }
     }
 }
@@ -29,12 +29,12 @@ impl CsafVulnerabilityMetric {
 impl Display for CsafVulnerabilityMetric {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            CsafVulnerabilityMetric::SsvcV2 => write!(f, "SSVC-v2"),
-            CsafVulnerabilityMetric::CvssV2(version) => write!(f, "CVSS-v{}", *version),
-            CsafVulnerabilityMetric::CvssV3(version) => write!(f, "CVSS-v{}", *version),
-            CsafVulnerabilityMetric::CvssV4(version) => write!(f, "CVSS-v{}", *version),
-            CsafVulnerabilityMetric::Epss => write!(f, "EPSS"),
-            CsafVulnerabilityMetric::QualitativeSeverityRating => write!(f, "Qualitative Severity Rating"),
+            Self::SsvcV2 => write!(f, "SSVC-v2"),
+            Self::CvssV2(version) => write!(f, "CVSS-v{}", *version),
+            Self::CvssV3(version) => write!(f, "CVSS-v{}", *version),
+            Self::CvssV4(version) => write!(f, "CVSS-v{}", *version),
+            Self::Epss => write!(f, "EPSS"),
+            Self::QualitativeSeverityRating => write!(f, "Qualitative Severity Rating"),
         }
     }
 }

--- a/csaf-rs/src/csaf/types/language/csaf_language.rs
+++ b/csaf-rs/src/csaf/types/language/csaf_language.rs
@@ -17,8 +17,8 @@ pub enum CsafLanguage {
 impl Display for CsafLanguage {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            CsafLanguage::Valid(lang) => write!(f, "{lang}"),
-            CsafLanguage::Invalid(lang, _) => write!(f, "{lang}"),
+            Self::Valid(lang) => write!(f, "{lang}"),
+            Self::Invalid(lang, _) => write!(f, "{lang}"),
         }
     }
 }
@@ -26,8 +26,8 @@ impl Display for CsafLanguage {
 impl PartialEq for CsafLanguage {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (CsafLanguage::Valid(a), CsafLanguage::Valid(b)) => a == b,
-            (CsafLanguage::Invalid(a, _), CsafLanguage::Invalid(b, _)) => a.eq_ignore_ascii_case(b),
+            (Self::Valid(a), Self::Valid(b)) => a == b,
+            (Self::Invalid(a, _), Self::Invalid(b, _)) => a.eq_ignore_ascii_case(b),
             _ => false,
         }
     }
@@ -35,13 +35,13 @@ impl PartialEq for CsafLanguage {
 
 impl From<&LangT20> for CsafLanguage {
     fn from(lang_code: &LangT20) -> Self {
-        CsafLanguage::from(&lang_code.to_string())
+        Self::from(&lang_code.to_string())
     }
 }
 
 impl From<&LangT21> for CsafLanguage {
     fn from(lang_code: &LangT21) -> Self {
-        CsafLanguage::from(&lang_code.to_string())
+        Self::from(&lang_code.to_string())
     }
 }
 
@@ -51,7 +51,7 @@ impl From<&String> for CsafLanguage {
         let parsed_lang_tag: LanguageTag<String> = match LanguageTag::parse(input_lang_tag.clone()) {
             Ok(lang_tag) => lang_tag,
             Err(err) => {
-                return CsafLanguage::Invalid(
+                return Self::Invalid(
                     input_lang_tag.clone(),
                     CsafLanguageError::ParserError(input_lang_tag.clone(), err.to_string()),
                 );
@@ -61,7 +61,7 @@ impl From<&String> for CsafLanguage {
         // Grandfathered tags are valid and skip further validation
         // This includes the default language (i-default) tags
         if is_valid_grandfathered_subtag(parsed_lang_tag.as_str()) {
-            return CsafLanguage::Valid(ValidCsafLanguage::new(parsed_lang_tag));
+            return Self::Valid(ValidCsafLanguage::new(parsed_lang_tag));
         }
 
         // A bit of a wonky workaround: If the language code is just a private use tag ("x-private"),
@@ -69,14 +69,14 @@ impl From<&String> for CsafLanguage {
         // So "is private use" + primary lang tag == full tag -> full tag is only private use,
         // so we can skip the validation
         if parsed_lang_tag.private_use().is_some() && input_lang_tag == parsed_lang_tag.primary_language() {
-            return CsafLanguage::Valid(ValidCsafLanguage::new(parsed_lang_tag));
+            return Self::Valid(ValidCsafLanguage::new(parsed_lang_tag));
         }
 
         // TODO: Also discuss if we want this precedence of primary -> script -> region,
         // or if we want to expose everything "wrong" with the tag to the consumers.
         // Validate primary language subtag
         if !is_valid_language_subtag(parsed_lang_tag.primary_language()) {
-            return CsafLanguage::Invalid(
+            return Self::Invalid(
                 input_lang_tag.clone(),
                 CsafLanguageError::InvalidPrimaryLanguageSubtag(
                     input_lang_tag.clone(),
@@ -89,7 +89,7 @@ impl From<&String> for CsafLanguage {
         if let Some(script) = parsed_lang_tag.script()
             && !is_valid_script_subtag(script)
         {
-            return CsafLanguage::Invalid(
+            return Self::Invalid(
                 input_lang_tag.clone(),
                 CsafLanguageError::InvalidScriptSubtag(input_lang_tag.clone(), script.to_string()),
             );
@@ -99,13 +99,13 @@ impl From<&String> for CsafLanguage {
         if let Some(region) = parsed_lang_tag.region()
             && !is_valid_region_subtag(region)
         {
-            return CsafLanguage::Invalid(
+            return Self::Invalid(
                 input_lang_tag.clone(),
                 CsafLanguageError::InvalidRegionSubtag(input_lang_tag.clone(), region.to_string()),
             );
         }
 
-        CsafLanguage::Valid(ValidCsafLanguage::new(parsed_lang_tag))
+        Self::Valid(ValidCsafLanguage::new(parsed_lang_tag))
     }
 }
 

--- a/csaf-rs/src/csaf/types/language/invalid_language.rs
+++ b/csaf-rs/src/csaf/types/language/invalid_language.rs
@@ -16,16 +16,16 @@ pub enum CsafLanguageError {
 impl IntoValidationError for CsafLanguageError {
     fn into_validation_error(self, instance_path: &str) -> ValidationError {
         let message = match self {
-            CsafLanguageError::ParserError(invalid_lang_tag, parser_error) => {
+            Self::ParserError(invalid_lang_tag, parser_error) => {
                 format!("Invalid language code '{invalid_lang_tag}': parser failed with error: {parser_error}")
             },
-            CsafLanguageError::InvalidPrimaryLanguageSubtag(invalid_lang_tag, primary_lang_subtag) => format!(
+            Self::InvalidPrimaryLanguageSubtag(invalid_lang_tag, primary_lang_subtag) => format!(
                 "Invalid language code '{invalid_lang_tag}': primary language subtag '{primary_lang_subtag}' is not a valid primary language subtag"
             ),
-            CsafLanguageError::InvalidScriptSubtag(invalid_lang_tag, script_subtag) => format!(
+            Self::InvalidScriptSubtag(invalid_lang_tag, script_subtag) => format!(
                 "Invalid language code '{invalid_lang_tag}': script subtag '{script_subtag}' is not a valid script subtag"
             ),
-            CsafLanguageError::InvalidRegionSubtag(invalid_lang_tag, region_sub_tag) => format!(
+            Self::InvalidRegionSubtag(invalid_lang_tag, region_sub_tag) => format!(
                 "Invalid language code '{invalid_lang_tag}': region subtag '{region_sub_tag}' is not a valid region subtag"
             ),
         };

--- a/csaf-rs/src/csaf/types/language/valid_language.rs
+++ b/csaf-rs/src/csaf/types/language/valid_language.rs
@@ -111,12 +111,12 @@ pub enum PrivateUseReason {
 impl Display for PrivateUseReason {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            PrivateUseReason::PrivateUseSubtag(subtag) => write!(f, "Private-use subtag '{subtag}'"),
-            PrivateUseReason::PrivateUsePrimaryLangSubtag(primary_lang) => {
+            Self::PrivateUseSubtag(subtag) => write!(f, "Private-use subtag '{subtag}'"),
+            Self::PrivateUsePrimaryLangSubtag(primary_lang) => {
                 write!(f, "Private-use primary language subtag '{primary_lang}'")
             },
-            PrivateUseReason::PrivateUseScriptSubtag(script) => write!(f, "Private-use script subtag '{script}'"),
-            PrivateUseReason::PrivateUseRegionSubtag(region) => write!(f, "Private-use region subtag '{region}'"),
+            Self::PrivateUseScriptSubtag(script) => write!(f, "Private-use script subtag '{script}'"),
+            Self::PrivateUseRegionSubtag(region) => write!(f, "Private-use region subtag '{region}'"),
         }
     }
 }

--- a/csaf-rs/src/csaf/types/purl/csaf_purl.rs
+++ b/csaf-rs/src/csaf/types/purl/csaf_purl.rs
@@ -21,26 +21,26 @@ impl CsafPurl {
             Ok(mut purl) => {
                 let normalized_purl = purl.to_string();
                 let base_without_qualifiers = purl.clear_qualifiers().to_string();
-                CsafPurl::Valid(ValidPurl::new(
+                Self::Valid(ValidPurl::new(
                     purl_str.to_owned(),
                     normalized_purl,
                     base_without_qualifiers,
                 ))
             },
-            Err(e) => CsafPurl::Invalid(PurlParseError::from_packageurl_error(purl_str, e)),
+            Err(e) => Self::Invalid(PurlParseError::from_packageurl_error(purl_str, e)),
         }
     }
 }
 
 impl From<&PackageUrlRepresentation20> for CsafPurl {
     fn from(purl: &PackageUrlRepresentation20) -> Self {
-        CsafPurl::parse(purl.deref())
+        Self::parse(purl.deref())
     }
 }
 
 impl From<&PackageUrlRepresentation21> for CsafPurl {
     fn from(purl: &PackageUrlRepresentation21) -> Self {
-        CsafPurl::parse(purl.deref())
+        Self::parse(purl.deref())
     }
 }
 

--- a/csaf-rs/src/csaf/types/purl/purl_error.rs
+++ b/csaf-rs/src/csaf/types/purl/purl_error.rs
@@ -29,7 +29,7 @@ pub enum PurlParseErrorKind {
 impl PurlParseError {
     /// Private constructor
     fn new(purl_str: &str, kind: PurlParseErrorKind) -> Self {
-        PurlParseError {
+        Self {
             original_purl: purl_str.to_owned(),
             kind,
         }

--- a/csaf-rs/src/csaf/types/version_number/csaf_version_number.rs
+++ b/csaf-rs/src/csaf/types/version_number/csaf_version_number.rs
@@ -38,12 +38,12 @@ impl CsafVersionNumber {
             && !(s.len() > 1 && s.starts_with('0'))
             && let Ok(num) = s.parse::<u64>()
         {
-            return CsafVersionNumber::IntVer(IntVerVersion::new(num));
+            return Self::IntVer(IntVerVersion::new(num));
         }
 
         // Try to parse as semver
         if let Ok(semver) = Version::parse(s) {
-            return CsafVersionNumber::SemVer(SemVerVersion::new(semver));
+            return Self::SemVer(SemVerVersion::new(semver));
         }
 
         // Panic if both fail
@@ -55,8 +55,8 @@ impl CsafVersionNumber {
     /// Helper function to get the major version number, which is either the integer version or the major version of the semantic version.
     pub fn get_major(&self) -> u64 {
         match &self {
-            CsafVersionNumber::IntVer(intver) => intver.get(),
-            CsafVersionNumber::SemVer(semver) => semver.get_major(),
+            Self::IntVer(intver) => intver.get(),
+            Self::SemVer(semver) => semver.get_major(),
         }
     }
 
@@ -67,8 +67,8 @@ impl CsafVersionNumber {
     /// This allows mixed-variant revision histories to be sorted and compared correctly.
     pub fn to_comparable_semver(&self) -> Version {
         match self {
-            CsafVersionNumber::IntVer(intver) => Version::new(intver.get(), 0, 0),
-            CsafVersionNumber::SemVer(semver) => semver.get_version().clone(),
+            Self::IntVer(intver) => Version::new(intver.get(), 0, 0),
+            Self::SemVer(semver) => semver.get_version().clone(),
         }
     }
 
@@ -78,13 +78,13 @@ impl CsafVersionNumber {
     /// Semantic versions perform a major bump, producing `x+1.0.0`.
     pub fn get_next_major_version(&self) -> CsafVersionNumber {
         match self {
-            CsafVersionNumber::IntVer(intver) => CsafVersionNumber::IntVer(IntVerVersion::new(
+            Self::IntVer(intver) => Self::IntVer(IntVerVersion::new(
                 intver
                     .get()
                     .checked_add(1)
                     .expect("Integer version overflow while incrementing"),
             )),
-            CsafVersionNumber::SemVer(semver) => CsafVersionNumber::SemVer(SemVerVersion::new(Version::new(
+            Self::SemVer(semver) => Self::SemVer(SemVerVersion::new(Version::new(
                 semver
                     .get_major()
                     .checked_add(1)
@@ -101,13 +101,13 @@ impl CsafVersionNumber {
     /// Semantic versions perform a major drop, producing `x-1.0.0`.
     pub fn get_previous_major_version(&self) -> CsafVersionNumber {
         match self {
-            CsafVersionNumber::IntVer(intver) => CsafVersionNumber::IntVer(IntVerVersion::new(
+            Self::IntVer(intver) => Self::IntVer(IntVerVersion::new(
                 intver
                     .get()
                     .checked_sub(1)
                     .expect("Integer version underflow while decrementing"),
             )),
-            CsafVersionNumber::SemVer(semver) => CsafVersionNumber::SemVer(SemVerVersion::new(Version::new(
+            Self::SemVer(semver) => Self::SemVer(SemVerVersion::new(Version::new(
                 semver
                     .get_major()
                     .checked_sub(1)
@@ -122,22 +122,22 @@ impl CsafVersionNumber {
 // Transform an already schema-validated version string (VersionT) from CSAF 2.0 into a CsafVersionNumber
 impl From<&VersionT20> for CsafVersionNumber {
     fn from(v: &VersionT20) -> Self {
-        CsafVersionNumber::parse_str(v.deref().as_str())
+        Self::parse_str(v.deref().as_str())
     }
 }
 
 // Transform an already schema-validated version string (VersionT) from CSAF 2.1 into a CsafVersionNumber
 impl From<&VersionT21> for CsafVersionNumber {
     fn from(v: &VersionT21) -> Self {
-        CsafVersionNumber::parse_str(v.deref().as_str())
+        Self::parse_str(v.deref().as_str())
     }
 }
 
 impl Display for CsafVersionNumber {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            CsafVersionNumber::IntVer(num) => write!(f, "{num}"),
-            CsafVersionNumber::SemVer(version) => write!(f, "{version}"),
+            Self::IntVer(num) => write!(f, "{num}"),
+            Self::SemVer(version) => write!(f, "{version}"),
         }
     }
 }
@@ -180,7 +180,7 @@ impl PartialOrd for CsafVersionNumber {
 impl From<&str> for CsafVersionNumber {
     fn from(s: &str) -> Self {
         use std::str::FromStr;
-        CsafVersionNumber::parse_str(
+        Self::parse_str(
             &crate::schema::csaf2_1::schema::VersionT::from_str(s).unwrap_or_else(|err| {
                 panic!("Raw version string '{s}' failed schema validation: {err}. This looks like a dev error.")
             }),

--- a/csaf-rs/src/csaf/types/version_number/int_ver_version.rs
+++ b/csaf-rs/src/csaf/types/version_number/int_ver_version.rs
@@ -21,7 +21,7 @@ impl IntVerVersion {
     /// Creates a new `IntVerVersion` from a `u64`.
     /// Only available within the version_number module.
     pub(super) const fn new(value: u64) -> Self {
-        IntVerVersion(value)
+        Self(value)
     }
 }
 
@@ -29,7 +29,7 @@ impl IntVerVersion {
 // This is only used for testing and not available on the public API
 impl From<u64> for IntVerVersion {
     fn from(value: u64) -> Self {
-        IntVerVersion::new(value)
+        Self::new(value)
     }
 }
 

--- a/csaf-rs/src/csaf/types/version_number/sem_ver_version.rs
+++ b/csaf-rs/src/csaf/types/version_number/sem_ver_version.rs
@@ -58,7 +58,7 @@ impl SemVerVersion {
     /// Creates a new `SemVerVersion` from a `semver::Version`.
     /// Only available within the version_number module.
     pub(super) const fn new(value: Version) -> Self {
-        SemVerVersion(value)
+        Self(value)
     }
 }
 
@@ -66,7 +66,7 @@ impl SemVerVersion {
 // This is only used for testing and not available on the public API
 impl From<Version> for SemVerVersion {
     fn from(value: Version) -> Self {
-        SemVerVersion::new(value)
+        Self::new(value)
     }
 }
 

--- a/type-generator/src/language_tags/mod.rs
+++ b/type-generator/src/language_tags/mod.rs
@@ -33,12 +33,7 @@ pub(crate) enum SubtagKind {
 
 impl SubtagKind {
     /// All variants in a fixed order.
-    pub const ALL: &[SubtagKind] = &[
-        Self::Language,
-        Self::Region,
-        Self::Script,
-        Self::Grandfathered,
-    ];
+    pub const ALL: &[SubtagKind] = &[Self::Language, Self::Region, Self::Script, Self::Grandfathered];
 
     /// Returns the registry `Type:` value that corresponds to this kind.
     pub fn registry_key(&self) -> &str {

--- a/type-generator/src/language_tags/mod.rs
+++ b/type-generator/src/language_tags/mod.rs
@@ -34,10 +34,10 @@ pub(crate) enum SubtagKind {
 impl SubtagKind {
     /// All variants in a fixed order.
     pub const ALL: &[SubtagKind] = &[
-        SubtagKind::Language,
-        SubtagKind::Region,
-        SubtagKind::Script,
-        SubtagKind::Grandfathered,
+        Self::Language,
+        Self::Region,
+        Self::Script,
+        Self::Grandfathered,
     ];
 
     /// Returns the registry `Type:` value that corresponds to this kind.


### PR DESCRIPTION
When refering to the type itself, we can use `Self::`.