### PR TITLE
refactor: move references to shared, add vulnerabilites references

### DIFF
--- a/csaf-rs/src/csaf/traits/document/mod.rs
+++ b/csaf-rs/src/csaf/traits/document/mod.rs
@@ -1,5 +1,4 @@
 pub mod distribution_trait;
-pub mod document_references_trait;
 pub mod generator_trait;
 pub mod publisher_trait;
 pub mod revision_trait;

--- a/csaf-rs/src/csaf/traits/document_trait.rs
+++ b/csaf-rs/src/csaf/traits/document_trait.rs
@@ -5,7 +5,7 @@ use crate::csaf::traits::util::extract_references::{
 use crate::csaf::traits::util::impl_str_field_getter;
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
-use crate::csaf_traits::{DistributionTrait, DocumentReferenceTrait, NoteTrait, PublisherTrait, TrackingTrait};
+use crate::csaf_traits::{DistributionTrait, ReferenceTrait, NoteTrait, PublisherTrait, TrackingTrait};
 use crate::schema::csaf2_0::schema::{
     CsafVersion as CsafVersion20, DocumentLevelMetaData as DocumentLevelMetaData20, Note as Note20,
     Publisher as Publisher20, Reference as Reference20, RulesForSharingDocument as RulesForSharingDocument20,
@@ -20,7 +20,7 @@ use crate::validation::ValidationError;
 
 /// Returns an iterator over the reference URLs that satisfy the canonical URL requirements:
 /// `category = "self"`, starts with `https://`, ends with the tracking-ID-derived filename.
-fn canonical_url_candidates<'a, R: DocumentReferenceTrait>(
+fn canonical_url_candidates<'a, R: ReferenceTrait>(
     references: Option<&'a Vec<R>>,
     expected_filename: &str,
 ) -> impl Iterator<Item = &'a str> {
@@ -47,7 +47,7 @@ pub trait DocumentTrait {
     /// Type representing document publisher information
     type PublisherType: PublisherTrait;
 
-    type DocumentReferenceType: DocumentReferenceTrait;
+    type ReferenceType: ReferenceTrait;
 
     /// Returns the tracking information for this document
     fn get_tracking(&self) -> &Self::TrackingType;
@@ -82,7 +82,7 @@ pub trait DocumentTrait {
     fn get_category(&self) -> CsafDocumentCategory;
 
     /// Returns the references of this document
-    fn get_references(&self) -> Option<&Vec<Self::DocumentReferenceType>>;
+    fn get_references(&self) -> Option<&Vec<Self::ReferenceType>>;
 
     /// Returns the canonical URLs from this document's references.
     fn get_canonical_urls(&self) -> Vec<&str> {
@@ -109,7 +109,7 @@ impl DocumentTrait for DocumentLevelMetaData20 {
     type DistributionType = RulesForSharingDocument20;
     type NoteType = Note20;
     type PublisherType = Publisher20;
-    type DocumentReferenceType = Reference20;
+    type ReferenceType = Reference20;
 
     fn get_tracking(&self) -> &Self::TrackingType {
         &self.tracking
@@ -143,7 +143,7 @@ impl DocumentTrait for DocumentLevelMetaData20 {
         self.source_lang.as_deref().map(CsafLanguage::from)
     }
 
-    fn get_publisher(&self) -> &Publisher20 {
+    fn get_publisher(&self) -> &Self::PublisherType {
         &self.publisher
     }
 
@@ -151,7 +151,7 @@ impl DocumentTrait for DocumentLevelMetaData20 {
         CsafDocumentCategory::from(&self.category)
     }
 
-    fn get_references(&self) -> Option<&Vec<Self::DocumentReferenceType>> {
+    fn get_references(&self) -> Option<&Vec<Self::ReferenceType>> {
         self.references.as_deref()
     }
 
@@ -169,7 +169,7 @@ impl DocumentTrait for DocumentLevelMetaData21 {
     type DistributionType = RulesForDocumentSharing21;
     type NoteType = Note21;
     type PublisherType = Publisher21;
-    type DocumentReferenceType = Reference21;
+    type ReferenceType = Reference21;
 
     fn get_tracking(&self) -> &Self::TrackingType {
         &self.tracking
@@ -205,7 +205,7 @@ impl DocumentTrait for DocumentLevelMetaData21 {
         CsafDocumentCategory::from(&self.category)
     }
 
-    fn get_references(&self) -> Option<&Vec<Reference21>> {
+    fn get_references(&self) -> Option<&Vec<Self::ReferenceType>> {
         self.references.as_deref()
     }
 

--- a/csaf-rs/src/csaf/traits/document_trait.rs
+++ b/csaf-rs/src/csaf/traits/document_trait.rs
@@ -5,7 +5,7 @@ use crate::csaf::traits::util::extract_references::{
 use crate::csaf::traits::util::impl_str_field_getter;
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
-use crate::csaf_traits::{DistributionTrait, ReferenceTrait, NoteTrait, PublisherTrait, TrackingTrait};
+use crate::csaf_traits::{DistributionTrait, NoteTrait, PublisherTrait, ReferenceTrait, TrackingTrait};
 use crate::schema::csaf2_0::schema::{
     CsafVersion as CsafVersion20, DocumentLevelMetaData as DocumentLevelMetaData20, Note as Note20,
     Publisher as Publisher20, Reference as Reference20, RulesForSharingDocument as RulesForSharingDocument20,

--- a/csaf-rs/src/csaf/traits/shared/mod.rs
+++ b/csaf-rs/src/csaf/traits/shared/mod.rs
@@ -1,1 +1,2 @@
 pub mod note_trait;
+pub mod references_trait;

--- a/csaf-rs/src/csaf/traits/shared/references_trait.rs
+++ b/csaf-rs/src/csaf/traits/shared/references_trait.rs
@@ -2,17 +2,17 @@ use crate::csaf::traits::util::impl_str_field_getter;
 use crate::schema::csaf2_0::schema::{CategoryOfReference as CategoryOfReference20, Reference as Reference20};
 use crate::schema::csaf2_1::schema::{CategoryOfReference as CategoryOfReference21, Reference as Reference21};
 
-/// Trait representing document references
-pub trait DocumentReferenceTrait {
-    /// Returns the category of the document reference as enum
+/// Trait representing document or vulnerability references
+pub trait ReferenceTrait {
+    /// Returns the category of the reference as enum
     fn get_category(&self) -> CategoryOfReference21;
-    /// Returns the summary of the document reference
+    /// Returns the summary of the reference
     fn get_summary(&self) -> &str;
-    /// Returns the URL of the document reference
+    /// Returns the URL of the reference
     fn get_url(&self) -> &str;
 }
 
-impl DocumentReferenceTrait for Reference20 {
+impl ReferenceTrait for Reference20 {
     fn get_category(&self) -> CategoryOfReference21 {
         match &self.category {
             CategoryOfReference20::External => CategoryOfReference21::External,
@@ -24,7 +24,7 @@ impl DocumentReferenceTrait for Reference20 {
     impl_str_field_getter!(get_url, url);
 }
 
-impl DocumentReferenceTrait for Reference21 {
+impl ReferenceTrait for Reference21 {
     fn get_category(&self) -> CategoryOfReference21 {
         self.category
     }

--- a/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
@@ -6,17 +6,17 @@ use crate::csaf::traits::util::not_present_20::NotPresentInCsaf20;
 use crate::csaf::traits::vulnerabilities::product_status_trait::ProductStatusTrait;
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf_traits::{
-    Cwe, FirstKnownExploitationDatesTrait, FlagTrait, InvolvementTrait, MetricTrait, NoteTrait, RemediationTrait,
+    Cwe, ReferenceTrait, FirstKnownExploitationDatesTrait, FlagTrait, InvolvementTrait, MetricTrait, NoteTrait, RemediationTrait,
     ThreatTrait, VulnerabilityIdTrait,
 };
 use crate::schema::csaf2_0::schema::{
     Flag as Flag20, Id as Id20, Involvement as Involvement20, Note as Note20, ProductStatus as ProductStatus20,
-    Remediation as Remediation20, Score as Score20, Threat as Threat20, Vulnerability as Vulnerability20,
+    Reference as Reference20, Remediation as Remediation20, Score as Score20, Threat as Threat20, Vulnerability as Vulnerability20,
 };
 use crate::schema::csaf2_1::schema::{
     FirstKnownExploitationDate as FirstKnownExploitationDate21, Flag as Flag21, Id as Id21,
     Involvement as Involvement21, Metric as Metric21, Note as Note21, ProductStatus as ProductStatus21,
-    Remediation as Remediation21, Threat as Threat21, Vulnerability as Vulnerability21,
+    Reference as Reference21, Remediation as Remediation21, Threat as Threat21, Vulnerability as Vulnerability21,
 };
 
 /// Collects references from all vulnerabilities using the given extractor, prepending
@@ -66,6 +66,9 @@ pub trait VulnerabilityTrait {
     type NoteType: NoteTrait;
 
     type FirstKnownExploitationDatesType: FirstKnownExploitationDatesTrait;
+
+    /// The associated type representing vulnerability references.
+    type ReferenceType: ReferenceTrait;
 
     /// Retrieves a list of remediations associated with the vulnerability.
     fn get_remediations(&self) -> &Vec<Self::RemediationType>;
@@ -136,6 +139,9 @@ pub trait VulnerabilityTrait {
     /// Returns the information about the first known exploitation dates of this vulnerability.
     fn get_first_known_exploitation_dates(&self) -> Option<&Vec<Self::FirstKnownExploitationDatesType>>;
 
+    /// Returns the references associated with this vulnerability.
+    fn get_references(&self) -> Option<&Vec<Self::ReferenceType>>;
+
     define_reference_accessors! {
         both: [
             (get_remediations_group_references,                     get_remediations_product_references,                     get_remediations,                     "remediations"),
@@ -166,6 +172,7 @@ impl VulnerabilityTrait for Vulnerability20 {
     type NoteType = Note20;
     // First known exploitation dates are not implemented in CSAF 2.0
     type FirstKnownExploitationDatesType = NotPresentInCsaf20;
+    type ReferenceType = Reference20;
 
     fn get_remediations(&self) -> &Vec<Self::RemediationType> {
         &self.remediations
@@ -224,6 +231,10 @@ impl VulnerabilityTrait for Vulnerability20 {
     fn get_first_known_exploitation_dates(&self) -> Option<&Vec<Self::FirstKnownExploitationDatesType>> {
         None
     }
+
+    fn get_references(&self) -> Option<&Vec<Self::ReferenceType>> {
+        self.references.as_deref()
+    }
 }
 
 impl VulnerabilityTrait for Vulnerability21 {
@@ -236,6 +247,7 @@ impl VulnerabilityTrait for Vulnerability21 {
     type VulnerabilityIdType = Id21;
     type NoteType = Note21;
     type FirstKnownExploitationDatesType = FirstKnownExploitationDate21;
+    type ReferenceType = Reference21;
 
     fn get_remediations(&self) -> &Vec<Self::RemediationType> {
         &self.remediations
@@ -293,5 +305,9 @@ impl VulnerabilityTrait for Vulnerability21 {
 
     fn get_first_known_exploitation_dates(&self) -> Option<&Vec<Self::FirstKnownExploitationDatesType>> {
         self.first_known_exploitation_dates.as_ref()
+    }
+
+    fn get_references(&self) -> Option<&Vec<Self::ReferenceType>> {
+        self.references.as_deref()
     }
 }

--- a/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
+++ b/csaf-rs/src/csaf/traits/vulnerabilities_trait.rs
@@ -6,12 +6,13 @@ use crate::csaf::traits::util::not_present_20::NotPresentInCsaf20;
 use crate::csaf::traits::vulnerabilities::product_status_trait::ProductStatusTrait;
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf_traits::{
-    Cwe, ReferenceTrait, FirstKnownExploitationDatesTrait, FlagTrait, InvolvementTrait, MetricTrait, NoteTrait, RemediationTrait,
-    ThreatTrait, VulnerabilityIdTrait,
+    Cwe, FirstKnownExploitationDatesTrait, FlagTrait, InvolvementTrait, MetricTrait, NoteTrait, ReferenceTrait,
+    RemediationTrait, ThreatTrait, VulnerabilityIdTrait,
 };
 use crate::schema::csaf2_0::schema::{
     Flag as Flag20, Id as Id20, Involvement as Involvement20, Note as Note20, ProductStatus as ProductStatus20,
-    Reference as Reference20, Remediation as Remediation20, Score as Score20, Threat as Threat20, Vulnerability as Vulnerability20,
+    Reference as Reference20, Remediation as Remediation20, Score as Score20, Threat as Threat20,
+    Vulnerability as Vulnerability20,
 };
 use crate::schema::csaf2_1::schema::{
     FirstKnownExploitationDate as FirstKnownExploitationDate21, Flag as Flag21, Id as Id21,

--- a/csaf-rs/src/csaf_traits.rs
+++ b/csaf-rs/src/csaf_traits.rs
@@ -7,7 +7,6 @@ pub use crate::csaf::enums::product_status::ProductStatus;
 pub use crate::csaf::enums::product_status_group::ProductStatusGroup;
 pub use crate::csaf::traits::csaf_trait::CsafTrait;
 pub use crate::csaf::traits::document::distribution_trait::DistributionTrait;
-pub use crate::csaf::traits::shared::references_trait::ReferenceTrait;
 pub use crate::csaf::traits::document::generator_trait::GeneratorTrait;
 pub use crate::csaf::traits::document::publisher_trait::PublisherTrait;
 pub use crate::csaf::traits::document::revision_trait::RevisionTrait;
@@ -22,6 +21,7 @@ pub use crate::csaf::traits::product_tree::product_path_trait::ProductPathTrait;
 pub use crate::csaf::traits::product_tree::product_trait::ProductTrait;
 pub use crate::csaf::traits::product_tree_trait::{BranchTrait, ProductTreeTrait, build_leaf_instance_path};
 pub use crate::csaf::traits::shared::note_trait::NoteTrait;
+pub use crate::csaf::traits::shared::references_trait::ReferenceTrait;
 pub use crate::csaf::traits::util::generic_with::{
     WithDate, WithOptionalDate, WithOptionalGroupIds, WithOptionalProductIds,
 };

--- a/csaf-rs/src/csaf_traits.rs
+++ b/csaf-rs/src/csaf_traits.rs
@@ -7,7 +7,7 @@ pub use crate::csaf::enums::product_status::ProductStatus;
 pub use crate::csaf::enums::product_status_group::ProductStatusGroup;
 pub use crate::csaf::traits::csaf_trait::CsafTrait;
 pub use crate::csaf::traits::document::distribution_trait::DistributionTrait;
-pub use crate::csaf::traits::document::document_references_trait::DocumentReferenceTrait;
+pub use crate::csaf::traits::shared::references_trait::ReferenceTrait;
 pub use crate::csaf::traits::document::generator_trait::GeneratorTrait;
 pub use crate::csaf::traits::document::publisher_trait::PublisherTrait;
 pub use crate::csaf::traits::document::revision_trait::RevisionTrait;

--- a/csaf-rs/src/validations/test_6_1_27_02.rs
+++ b/csaf-rs/src/validations/test_6_1_27_02.rs
@@ -1,5 +1,5 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
-use crate::csaf_traits::{CsafTrait, ReferenceTrait, DocumentTrait};
+use crate::csaf_traits::{CsafTrait, DocumentTrait, ReferenceTrait};
 use crate::schema::csaf2_1::schema::CategoryOfReference;
 use crate::validation::ValidationError;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;

--- a/csaf-rs/src/validations/test_6_1_27_02.rs
+++ b/csaf-rs/src/validations/test_6_1_27_02.rs
@@ -1,5 +1,5 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
-use crate::csaf_traits::{CsafTrait, DocumentReferenceTrait, DocumentTrait};
+use crate::csaf_traits::{CsafTrait, ReferenceTrait, DocumentTrait};
 use crate::schema::csaf2_1::schema::CategoryOfReference;
 use crate::validation::ValidationError;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
-use crate::csaf_traits::{CsafTrait, DocumentReferenceTrait, DocumentTrait};
+use crate::csaf_traits::{CsafTrait, ReferenceTrait, DocumentTrait};
 use crate::schema::csaf2_1::schema::CategoryOfReference;
 use crate::validation::ValidationError;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
-use crate::csaf_traits::{CsafTrait, ReferenceTrait, DocumentTrait};
+use crate::csaf_traits::{CsafTrait, DocumentTrait, ReferenceTrait};
 use crate::schema::csaf2_1::schema::CategoryOfReference;
 use crate::validation::ValidationError;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;


### PR DESCRIPTION
This PR:
* renames `DocumentReferences` to `References`
* moves the file trait file from `document` to `shared`
* adds a refernces getter to the vulnerabilites trait
* update usage to apply new name / location

This is in preparation for #143 and #142 