### PR TITLE
ci: compare PR benchmarks against the merge base on the same runner

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,20 +34,54 @@ jobs:
       - name: Update rustup
         run: rustup update stable --no-self-update
 
+      - name: Run benchmarks (merge base)
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
+          git checkout --detach ${{ github.event.pull_request.base.sha }}
+          git submodule update --init
+          cargo bench --bench validation_benchmark -- --output-format bencher | tee base-output.txt
+          git checkout --detach ${{ github.sha }}
+          git submodule update --init
+
+      - name: Save the merge-base result as comparison baseline
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: CSAF Validation Benchmark
+          tool: "cargo"
+          output-file-path: base-output.txt
+          external-data-json-path: ./benchmark-base/data.json
+
       - name: Run benchmarks
         run: cargo bench --bench validation_benchmark -- --output-format bencher | tee output.txt
 
-      - name: Store benchmark result
+      - name: Compare with the merge base on the same runner
+        if: github.event_name == 'pull_request'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: CSAF Validation Benchmark
           tool: "cargo"
           output-file-path: output.txt
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+          external-data-json-path: ./benchmark-base/data.json
+          save-data-file: false
           alert-threshold: "150%"
-          comment-on-alert: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+          comment-on-alert: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
           summary-always: true
-          comment-always: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+          comment-always: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+
+      - name: Store benchmark result
+        if: github.event_name == 'push'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: CSAF Validation Benchmark
+          tool: "cargo"
+          output-file-path: output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          summary-always: true
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench


### PR DESCRIPTION
The PR summary previously compared against the last gh-pages entry, measured on a different runner instance; the stored history swings 1.16-1.47x between main runs, so the table flagged noise as regressions. PRs now bench the merge base first and compare within one runner through an external data file; pushes to main keep storing the gh-pages trend unchanged. The PR job pays one extra compile-and-bench pass for it.