### PR TITLE
feat: add test 6.2.47

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ This creates TypeScript + WASM output in `wasm/`.
 | 6.2.1 |  |  |
 | 6.2.23 | ⭕ | ✅ |
 | 6.2.24 | ⭕ | ✅ |
+| 6.2.47 | ⭕ | ✅ |
 
 ### Informative Tests
 

--- a/csaf-rs/src/csaf/traits/document/tracking_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/tracking_trait.rs
@@ -12,9 +12,20 @@ use crate::schema::csaf2_1::schema::{
     Tracking as Tracking21,
 };
 use chrono::{DateTime, Utc};
+use regex::Regex;
+use std::sync::LazyLock;
 
 /// Type alias for a vector of revision history items
 pub type RevisionHistory = Vec<RevisionHistoryItem>;
+
+/// Generates the canonical filename for a CSAF document from its tracking ID, per section 5.1:
+/// lowercase, non-`[+\-a-z0-9]` sequences replaced with `_`, `.json` appended.
+fn canonical_filename_from_id(tracking_id: &str) -> String {
+    static INVALID_CHARS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^+\-a-z0-9]+").unwrap());
+    let lowercase_id = tracking_id.to_lowercase();
+    let cleaned_id = INVALID_CHARS.replace_all(&lowercase_id, "_");
+    format!("{cleaned_id}.json")
+}
 
 /// Struct representing a revision history item
 /// Includes the path index in the original revision history, the date, and the version number
@@ -83,6 +94,12 @@ pub trait TrackingTrait {
     /// Returns the tracking ID of this document
     fn get_id(&self) -> &str;
 
+    /// Generates the canonical filename from this document's tracking ID, per section 5.1:
+    /// lowercased, non-`[+\-a-z0-9]` sequences replaced with `_`, `.json` appended.
+    fn get_canonical_filename(&self) -> String {
+        canonical_filename_from_id(self.get_id())
+    }
+
     fn get_version(&self) -> CsafVersionNumber;
 }
 
@@ -149,5 +166,23 @@ impl TrackingTrait for Tracking21 {
 
     fn get_version(&self) -> CsafVersionNumber {
         CsafVersionNumber::from(&self.version)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(
+        "OASIS_CSAF_TC-CSAF_2.0-2021-6-2-11-01",
+        "oasis_csaf_tc-csaf_2_0-2021-6-2-11-01.json"
+    )]
+    #[case("2022_#01-A", "2022_01-a.json")]
+    #[case("test###value", "test_value.json")]
+    #[case("Test+123-456", "test+123-456.json")]
+    fn test_canonical_filename_from_id(#[case] input: &str, #[case] expected: &str) {
+        assert_eq!(canonical_filename_from_id(input), expected);
     }
 }

--- a/csaf-rs/src/csaf/traits/document_trait.rs
+++ b/csaf-rs/src/csaf/traits/document_trait.rs
@@ -12,11 +12,26 @@ use crate::schema::csaf2_0::schema::{
     Tracking as Tracking20,
 };
 use crate::schema::csaf2_1::schema::{
-    CsafVersion as CsafVersion21, DocumentLevelMetaData as DocumentLevelMetaData21, Note as Note21,
-    Publisher as Publisher21, Reference as Reference21, RulesForDocumentSharing as RulesForDocumentSharing21,
-    Tracking as Tracking21,
+    CategoryOfReference as CategoryOfReference21, CsafVersion as CsafVersion21,
+    DocumentLevelMetaData as DocumentLevelMetaData21, Note as Note21, Publisher as Publisher21,
+    Reference as Reference21, RulesForDocumentSharing as RulesForDocumentSharing21, Tracking as Tracking21,
 };
 use crate::validation::ValidationError;
+
+/// Returns an iterator over the reference URLs that satisfy the canonical URL requirements:
+/// `category = "self"`, starts with `https://`, ends with the tracking-ID-derived filename.
+fn canonical_url_candidates<'a, R: DocumentReferenceTrait>(
+    references: Option<&'a Vec<R>>,
+    expected_filename: &str,
+) -> impl Iterator<Item = &'a str> {
+    references
+        .into_iter()
+        .flatten()
+        // using CategoryOfReference21 here is fine, CategoryOfReference20 is 1:1 mapped to this
+        .filter(|r| r.get_category() == CategoryOfReference21::Self_)
+        .map(|r| r.get_url())
+        .filter(move |url| url.starts_with("https://") && url.ends_with(expected_filename))
+}
 
 /// Trait representing document meta-level information
 pub trait DocumentTrait {
@@ -68,6 +83,20 @@ pub trait DocumentTrait {
 
     /// Returns the references of this document
     fn get_references(&self) -> Option<&Vec<Self::DocumentReferenceType>>;
+
+    /// Returns the canonical URLs from this document's references.
+    fn get_canonical_urls(&self) -> Vec<&str> {
+        let expected_filename = self.get_tracking().get_canonical_filename();
+        canonical_url_candidates(self.get_references(), expected_filename.as_str()).collect()
+    }
+
+    /// Returns `true` if the document has at least one canonical URL.
+    fn has_canonical_url(&self) -> bool {
+        let expected_filename = self.get_tracking().get_canonical_filename();
+        canonical_url_candidates(self.get_references(), expected_filename.as_str())
+            .next()
+            .is_some()
+    }
 
     fn get_csaf_version(&self) -> CsafVersion;
 
@@ -187,4 +216,50 @@ impl DocumentTrait for DocumentLevelMetaData21 {
     }
 
     impl_str_field_getter!(get_title, title);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::csaf2_1::schema::Reference as Reference21;
+    use rstest::rstest;
+    use serde_json::json;
+
+    /// Reference21 mock, Reference20 is exactly the same though
+    fn make_ref21(category: &str, url: &str) -> Reference21 {
+        serde_json::from_value(json!({
+            "category": category,
+            "summary": "x",
+            "url": url
+        }))
+        .unwrap()
+    }
+
+    const FILENAME: &str = "example_company_-_2019-yh3234.json";
+    const HTTPS_MATCH: &str = "https://example.com/example_company_-_2019-yh3234.json";
+    const HTTP_MATCH: &str = "http://example.com/example_company_-_2019-yh3234.json";
+    const HTTPS_WRONG_FILE: &str = "https://example.com/example_company_-_2019-yh3235.json";
+
+    #[rstest]
+    #[case::no_references(None, 0)]
+    #[case::http_rejected(Some(vec![make_ref21("self", HTTP_MATCH)]), 0)]
+    #[case::wrong_filename(Some(vec![make_ref21("self", HTTPS_WRONG_FILE)]), 0)]
+    #[case::external_rejected(Some(vec![make_ref21("external", HTTPS_MATCH)]), 0)]
+    #[case::valid_match(Some(vec![make_ref21("self", HTTPS_MATCH)]), 1)]
+    fn test_candidate_filtering(#[case] refs: Option<Vec<Reference21>>, #[case] expected_count: usize) {
+        let refs_ref = refs.as_ref();
+        assert_eq!(canonical_url_candidates(refs_ref, FILENAME).count(), expected_count);
+    }
+
+    #[test]
+    fn only_matching_refs_are_returned_from_mixed_list() {
+        let refs = vec![
+            make_ref21("self", HTTPS_MATCH),
+            make_ref21("self", HTTP_MATCH),
+            make_ref21("self", HTTPS_WRONG_FILE),
+            make_ref21("external", HTTPS_MATCH),
+        ];
+        let result: Vec<_> = canonical_url_candidates(Some(&refs), FILENAME).collect();
+        assert_eq!(result, vec![HTTPS_MATCH]);
+    }
 }

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -243,7 +243,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.2.44" => None, // Some(ValidatorForTest6_2_44.validate(self)),
                 "6.2.45" => None, // Some(ValidatorForTest6_2_45.validate(self)),
                 "6.2.46" => None, // Some(ValidatorForTest6_2_46.validate(self)),
-                "6.2.47" => None, // Some(ValidatorForTest6_2_47.validate(self)),
+                "6.2.47" => Some(ValidatorForTest6_2_47.validate(self)),
                 "6.2.48" => Some(ValidatorForTest6_2_48.validate(self)),
                 "6.2.49" => None,   // Some(ValidatorForTest6_2_49.validate(self)),
                 "6.2.50.1" => None, // Some(ValidatorForTest6_2_50_1.validate(self)),

--- a/csaf-rs/src/validations/mod.rs
+++ b/csaf-rs/src/validations/mod.rs
@@ -110,6 +110,7 @@ pub mod test_6_2_32;
 pub mod test_6_2_33;
 pub mod test_6_2_38;
 pub mod test_6_2_41;
+pub mod test_6_2_47;
 pub mod test_6_2_48;
 pub mod test_6_2_52;
 pub mod test_6_2_53;

--- a/csaf-rs/src/validations/test_6_2_11.rs
+++ b/csaf-rs/src/validations/test_6_2_11.rs
@@ -1,7 +1,5 @@
-use crate::csaf_traits::{CsafTrait, DocumentReferenceTrait, DocumentTrait, TrackingTrait};
-use crate::schema::csaf2_1::schema::CategoryOfReference;
+use crate::csaf_traits::{CsafTrait, DocumentTrait};
 use crate::validation::ValidationError;
-use regex::Regex;
 use std::sync::LazyLock;
 
 /// 6.2.11 Missing Canonical URL
@@ -11,35 +9,10 @@ use std::sync::LazyLock;
 /// - url starts with "https://"
 /// - url ends with the valid filename according to section 5.1
 pub fn test_6_2_11_missing_canonical_url(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    // Get the expected filename from tracking ID
-    let expected_filename = generate_filename(doc.get_document().get_tracking().get_id());
-
-    // Check if any reference meets the criteria
-    if let Some(references) = doc.get_document().get_references() {
-        for reference in references {
-            if CategoryOfReference::Self_ == reference.get_category()
-                && reference.get_url().starts_with("https://")
-                && reference.get_url().ends_with(&expected_filename)
-            {
-                return Ok(());
-            }
-        }
+    if !doc.get_document().has_canonical_url() {
+        return Err(vec![MISSING_CANONICAL_URL.clone()]);
     }
-
-    Err(vec![MISSING_CANONICAL_URL.clone()])
-}
-
-/// Generate the valid filename according to section 5.1
-fn generate_filename(tracking_id: &str) -> String {
-    // Step 1: Convert to lowercase
-    let lowercase_id = tracking_id.to_lowercase();
-
-    // Step 2: Replace any character sequence not in [+\-a-z0-9] with single underscore
-    static INVALID_CHARS: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[^+\-a-z0-9]+").unwrap());
-    let cleaned_id = INVALID_CHARS.replace_all(&lowercase_id, "_");
-
-    // Step 3: Append .json
-    format!("{cleaned_id}.json")
+    Ok(())
 }
 
 static MISSING_CANONICAL_URL: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
@@ -67,21 +40,5 @@ mod tests {
         TESTS_2_1
             .test_6_2_11
             .expect(err.clone(), err.clone(), err, ok.clone(), ok.clone(), ok);
-    }
-
-    #[test]
-    fn test_generate_filename() {
-        // Test examples from the spec
-        assert_eq!(
-            generate_filename("OASIS_CSAF_TC-CSAF_2.0-2021-6-2-11-01"),
-            "oasis_csaf_tc-csaf_2_0-2021-6-2-11-01.json"
-        );
-        assert_eq!(generate_filename("2022_#01-A"), "2022_01-a.json");
-
-        // Test that multiple consecutive invalid chars become single underscore
-        assert_eq!(generate_filename("test###value"), "test_value.json");
-
-        // Test valid characters are preserved
-        assert_eq!(generate_filename("Test+123-456"), "test+123-456.json");
     }
 }

--- a/csaf-rs/src/validations/test_6_2_47.rs
+++ b/csaf-rs/src/validations/test_6_2_47.rs
@@ -1,0 +1,89 @@
+use crate::csaf_traits::{ContentTrait, CsafTrait, DocumentTrait, MetricTrait, VulnerabilityTrait};
+use crate::validation::ValidationError;
+use std::collections::HashSet;
+
+fn create_qualitative_severity_rating_error(content_path: &str) -> ValidationError {
+    ValidationError {
+        message: "A metric provided by the issuing party must not use `qualitative_severity_rating`.".to_string(),
+        instance_path: format!("{content_path}/qualitative_severity_rating"),
+    }
+}
+
+/// 6.2.47 Use of Qualitative Severity Rating by Issuing Party
+///
+/// For each item in metrics provided by the issuing party it MUST be tested that it does not use
+/// the qualitative severity rating.
+///
+/// This covers all items in metrics that do not have a source property and those where the source
+/// is equal to the canonical URL. It does not cover assessments made by third parties.
+pub fn test_6_2_47_use_of_qualitative_severity_rating_by_issuing_party(
+    doc: &impl CsafTrait,
+) -> Result<(), Vec<ValidationError>> {
+    let vulnerabilities = doc.get_vulnerabilities();
+    if vulnerabilities.is_empty() {
+        // wasSkipped later (#407)
+        return Ok(());
+    }
+
+    // collect canonical URLs into a HashSet for O(1) lookups
+    let canonical_urls: HashSet<&str> = doc.get_document().get_canonical_urls().into_iter().collect();
+
+    let mut errors: Option<Vec<ValidationError>> = None;
+
+    for (i_v, vulnerability) in vulnerabilities.iter().enumerate() {
+        if let Some(metrics) = vulnerability.get_metrics() {
+            for (i_m, metric) in metrics.iter().enumerate() {
+                // check if metric is by issuing party
+                let is_by_issuing_party = match metric.get_source() {
+                    None => true,
+                    Some(source) => canonical_urls.contains(source),
+                };
+
+                // if not, this metric is irrelevant to this test
+                if !is_by_issuing_party {
+                    continue;
+                }
+
+                // if metric has qualitative severity rating, generate an error
+                let content = metric.get_content();
+                if content.has_qualitative_severity() {
+                    let content_path = content.get_content_json_path(i_v, i_m);
+                    errors
+                        .get_or_insert_default()
+                        .push(create_qualitative_severity_rating_error(&content_path));
+                }
+            }
+        }
+    }
+
+    errors.map_or(Ok(()), Err)
+}
+
+crate::test_validation::impl_validator!(
+    csaf2_1,
+    ValidatorForTest6_2_47,
+    test_6_2_47_use_of_qualitative_severity_rating_by_issuing_party
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::csaf2_1::testcases::TESTS_2_1;
+
+    #[test]
+    fn test_test_6_2_47() {
+        let case_01_no_source = Err(vec![create_qualitative_severity_rating_error(
+            "/vulnerabilities/0/metrics/0/content",
+        )]);
+        let case_02_source_is_canonical = Err(vec![create_qualitative_severity_rating_error(
+            "/vulnerabilities/0/metrics/0/content",
+        )]);
+
+        // Case 11: metric without source and without qualitative severity
+        // Case 12: metric with third-party URL as source and qualitative severity rating
+
+        TESTS_2_1
+            .test_6_2_47
+            .expect(case_01_no_source, case_02_source_is_canonical, Ok(()), Ok(()));
+    }
+}


### PR DESCRIPTION
This PR:
* moves the "generate canonical filename" and "has canonical url" functions into the trait, including test coverage
* moves 6.2.11, which previously contained the functions, to use them
* adds test 6.2.47, which needed a similar function "get all canonical urls"

Test coverage looks fine IMO, but I would invite you to discuss edge cases if you find any during review


