### PR TITLE
Chore/refactor return types

### DIFF
--- a/csaf-rs/src/csaf/raw.rs
+++ b/csaf-rs/src/csaf/raw.rs
@@ -2,7 +2,7 @@ use std::cell::OnceCell;
 
 use serde::de::DeserializeOwned;
 
-use crate::validation::{TestResult, TestResultStatus, Validatable, ValidationError};
+use crate::validation::{TestFinding, TestResult, TestResultStatus, Validatable};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RawDocument<T> {
@@ -86,7 +86,7 @@ where
     T: crate::test_validation::TestValidator<CSAF>,
     CSAF: DeserializeOwned,
 {
-    fn validate(&self, doc: &RawDocument<CSAF>) -> Result<(), Vec<ValidationError>> {
+    fn validate(&self, doc: &RawDocument<CSAF>) -> Result<(), Vec<TestFinding>> {
         let parsed = doc.get_parsed();
         match parsed {
             Ok(parsed_doc) => self.validate(parsed_doc),

--- a/csaf-rs/src/csaf/traits/document/distribution_trait.rs
+++ b/csaf-rs/src/csaf/traits/document/distribution_trait.rs
@@ -7,7 +7,7 @@ use crate::schema::csaf2_1::schema::{
     RulesForDocumentSharing as RulesForDocumentSharing21, SharingGroup as SharingGroup21,
     TrafficLightProtocolTlp as TrafficLightProtocolTlp21,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// Trait representing distribution information for a document
 pub trait DistributionTrait {
@@ -24,7 +24,7 @@ pub trait DistributionTrait {
     fn get_tlp_20(&self) -> Option<&Self::TlpType>;
 
     /// Returns the TLP information for this distribution with CSAF 2.1 semantics
-    fn get_tlp_21(&self) -> Result<&Self::TlpType, ValidationError>;
+    fn get_tlp_21(&self) -> Result<&Self::TlpType, TestFinding>;
 }
 
 impl DistributionTrait for RulesForSharingDocument20 {
@@ -40,13 +40,13 @@ impl DistributionTrait for RulesForSharingDocument20 {
         self.tlp.as_ref()
     }
 
-    /// Return TLP or a ValidationError to satisfy CSAF 2.1 semantics
-    fn get_tlp_21(&self) -> Result<&Self::TlpType, ValidationError> {
+    /// Return TLP or a TestFinding to satisfy CSAF 2.1 semantics
+    fn get_tlp_21(&self) -> Result<&Self::TlpType, TestFinding> {
         match self.tlp.as_ref() {
-            None => Err(ValidationError {
+            None => Err(TestFinding::Error(TestFindingData {
                 message: "CSAF 2.1 requires the TLP property, but it is not set.".to_string(),
                 instance_path: "/document/distribution/tlp".to_string(),
-            }),
+            })),
             Some(tlp) => Ok(tlp),
         }
     }
@@ -66,7 +66,7 @@ impl DistributionTrait for RulesForDocumentSharing21 {
     }
 
     /// Always return the value because it is mandatory
-    fn get_tlp_21(&self) -> Result<&Self::TlpType, ValidationError> {
+    fn get_tlp_21(&self) -> Result<&Self::TlpType, TestFinding> {
         Ok(&self.tlp)
     }
 }

--- a/csaf-rs/src/csaf/traits/document_trait.rs
+++ b/csaf-rs/src/csaf/traits/document_trait.rs
@@ -16,7 +16,7 @@ use crate::schema::csaf2_1::schema::{
     DocumentLevelMetaData as DocumentLevelMetaData21, Note as Note21, Publisher as Publisher21,
     Reference as Reference21, RulesForDocumentSharing as RulesForDocumentSharing21, Tracking as Tracking21,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// Returns an iterator over the reference URLs that satisfy the canonical URL requirements:
 /// `category = "self"`, starts with `https://`, ends with the tracking-ID-derived filename.
@@ -53,7 +53,7 @@ pub trait DocumentTrait {
     fn get_tracking(&self) -> &Self::TrackingType;
 
     /// Returns the distribution information for this document with CSAF 2.1 semantics
-    fn get_distribution_21(&self) -> Result<&Self::DistributionType, ValidationError>;
+    fn get_distribution_21(&self) -> Result<&Self::DistributionType, TestFinding>;
 
     /// Returns the distribution information for this document with CSAF 2.0 semantics
     fn get_distribution_20(&self) -> Option<&Self::DistributionType>;
@@ -121,12 +121,12 @@ impl DocumentTrait for DocumentLevelMetaData20 {
     }
 
     /// Return distribution or a Validation error to satisfy CSAF 2.1 semantics
-    fn get_distribution_21(&self) -> Result<&Self::DistributionType, ValidationError> {
+    fn get_distribution_21(&self) -> Result<&Self::DistributionType, TestFinding> {
         match self.distribution.as_ref() {
-            None => Err(ValidationError {
+            None => Err(TestFinding::Error(TestFindingData {
                 message: "CSAF 2.1 requires the distribution property, but it is not set.".to_string(),
                 instance_path: "/document/distribution".to_string(),
-            }),
+            })),
             Some(distribution) => Ok(distribution),
         }
     }
@@ -176,7 +176,7 @@ impl DocumentTrait for DocumentLevelMetaData21 {
     }
 
     /// We normalize to Option here because property was optional in CSAF 2.0
-    fn get_distribution_21(&self) -> Result<&Self::DistributionType, ValidationError> {
+    fn get_distribution_21(&self) -> Result<&Self::DistributionType, TestFinding> {
         Ok(&self.distribution)
     }
 

--- a/csaf-rs/src/csaf/types/csaf_datetime.rs
+++ b/csaf-rs/src/csaf/types/csaf_datetime.rs
@@ -1,4 +1,4 @@
-use crate::validation::{IntoValidationError, ValidationError};
+use crate::validation::{IntoTestFindingError, TestFinding, TestFindingData};
 use chrono::{DateTime, FixedOffset, ParseError, Utc};
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter, Result as FmtResult};
@@ -123,12 +123,12 @@ impl CsafDateTimeParseError {
     }
 }
 
-impl IntoValidationError for CsafDateTimeParseError {
-    fn into_validation_error(self, instance_path: &str) -> ValidationError {
-        ValidationError {
+impl IntoTestFindingError for CsafDateTimeParseError {
+    fn into_test_finding_error(self, instance_path: &str) -> TestFinding {
+        TestFinding::Error(TestFindingData {
             message: self.to_string(),
             instance_path: instance_path.to_string(),
-        }
+        })
     }
 }
 

--- a/csaf-rs/src/csaf/types/language/invalid_language.rs
+++ b/csaf-rs/src/csaf/types/language/invalid_language.rs
@@ -1,4 +1,4 @@
-use crate::validation::{IntoValidationError, ValidationError};
+use crate::validation::{IntoTestFindingError, TestFinding, TestFindingData};
 
 /// Represents an error that occurred while parsing or validating a language tag in a CSAF document.
 #[derive(Debug, PartialEq, Clone)]
@@ -13,8 +13,8 @@ pub enum CsafLanguageError {
     InvalidRegionSubtag(String, String),
 }
 
-impl IntoValidationError for CsafLanguageError {
-    fn into_validation_error(self, instance_path: &str) -> ValidationError {
+impl IntoTestFindingError for CsafLanguageError {
+    fn into_test_finding_error(self, instance_path: &str) -> TestFinding {
         let message = match self {
             Self::ParserError(invalid_lang_tag, parser_error) => {
                 format!("Invalid language code '{invalid_lang_tag}': parser failed with error: {parser_error}")
@@ -29,9 +29,9 @@ impl IntoValidationError for CsafLanguageError {
                 "Invalid language code '{invalid_lang_tag}': region subtag '{region_sub_tag}' is not a valid region subtag"
             ),
         };
-        ValidationError {
+        TestFinding::Error(TestFindingData {
             message,
             instance_path: instance_path.to_string(),
-        }
+        })
     }
 }

--- a/csaf-rs/src/csaf/types/purl/csaf_purl.rs
+++ b/csaf-rs/src/csaf/types/purl/csaf_purl.rs
@@ -97,7 +97,7 @@ mod test_purl_full_pipeline {
     use crate::csaf::types::purl::{PurlParseError, PurlParseErrorKind};
     use crate::schema::csaf2_0::schema::PackageUrlRepresentation as PackageUrlRepresentation20;
     use crate::schema::csaf2_1::schema::PackageUrlRepresentation as PackageUrlRepresentation21;
-    use crate::validation::IntoValidationError;
+    use crate::validation::IntoTestFindingError;
     use rstest::rstest;
     use std::str::FromStr;
 
@@ -142,11 +142,11 @@ mod test_purl_full_pipeline {
     ) {
         let csaf_purl = to_csaf_purl(purl_str, version);
 
-        let expected = PurlParseError::new_for_test(purl_str, expected_error).into_validation_error("");
+        let expected = PurlParseError::new_for_test(purl_str, expected_error).into_test_finding_error("");
 
         match csaf_purl {
             CsafPurl::Invalid(err) => {
-                let actual = err.into_validation_error("");
+                let actual = err.into_test_finding_error("");
                 assert_eq!(actual, expected);
             },
             CsafPurl::Valid(_) => {

--- a/csaf-rs/src/csaf/types/purl/purl_error.rs
+++ b/csaf-rs/src/csaf/types/purl/purl_error.rs
@@ -1,4 +1,4 @@
-use crate::validation::{IntoValidationError, ValidationError};
+use crate::validation::{IntoTestFindingError, TestFinding, TestFindingData};
 use std::fmt::Display;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,12 +58,12 @@ impl PurlParseError {
     }
 }
 
-impl IntoValidationError for PurlParseError {
-    fn into_validation_error(self, instance_path: &str) -> ValidationError {
-        ValidationError {
+impl IntoTestFindingError for PurlParseError {
+    fn into_test_finding_error(self, instance_path: &str) -> TestFinding {
+        TestFinding::Error(TestFindingData {
             message: format!("Invalid PURL format: {}, Error: {}", self.original_purl, self.kind),
             instance_path: instance_path.to_string(),
-        }
+        })
     }
 }
 

--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -6,9 +6,9 @@
  * Re-generate with: cargo run --locked -p type-generator
  */
 crate::macros::define_csaf_test!(
-    Test6_1_1, ValidatorForTest6_1_1, id : "6.1.1", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_1, ValidatorForTest6_1_1, ExpectedResults_6_1_1, id : "6.1.1", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-01-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-01-02.json",
@@ -21,18 +21,18 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-01-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_2, ValidatorForTest6_1_2, id : "6.1.2", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_2, ValidatorForTest6_1_2, ExpectedResults_6_1_2, id : "6.1.2", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-02-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-02-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-02-s01.json",
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-02-s01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_3, ValidatorForTest6_1_3, id : "6.1.3", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_3, ValidatorForTest6_1_3, ExpectedResults_6_1_3, id : "6.1.3", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-03-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-03-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-03-s01.json",
@@ -41,9 +41,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-03-s02.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_4, ValidatorForTest6_1_4, id : "6.1.4", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_4, ValidatorForTest6_1_4, ExpectedResults_6_1_4, id : "6.1.4", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-04-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-04-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-04-02.json",
@@ -56,9 +56,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-04-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_5, ValidatorForTest6_1_5, id : "6.1.5", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_5, ValidatorForTest6_1_5, ExpectedResults_6_1_5, id : "6.1.5", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-05-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-05-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-05-s01.json",
@@ -67,9 +67,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-05-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_6, ValidatorForTest6_1_6, id : "6.1.6", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_6, ValidatorForTest6_1_6, ExpectedResults_6_1_6, id : "6.1.6", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-06-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-06-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-06-02.json",
@@ -92,9 +92,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-06-15.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_7, ValidatorForTest6_1_7, id : "6.1.7", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_7, ValidatorForTest6_1_7, ExpectedResults_6_1_7, id : "6.1.7", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-07-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-07-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-07-11.json",
@@ -103,9 +103,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-07-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_8, ValidatorForTest6_1_8, id : "6.1.8", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_8, ValidatorForTest6_1_8, ExpectedResults_6_1_8, id : "6.1.8", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-08-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-08-02.json",
@@ -122,9 +122,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-08-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_9, ValidatorForTest6_1_9, id : "6.1.9", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_9, ValidatorForTest6_1_9, ExpectedResults_6_1_9, id : "6.1.9", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-09-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-09-02.json",
@@ -139,23 +139,23 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-09-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_10, ValidatorForTest6_1_10, id : "6.1.10", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_10, ValidatorForTest6_1_10, ExpectedResults_6_1_10, id : "6.1.10", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-10-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-10-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_11, ValidatorForTest6_1_11, id : "6.1.11", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_11, ValidatorForTest6_1_11, ExpectedResults_6_1_11, id : "6.1.11", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-11-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-11-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_12, ValidatorForTest6_1_12, id : "6.1.12", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_12, ValidatorForTest6_1_12, ExpectedResults_6_1_12, id : "6.1.12", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-12-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-12-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-12-s01.json",
@@ -170,9 +170,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-12-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_13, ValidatorForTest6_1_13, id : "6.1.13", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_13, ValidatorForTest6_1_13, ExpectedResults_6_1_13, id : "6.1.13", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-13-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-13-01.json"), (case_s06, "s06",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-13-s06.json",
@@ -183,9 +183,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-13-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_14, ValidatorForTest6_1_14, id : "6.1.14", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_14, ValidatorForTest6_1_14, ExpectedResults_6_1_14, id : "6.1.14", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-14-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-14-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-14-02.json",
@@ -224,9 +224,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-14-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_15, ValidatorForTest6_1_15, id : "6.1.15", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_15, ValidatorForTest6_1_15, ExpectedResults_6_1_15, id : "6.1.15", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-15-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-15-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-15-02.json",
@@ -239,9 +239,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-15-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_16, ValidatorForTest6_1_16, id : "6.1.16", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_16, ValidatorForTest6_1_16, ExpectedResults_6_1_16, id : "6.1.16", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-16-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-16-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-16-02.json",
@@ -280,9 +280,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-16-31.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_17, ValidatorForTest6_1_17, id : "6.1.17", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_17, ValidatorForTest6_1_17, ExpectedResults_6_1_17, id : "6.1.17", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-17-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-17-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-17-s01.json",
@@ -307,9 +307,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-17-s15.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_18, ValidatorForTest6_1_18, id : "6.1.18", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_18, ValidatorForTest6_1_18, ExpectedResults_6_1_18, id : "6.1.18", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-18-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-18-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-18-s01.json",
@@ -318,18 +318,18 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-18-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_19, ValidatorForTest6_1_19, id : "6.1.19", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_19, ValidatorForTest6_1_19, ExpectedResults_6_1_19, id : "6.1.19", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-19-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-19-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-19-02.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-19-02.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_20, ValidatorForTest6_1_20, id : "6.1.20", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_20, ValidatorForTest6_1_20, ExpectedResults_6_1_20, id : "6.1.20", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-20-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-20-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-20-s01.json",
@@ -338,9 +338,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-20-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_21, ValidatorForTest6_1_21, id : "6.1.21", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_21, ValidatorForTest6_1_21, ExpectedResults_6_1_21, id : "6.1.21", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-21-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-21-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-21-02.json",
@@ -373,9 +373,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-21-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_22, ValidatorForTest6_1_22, id : "6.1.22", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_22, ValidatorForTest6_1_22, ExpectedResults_6_1_22, id : "6.1.22", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-22-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-22-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-22-s01.json",
@@ -386,9 +386,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-22-s03.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_23, ValidatorForTest6_1_23, id : "6.1.23", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_23, ValidatorForTest6_1_23, ExpectedResults_6_1_23, id : "6.1.23", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-23-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-23-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-23-s01.json",
@@ -401,9 +401,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-23-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_24, ValidatorForTest6_1_24, id : "6.1.24", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_24, ValidatorForTest6_1_24, ExpectedResults_6_1_24, id : "6.1.24", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-24-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-24-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-24-02.json",
@@ -428,9 +428,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-24-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_25, ValidatorForTest6_1_25, id : "6.1.25", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_25, ValidatorForTest6_1_25, ExpectedResults_6_1_25, id : "6.1.25", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-25-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-25-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-25-s01.json",
@@ -445,9 +445,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-25-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_26, ValidatorForTest6_1_26, id : "6.1.26", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_26, ValidatorForTest6_1_26, ExpectedResults_6_1_26, id : "6.1.26", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-02.json",
@@ -468,71 +468,71 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-26-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_1, ValidatorForTest6_1_27_1, id : "6.1.27.1", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_1, ValidatorForTest6_1_27_1, ExpectedResults_6_1_27_1, id : "6.1.27.1",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-01-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-01-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_2, ValidatorForTest6_1_27_2, id : "6.1.27.2", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_2, ValidatorForTest6_1_27_2, ExpectedResults_6_1_27_2, id : "6.1.27.2",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-02-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-02-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_3, ValidatorForTest6_1_27_3, id : "6.1.27.3", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_3, ValidatorForTest6_1_27_3, ExpectedResults_6_1_27_3, id : "6.1.27.3",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-03-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-03-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_4, ValidatorForTest6_1_27_4, id : "6.1.27.4", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_4, ValidatorForTest6_1_27_4, ExpectedResults_6_1_27_4, id : "6.1.27.4",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-04-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-04-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_5, ValidatorForTest6_1_27_5, id : "6.1.27.5", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_5, ValidatorForTest6_1_27_5, ExpectedResults_6_1_27_5, id : "6.1.27.5",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-05-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-05-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-05-s01.json",
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-05-s01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_6, ValidatorForTest6_1_27_6, id : "6.1.27.6", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_6, ValidatorForTest6_1_27_6, ExpectedResults_6_1_27_6, id : "6.1.27.6",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-06-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-06-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_7, ValidatorForTest6_1_27_7, id : "6.1.27.7", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_7, ValidatorForTest6_1_27_7, ExpectedResults_6_1_27_7, id : "6.1.27.7",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-07-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-07-01.json"), (case_s11, "s11",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-07-s11.json",
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-07-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_8, ValidatorForTest6_1_27_8, id : "6.1.27.8", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_8, ValidatorForTest6_1_27_8, ExpectedResults_6_1_27_8, id : "6.1.27.8",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-08-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-08-01.json"), (case_s11, "s11",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-08-s11.json",
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-08-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_9, ValidatorForTest6_1_27_9, id : "6.1.27.9", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_27_9, ValidatorForTest6_1_27_9, ExpectedResults_6_1_27_9, id : "6.1.27.9",
+    doc_type : crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_0", cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-09-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-09-02.json",
@@ -561,7 +561,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-09-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_10, ValidatorForTest6_1_27_10, id : "6.1.27.10", doc_type : crate
+    Test6_1_27_10, ValidatorForTest6_1_27_10, ExpectedResults_6_1_27_10, id :
+    "6.1.27.10", doc_type : crate
     ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
     [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-10-01.json",
@@ -576,7 +577,8 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_11, ValidatorForTest6_1_27_11, id : "6.1.27.11", doc_type : crate
+    Test6_1_27_11, ValidatorForTest6_1_27_11, ExpectedResults_6_1_27_11, id :
+    "6.1.27.11", doc_type : crate
     ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
     [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-27-11-01.json",
@@ -589,9 +591,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-11-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_28, ValidatorForTest6_1_28, id : "6.1.28", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_28, ValidatorForTest6_1_28, ExpectedResults_6_1_28, id : "6.1.28", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-28-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-28-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-28-s01.json",
@@ -600,9 +602,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-28-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_29, ValidatorForTest6_1_29, id : "6.1.29", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_29, ValidatorForTest6_1_29, ExpectedResults_6_1_29, id : "6.1.29", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-29-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-29-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-29-s01.json",
@@ -617,9 +619,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-29-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_30, ValidatorForTest6_1_30, id : "6.1.30", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_30, ValidatorForTest6_1_30, ExpectedResults_6_1_30, id : "6.1.30", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-30-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-30-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-30-s01.json",
@@ -632,9 +634,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-30-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_31, ValidatorForTest6_1_31, id : "6.1.31", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_31, ValidatorForTest6_1_31, ExpectedResults_6_1_31, id : "6.1.31", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-31-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-31-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-31-02.json",
@@ -671,9 +673,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-31-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_32, ValidatorForTest6_1_32, id : "6.1.32", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_32, ValidatorForTest6_1_32, ExpectedResults_6_1_32, id : "6.1.32", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-32-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-32-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-32-s01.json",
@@ -688,69 +690,69 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_0-6-1-32-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_33, ValidatorForTest6_1_33, id : "6.1.33", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_1_33, ValidatorForTest6_1_33, ExpectedResults_6_1_33, id : "6.1.33", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-33-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-33-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-33-11.json",
     "mandatory/oasis_csaf_tc-csaf_2_0-2021-6-1-33-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_1, ValidatorForTest6_2_1, id : "6.2.1", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_1, ValidatorForTest6_2_1, ExpectedResults_6_2_1, id : "6.2.1", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-01-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-01-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-01-11.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-01-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_2, ValidatorForTest6_2_2, id : "6.2.2", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_2, ValidatorForTest6_2_2, ExpectedResults_6_2_2, id : "6.2.2", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-02-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-02-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_3, ValidatorForTest6_2_3, id : "6.2.3", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_3, ValidatorForTest6_2_3, ExpectedResults_6_2_3, id : "6.2.3", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-03-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-03-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_4, ValidatorForTest6_2_4, id : "6.2.4", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_4, ValidatorForTest6_2_4, ExpectedResults_6_2_4, id : "6.2.4", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-04-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-04-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_5, ValidatorForTest6_2_5, id : "6.2.5", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_5, ValidatorForTest6_2_5, ExpectedResults_6_2_5, id : "6.2.5", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-05-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-05-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_6, ValidatorForTest6_2_6, id : "6.2.6", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_6, ValidatorForTest6_2_6, ExpectedResults_6_2_6, id : "6.2.6", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-06-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-06-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_7, ValidatorForTest6_2_7, id : "6.2.7", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_7, ValidatorForTest6_2_7, ExpectedResults_6_2_7, id : "6.2.7", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-07-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-07-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_8, ValidatorForTest6_2_8, id : "6.2.8", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_8, ValidatorForTest6_2_8, ExpectedResults_6_2_8, id : "6.2.8", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-08-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-08-02.json",
@@ -761,9 +763,9 @@ crate::macros::define_csaf_test!(
     "optional/csaf-rs_csaf-csaf_2_0-6-2-08-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_9, ValidatorForTest6_2_9, id : "6.2.9", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_9, ValidatorForTest6_2_9, ExpectedResults_6_2_9, id : "6.2.9", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-09-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-09-02.json",
@@ -774,41 +776,41 @@ crate::macros::define_csaf_test!(
     "optional/csaf-rs_csaf-csaf_2_0-6-2-09-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_10, ValidatorForTest6_2_10, id : "6.2.10", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_10, ValidatorForTest6_2_10, ExpectedResults_6_2_10, id : "6.2.10", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-10-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-10-01.json"), (case_s11, "s11",
     "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json",
     "optional/csaf-rs_csaf-csaf_2_0-6-2-10-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_11, ValidatorForTest6_2_11, id : "6.2.11", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_11, ValidatorForTest6_2_11, ExpectedResults_6_2_11, id : "6.2.11", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-11-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-11-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-11-11.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-11-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_12, ValidatorForTest6_2_12, id : "6.2.12", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_12, ValidatorForTest6_2_12, ExpectedResults_6_2_12, id : "6.2.12", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-12-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-12-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_13, ValidatorForTest6_2_13, id : "6.2.13", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_13, ValidatorForTest6_2_13, ExpectedResults_6_2_13, id : "6.2.13", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-13-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-13-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_14, ValidatorForTest6_2_14, id : "6.2.14", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_14, ValidatorForTest6_2_14, ExpectedResults_6_2_14, id : "6.2.14", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-14-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-14-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-14-02.json",
@@ -835,9 +837,9 @@ crate::macros::define_csaf_test!(
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-14-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_15, ValidatorForTest6_2_15, id : "6.2.15", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_15, ValidatorForTest6_2_15, ExpectedResults_6_2_15, id : "6.2.15", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-15-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-15-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-15-02.json",
@@ -852,9 +854,9 @@ crate::macros::define_csaf_test!(
     "optional/csaf-rs_csaf-csaf_2_0-6-2-15-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_16, ValidatorForTest6_2_16, id : "6.2.16", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_16, ValidatorForTest6_2_16, ExpectedResults_6_2_16, id : "6.2.16", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-16-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-16-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-16-02.json",
@@ -863,27 +865,27 @@ crate::macros::define_csaf_test!(
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-16-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_17, ValidatorForTest6_2_17, id : "6.2.17", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_17, ValidatorForTest6_2_17, ExpectedResults_6_2_17, id : "6.2.17", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-11.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_18, ValidatorForTest6_2_18, id : "6.2.18", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_18, ValidatorForTest6_2_18, ExpectedResults_6_2_18, id : "6.2.18", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-18-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-18-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-18-11.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-18-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_19, ValidatorForTest6_2_19, id : "6.2.19", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_19, ValidatorForTest6_2_19, ExpectedResults_6_2_19, id : "6.2.19", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-19-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-19-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-19-02.json",
@@ -912,16 +914,16 @@ crate::macros::define_csaf_test!(
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-19-17.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_20, ValidatorForTest6_2_20, id : "6.2.20", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_2_20, ValidatorForTest6_2_20, ExpectedResults_6_2_20, id : "6.2.20", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-20-01.json",
     "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-20-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_1, ValidatorForTest6_3_1, id : "6.3.1", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_1, ValidatorForTest6_3_1, ExpectedResults_6_3_1, id : "6.3.1", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-01-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-01-02.json",
@@ -932,9 +934,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-01-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_2, ValidatorForTest6_3_2, id : "6.3.2", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_2, ValidatorForTest6_3_2, ExpectedResults_6_3_2, id : "6.3.2", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-02-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-02-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-02-02.json",
@@ -945,9 +947,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-02-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_3, ValidatorForTest6_3_3, id : "6.3.3", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_3, ValidatorForTest6_3_3, ExpectedResults_6_3_3, id : "6.3.3", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-02.json",
@@ -958,9 +960,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_4, ValidatorForTest6_3_4, id : "6.3.4", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_4, ValidatorForTest6_3_4, ExpectedResults_6_3_4, id : "6.3.4", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-04-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-04-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-04-02.json",
@@ -971,16 +973,16 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-04-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_5, ValidatorForTest6_3_5, id : "6.3.5", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_5, ValidatorForTest6_3_5, ExpectedResults_6_3_5, id : "6.3.5", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-05-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-05-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_6, ValidatorForTest6_3_6, id : "6.3.6", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_6, ValidatorForTest6_3_6, ExpectedResults_6_3_6, id : "6.3.6", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-06-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-06-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-06-02.json",
@@ -989,18 +991,18 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-06-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_7, ValidatorForTest6_3_7, id : "6.3.7", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_7, ValidatorForTest6_3_7, ExpectedResults_6_3_7, id : "6.3.7", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-07-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-07-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-07-11.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-07-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_8, ValidatorForTest6_3_8, id : "6.3.8", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_8, ValidatorForTest6_3_8, ExpectedResults_6_3_8, id : "6.3.8", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-08-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-08-02.json",
@@ -1011,9 +1013,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-08-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_9, ValidatorForTest6_3_9, id : "6.3.9", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_9, ValidatorForTest6_3_9, ExpectedResults_6_3_9, id : "6.3.9", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-09-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-09-02.json",
@@ -1042,18 +1044,18 @@ crate::macros::define_csaf_test!(
     "informative/csaf-rs_csaf-csaf_2_0-6-3-09-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_10, ValidatorForTest6_3_10, id : "6.3.10", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_10, ValidatorForTest6_3_10, ExpectedResults_6_3_10, id : "6.3.10", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-11.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_11, ValidatorForTest6_3_11, id : "6.3.11", doc_type : crate
-    ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0", cases :
-    [(case_01, "01",
+    Test6_3_11, ValidatorForTest6_3_11, ExpectedResults_6_3_11, id : "6.3.11", doc_type :
+    crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-11-01.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-11-01.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-11-11.json",

--- a/csaf-rs/src/csaf2_0/validation.rs
+++ b/csaf-rs/src/csaf2_0/validation.rs
@@ -2,41 +2,31 @@ use crate::csaf::raw::{RawDocument, RawValidatable};
 use crate::csaf2_0::testcases::*;
 use crate::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework;
 use crate::test_validation::TestValidator;
-use crate::validation::{TestResult, TestResultStatus, Validatable};
+use crate::validation::{TestFinding, TestResult, TestResultStatus, Validatable, ValidationError};
 use crate::validations::test_schema::validate_schema_csaf_2_0;
 
-enum Severity {
-    Error,
-    Warning,
-    Info,
-}
-
-fn to_test_result(
-    test_id: &str,
-    severity: Severity,
-    result: Option<Result<(), Vec<crate::validation::ValidationError>>>,
-) -> TestResult {
+fn to_test_result(test_id: &str, result: Option<Result<(), Vec<crate::validation::TestFinding>>>) -> TestResult {
     TestResult {
         test_id: test_id.to_string(),
         status: match result {
             None => TestResultStatus::NotFound,
             Some(Ok(())) => TestResultStatus::Success,
-            Some(Err(data)) => match severity {
-                Severity::Error => TestResultStatus::Failure {
-                    errors: data,
-                    warnings: vec![],
-                    infos: vec![],
-                },
-                Severity::Warning => TestResultStatus::Failure {
-                    errors: vec![],
-                    warnings: data,
-                    infos: vec![],
-                },
-                Severity::Info => TestResultStatus::Failure {
-                    errors: vec![],
-                    warnings: vec![],
-                    infos: data,
-                },
+            Some(Err(data)) => TestResultStatus::Failure {
+                errors: data
+                    .iter()
+                    .filter(|f| matches!(f, TestFinding::Error(_)))
+                    .map(ValidationError::from)
+                    .collect(),
+                warnings: data
+                    .iter()
+                    .filter(|f| matches!(f, TestFinding::Warning(_)))
+                    .map(ValidationError::from)
+                    .collect(),
+                infos: data
+                    .iter()
+                    .filter(|f| matches!(f, TestFinding::Information(_)))
+                    .map(ValidationError::from)
+                    .collect(),
             },
         },
     }
@@ -63,7 +53,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
     fn run_test(&self, test_id: &str) -> TestResult {
         let mandatory_result = to_test_result(
             test_id,
-            Severity::Error,
             match test_id {
                 // mandatory tests
                 "6.1.1" => Some(ValidatorForTest6_1_1.validate(self)),
@@ -118,7 +107,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 
         let recommended_result = to_test_result(
             test_id,
-            Severity::Warning,
             match test_id {
                 // recommended tests
                 "6.2.1" => Some(ValidatorForTest6_2_1.validate(self)),
@@ -162,7 +150,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 
         to_test_result(
             test_id,
-            Severity::Info,
             match test_id {
                 // informative tests
                 "6.3.1" => Some(ValidatorForTest6_3_1.validate(self)),
@@ -186,12 +173,11 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 impl RawValidatable for RawDocument<CommonSecurityAdvisoryFramework> {
     fn run_raw_test(&self, test_id: &str) -> TestResult {
         if test_id == "schema" {
-            return to_test_result(test_id, Severity::Error, Some(validate_schema_csaf_2_0(self)));
+            return to_test_result(test_id, Some(validate_schema_csaf_2_0(self)));
         }
 
         to_test_result(
             test_id,
-            Severity::Warning,
             match test_id {
                 "6.2.13" => Some(ValidatorForTest6_2_13.validate(self)),
                 "6.2.20" => Some(ValidatorForTest6_2_20.validate(self)),

--- a/csaf-rs/src/csaf2_0/validation.rs
+++ b/csaf-rs/src/csaf2_0/validation.rs
@@ -51,7 +51,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
     }
 
     fn run_test(&self, test_id: &str) -> TestResult {
-        let mandatory_result = to_test_result(
+        to_test_result(
             test_id,
             match test_id {
                 // mandatory tests
@@ -98,17 +98,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.1.31" => Some(ValidatorForTest6_1_31.validate(self)),
                 "6.1.32" => Some(ValidatorForTest6_1_32.validate(self)),
                 "6.1.33" => Some(ValidatorForTest6_1_33.validate(self)),
-                _ => None,
-            },
-        );
-        if TestResultStatus::NotFound != mandatory_result.status {
-            return mandatory_result;
-        }
-
-        let recommended_result = to_test_result(
-            test_id,
-            match test_id {
-                // recommended tests
+                // optional
                 "6.2.1" => Some(ValidatorForTest6_2_1.validate(self)),
                 "6.2.2" => Some(ValidatorForTest6_2_2.validate(self)),
                 "6.2.3" => Some(ValidatorForTest6_2_3.validate(self)),
@@ -141,16 +131,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                         status: TestResultStatus::Skipped,
                     };
                 },
-                _ => None,
-            },
-        );
-        if TestResultStatus::NotFound != recommended_result.status {
-            return recommended_result;
-        }
-
-        to_test_result(
-            test_id,
-            match test_id {
                 // informative tests
                 "6.3.1" => Some(ValidatorForTest6_3_1.validate(self)),
                 "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
@@ -163,7 +143,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.3.9" => Some(ValidatorForTest6_3_9.validate(self)),
                 "6.3.10" => Some(ValidatorForTest6_3_10.validate(self)),
                 "6.3.11" => Some(ValidatorForTest6_3_11.validate(self)),
-                // invalid tests
                 _ => None,
             },
         )
@@ -172,13 +151,10 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 
 impl RawValidatable for RawDocument<CommonSecurityAdvisoryFramework> {
     fn run_raw_test(&self, test_id: &str) -> TestResult {
-        if test_id == "schema" {
-            return to_test_result(test_id, Some(validate_schema_csaf_2_0(self)));
-        }
-
         to_test_result(
             test_id,
             match test_id {
+                "schema" => Some(validate_schema_csaf_2_0(self)),
                 "6.2.13" => Some(ValidatorForTest6_2_13.validate(self)),
                 "6.2.20" => Some(ValidatorForTest6_2_20.validate(self)),
                 _ => None,

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -6,9 +6,9 @@
  * Re-generate with: cargo run --locked -p type-generator
  */
 crate::macros::define_csaf_test!(
-    Test6_1_1, ValidatorForTest6_1_1, id : "6.1.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_1, ValidatorForTest6_1_1, ExpectedResults_6_1_1, id : "6.1.1", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-02.json",
@@ -25,18 +25,18 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-01-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_2, ValidatorForTest6_1_2, id : "6.1.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_2, ValidatorForTest6_1_2, ExpectedResults_6_1_2, id : "6.1.2", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-02-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-02-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-02-s01.json",
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-02-s01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_3, ValidatorForTest6_1_3, id : "6.1.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_3, ValidatorForTest6_1_3, ExpectedResults_6_1_3, id : "6.1.3", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-03-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-03-02.json",
@@ -51,9 +51,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-03-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_4, ValidatorForTest6_1_4, id : "6.1.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_4, ValidatorForTest6_1_4, ExpectedResults_6_1_4, id : "6.1.4", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-02.json",
@@ -68,9 +68,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-04-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_5, ValidatorForTest6_1_5, id : "6.1.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_5, ValidatorForTest6_1_5, ExpectedResults_6_1_5, id : "6.1.5", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-05-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-05-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-05-s01.json",
@@ -79,9 +79,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-05-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_6, ValidatorForTest6_1_6, id : "6.1.6", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_6, ValidatorForTest6_1_6, ExpectedResults_6_1_6, id : "6.1.6", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-02.json",
@@ -114,9 +114,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-06-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_7, ValidatorForTest6_1_7, id : "6.1.7", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_7, ValidatorForTest6_1_7, ExpectedResults_6_1_7, id : "6.1.7", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-02.json",
@@ -147,9 +147,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-07-18.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_8, ValidatorForTest6_1_8, id : "6.1.8", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_8, ValidatorForTest6_1_8, ExpectedResults_6_1_8, id : "6.1.8", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-02.json",
@@ -178,9 +178,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-08-17.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_9, ValidatorForTest6_1_9, id : "6.1.9", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_9, ValidatorForTest6_1_9, ExpectedResults_6_1_9, id : "6.1.9", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-02.json",
@@ -205,9 +205,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-09-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_10, ValidatorForTest6_1_10, id : "6.1.10", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_10, ValidatorForTest6_1_10, ExpectedResults_6_1_10, id : "6.1.10", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-02.json",
@@ -226,9 +226,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-10-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_11, ValidatorForTest6_1_11, id : "6.1.11", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_11, ValidatorForTest6_1_11, ExpectedResults_6_1_11, id : "6.1.11", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-11-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-11-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-11-02.json",
@@ -259,9 +259,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-11-18.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_12, ValidatorForTest6_1_12, id : "6.1.12", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_12, ValidatorForTest6_1_12, ExpectedResults_6_1_12, id : "6.1.12", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-12-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-12-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-12-s01.json",
@@ -276,9 +276,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-12-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_13, ValidatorForTest6_1_13, id : "6.1.13", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_13, ValidatorForTest6_1_13, ExpectedResults_6_1_13, id : "6.1.13", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-13-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-13-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-13-02.json",
@@ -289,9 +289,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-13-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_14, ValidatorForTest6_1_14, id : "6.1.14", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_14, ValidatorForTest6_1_14, ExpectedResults_6_1_14, id : "6.1.14", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-14-02.json",
@@ -340,9 +340,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-14-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_15, ValidatorForTest6_1_15, id : "6.1.15", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_15, ValidatorForTest6_1_15, ExpectedResults_6_1_15, id : "6.1.15", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-15-02.json",
@@ -355,9 +355,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-15-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_16, ValidatorForTest6_1_16, id : "6.1.16", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_16, ValidatorForTest6_1_16, ExpectedResults_6_1_16, id : "6.1.16", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-02.json",
@@ -400,9 +400,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-16-32.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_17, ValidatorForTest6_1_17, id : "6.1.17", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_17, ValidatorForTest6_1_17, ExpectedResults_6_1_17, id : "6.1.17", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-17-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-17-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-17-s01.json",
@@ -427,9 +427,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-17-s15.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_18, ValidatorForTest6_1_18, id : "6.1.18", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_18, ValidatorForTest6_1_18, ExpectedResults_6_1_18, id : "6.1.18", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-18-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-18-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-18-s01.json",
@@ -438,18 +438,18 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-18-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_19, ValidatorForTest6_1_19, id : "6.1.19", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_19, ValidatorForTest6_1_19, ExpectedResults_6_1_19, id : "6.1.19", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-02.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-19-02.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_20, ValidatorForTest6_1_20, id : "6.1.20", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_20, ValidatorForTest6_1_20, ExpectedResults_6_1_20, id : "6.1.20", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-20-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-20-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-20-s01.json",
@@ -458,9 +458,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-20-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_21, ValidatorForTest6_1_21, id : "6.1.21", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_21, ValidatorForTest6_1_21, ExpectedResults_6_1_21, id : "6.1.21", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-21-02.json",
@@ -501,9 +501,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-21-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_22, ValidatorForTest6_1_22, id : "6.1.22", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_22, ValidatorForTest6_1_22, ExpectedResults_6_1_22, id : "6.1.22", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-22-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-22-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-22-s01.json",
@@ -514,9 +514,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-22-s03.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_23, ValidatorForTest6_1_23, id : "6.1.23", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_23, ValidatorForTest6_1_23, ExpectedResults_6_1_23, id : "6.1.23", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-23-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-23-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-23-s01.json",
@@ -529,9 +529,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-23-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_24, ValidatorForTest6_1_24, id : "6.1.24", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_24, ValidatorForTest6_1_24, ExpectedResults_6_1_24, id : "6.1.24", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-24-02.json",
@@ -556,9 +556,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-24-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_25, ValidatorForTest6_1_25, id : "6.1.25", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_25, ValidatorForTest6_1_25, ExpectedResults_6_1_25, id : "6.1.25", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-25-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-25-s01.json",
@@ -575,9 +575,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-25-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_26, ValidatorForTest6_1_26, id : "6.1.26", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_26, ValidatorForTest6_1_26, ExpectedResults_6_1_26, id : "6.1.26", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-26-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-26-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-26-02.json",
@@ -604,23 +604,23 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-26-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_1, ValidatorForTest6_1_27_1, id : "6.1.27.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_1, ValidatorForTest6_1_27_1, ExpectedResults_6_1_27_1, id : "6.1.27.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-01-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-01-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_2, ValidatorForTest6_1_27_2, id : "6.1.27.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_2, ValidatorForTest6_1_27_2, ExpectedResults_6_1_27_2, id : "6.1.27.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-02-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-02-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_3, ValidatorForTest6_1_27_3, id : "6.1.27.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_3, ValidatorForTest6_1_27_3, ExpectedResults_6_1_27_3, id : "6.1.27.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-03-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-03-02.json",
@@ -635,9 +635,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-03-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_4, ValidatorForTest6_1_27_4, id : "6.1.27.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_4, ValidatorForTest6_1_27_4, ExpectedResults_6_1_27_4, id : "6.1.27.4",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-04-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-04-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-04-02.json",
@@ -646,9 +646,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-04-03.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_5, ValidatorForTest6_1_27_5, id : "6.1.27.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_5, ValidatorForTest6_1_27_5, ExpectedResults_6_1_27_5, id : "6.1.27.5",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-02.json",
@@ -657,9 +657,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-05-03.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_6, ValidatorForTest6_1_27_6, id : "6.1.27.6", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_6, ValidatorForTest6_1_27_6, ExpectedResults_6_1_27_6, id : "6.1.27.6",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-06-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-06-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-06-02.json",
@@ -668,18 +668,18 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-06-03.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_7, ValidatorForTest6_1_27_7, id : "6.1.27.7", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_7, ValidatorForTest6_1_27_7, ExpectedResults_6_1_27_7, id : "6.1.27.7",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-07-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-07-01.json"), (case_s11, "s11",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-07-s11.json",
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-07-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_8, ValidatorForTest6_1_27_8, id : "6.1.27.8", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_8, ValidatorForTest6_1_27_8, ExpectedResults_6_1_27_8, id : "6.1.27.8",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-08-02.json",
@@ -692,9 +692,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-08-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_9, ValidatorForTest6_1_27_9, id : "6.1.27.9", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_27_9, ValidatorForTest6_1_27_9, ExpectedResults_6_1_27_9, id : "6.1.27.9",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-02.json",
@@ -723,7 +723,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-09-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_10, ValidatorForTest6_1_27_10, id : "6.1.27.10", doc_type : crate
+    Test6_1_27_10, ValidatorForTest6_1_27_10, ExpectedResults_6_1_27_10, id :
+    "6.1.27.10", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-10-01.json",
@@ -738,7 +739,8 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_11, ValidatorForTest6_1_27_11, id : "6.1.27.11", doc_type : crate
+    Test6_1_27_11, ValidatorForTest6_1_27_11, ExpectedResults_6_1_27_11, id :
+    "6.1.27.11", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-11-01.json",
@@ -753,7 +755,8 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-11-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_12, ValidatorForTest6_1_27_12, id : "6.1.27.12", doc_type : crate
+    Test6_1_27_12, ValidatorForTest6_1_27_12, ExpectedResults_6_1_27_12, id :
+    "6.1.27.12", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-12-01.json",
@@ -768,7 +771,8 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-12-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_13, ValidatorForTest6_1_27_13, id : "6.1.27.13", doc_type : crate
+    Test6_1_27_13, ValidatorForTest6_1_27_13, ExpectedResults_6_1_27_13, id :
+    "6.1.27.13", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-13-01.json",
@@ -793,7 +797,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-13-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_14, ValidatorForTest6_1_27_14, id : "6.1.27.14", doc_type : crate
+    Test6_1_27_14, ValidatorForTest6_1_27_14, ExpectedResults_6_1_27_14, id :
+    "6.1.27.14", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-14-01.json",
@@ -808,7 +813,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-14-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_15, ValidatorForTest6_1_27_15, id : "6.1.27.15", doc_type : crate
+    Test6_1_27_15, ValidatorForTest6_1_27_15, ExpectedResults_6_1_27_15, id :
+    "6.1.27.15", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-15-01.json",
@@ -821,7 +827,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-15-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_16, ValidatorForTest6_1_27_16, id : "6.1.27.16", doc_type : crate
+    Test6_1_27_16, ValidatorForTest6_1_27_16, ExpectedResults_6_1_27_16, id :
+    "6.1.27.16", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-16-01.json",
@@ -838,7 +845,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-16-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_17, ValidatorForTest6_1_27_17, id : "6.1.27.17", doc_type : crate
+    Test6_1_27_17, ValidatorForTest6_1_27_17, ExpectedResults_6_1_27_17, id :
+    "6.1.27.17", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-17-01.json",
@@ -863,7 +871,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-17-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_18, ValidatorForTest6_1_27_18, id : "6.1.27.18", doc_type : crate
+    Test6_1_27_18, ValidatorForTest6_1_27_18, ExpectedResults_6_1_27_18, id :
+    "6.1.27.18", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-18-01.json",
@@ -888,7 +897,8 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-18-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_27_19, ValidatorForTest6_1_27_19, id : "6.1.27.19", doc_type : crate
+    Test6_1_27_19, ValidatorForTest6_1_27_19, ExpectedResults_6_1_27_19, id :
+    "6.1.27.19", doc_type : crate
     ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
     [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-27-19-01.json",
@@ -909,9 +919,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-19-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_28, ValidatorForTest6_1_28, id : "6.1.28", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_28, ValidatorForTest6_1_28, ExpectedResults_6_1_28, id : "6.1.28", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-28-s01.json",
@@ -920,9 +930,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-28-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_29, ValidatorForTest6_1_29, id : "6.1.29", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_29, ValidatorForTest6_1_29, ExpectedResults_6_1_29, id : "6.1.29", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-29-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-29-s01.json",
@@ -937,9 +947,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-29-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_30, ValidatorForTest6_1_30, id : "6.1.30", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_30, ValidatorForTest6_1_30, ExpectedResults_6_1_30, id : "6.1.30", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-30-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-30-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-30-s01.json",
@@ -952,9 +962,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-30-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_31, ValidatorForTest6_1_31, id : "6.1.31", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_31, ValidatorForTest6_1_31, ExpectedResults_6_1_31, id : "6.1.31", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-31-02.json",
@@ -991,9 +1001,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-31-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_32, ValidatorForTest6_1_32, id : "6.1.32", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_32, ValidatorForTest6_1_32, ExpectedResults_6_1_32, id : "6.1.32", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-32-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-32-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-32-s01.json",
@@ -1008,18 +1018,18 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-32-s13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_33, ValidatorForTest6_1_33, id : "6.1.33", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_33, ValidatorForTest6_1_33, ExpectedResults_6_1_33, id : "6.1.33", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-11.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-33-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_34, ValidatorForTest6_1_34, id : "6.1.34", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_34, ValidatorForTest6_1_34, ExpectedResults_6_1_34, id : "6.1.34", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-34-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-34-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-34-02.json",
@@ -1030,9 +1040,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-34-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_35, ValidatorForTest6_1_35, id : "6.1.35", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_35, ValidatorForTest6_1_35, ExpectedResults_6_1_35, id : "6.1.35", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-35-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-35-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-35-02.json",
@@ -1055,9 +1065,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-35-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_36, ValidatorForTest6_1_36, id : "6.1.36", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_36, ValidatorForTest6_1_36, ExpectedResults_6_1_36, id : "6.1.36", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-36-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-36-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-36-02.json",
@@ -1076,9 +1086,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-36-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_37, ValidatorForTest6_1_37, id : "6.1.37", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_37, ValidatorForTest6_1_37, ExpectedResults_6_1_37, id : "6.1.37", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-02.json",
@@ -1113,9 +1123,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-37-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_38, ValidatorForTest6_1_38, id : "6.1.38", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_38, ValidatorForTest6_1_38, ExpectedResults_6_1_38, id : "6.1.38", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-38-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-38-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-38-02.json",
@@ -1136,9 +1146,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-38-15.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_39, ValidatorForTest6_1_39, id : "6.1.39", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_39, ValidatorForTest6_1_39, ExpectedResults_6_1_39, id : "6.1.39", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-39-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-39-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-39-02.json",
@@ -1149,9 +1159,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-39-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_40, ValidatorForTest6_1_40, id : "6.1.40", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_40, ValidatorForTest6_1_40, ExpectedResults_6_1_40, id : "6.1.40", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-40-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-40-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-40-02.json",
@@ -1166,9 +1176,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-40-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_41, ValidatorForTest6_1_41, id : "6.1.41", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_41, ValidatorForTest6_1_41, ExpectedResults_6_1_41, id : "6.1.41", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-41-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-41-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-41-02.json",
@@ -1183,9 +1193,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-41-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_42, ValidatorForTest6_1_42, id : "6.1.42", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_42, ValidatorForTest6_1_42, ExpectedResults_6_1_42, id : "6.1.42", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-42-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-42-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-42-02.json",
@@ -1198,9 +1208,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-42-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_43, ValidatorForTest6_1_43, id : "6.1.43", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_43, ValidatorForTest6_1_43, ExpectedResults_6_1_43, id : "6.1.43", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-43-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-43-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-43-02.json",
@@ -1213,9 +1223,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-43-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_44, ValidatorForTest6_1_44, id : "6.1.44", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_44, ValidatorForTest6_1_44, ExpectedResults_6_1_44, id : "6.1.44", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-44-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-44-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-44-02.json",
@@ -1228,9 +1238,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-44-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_45, ValidatorForTest6_1_45, id : "6.1.45", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_45, ValidatorForTest6_1_45, ExpectedResults_6_1_45, id : "6.1.45", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-45-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-45-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-45-02.json",
@@ -1247,9 +1257,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-45-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_46, ValidatorForTest6_1_46, id : "6.1.46", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_46, ValidatorForTest6_1_46, ExpectedResults_6_1_46, id : "6.1.46", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-46-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-46-02.json",
@@ -1260,9 +1270,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-46-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_47, ValidatorForTest6_1_47, id : "6.1.47", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_47, ValidatorForTest6_1_47, ExpectedResults_6_1_47, id : "6.1.47", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-47-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-47-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-47-02.json",
@@ -1287,9 +1297,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-47-15.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_48, ValidatorForTest6_1_48, id : "6.1.48", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_48, ValidatorForTest6_1_48, ExpectedResults_6_1_48, id : "6.1.48", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-02.json",
@@ -1332,9 +1342,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-48-31.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_49, ValidatorForTest6_1_49, id : "6.1.49", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_49, ValidatorForTest6_1_49, ExpectedResults_6_1_49, id : "6.1.49", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-49-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-49-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-49-02.json",
@@ -1349,9 +1359,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-49-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_50, ValidatorForTest6_1_50, id : "6.1.50", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_50, ValidatorForTest6_1_50, ExpectedResults_6_1_50, id : "6.1.50", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-50-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-50-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-50-02.json",
@@ -1378,9 +1388,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-50-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_51, ValidatorForTest6_1_51, id : "6.1.51", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_51, ValidatorForTest6_1_51, ExpectedResults_6_1_51, id : "6.1.51", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-51-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-51-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-51-02.json",
@@ -1395,9 +1405,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-51-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_52, ValidatorForTest6_1_52, id : "6.1.52", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_52, ValidatorForTest6_1_52, ExpectedResults_6_1_52, id : "6.1.52", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-52-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-52-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-52-02.json",
@@ -1408,9 +1418,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-52-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_53, ValidatorForTest6_1_53, id : "6.1.53", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_53, ValidatorForTest6_1_53, ExpectedResults_6_1_53, id : "6.1.53", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-53-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-53-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-53-02.json",
@@ -1421,9 +1431,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-53-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_54, ValidatorForTest6_1_54, id : "6.1.54", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_54, ValidatorForTest6_1_54, ExpectedResults_6_1_54, id : "6.1.54", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-54-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-54-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-54-02.json",
@@ -1450,9 +1460,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-54-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_55, ValidatorForTest6_1_55, id : "6.1.55", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_55, ValidatorForTest6_1_55, ExpectedResults_6_1_55, id : "6.1.55", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-55-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-55-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-55-02.json",
@@ -1469,9 +1479,9 @@ crate::macros::define_csaf_test!(
     "mandatory/csaf-rs_csaf-csaf_2_1-6-1-55-s12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_56, ValidatorForTest6_1_56, id : "6.1.56", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_56, ValidatorForTest6_1_56, ExpectedResults_6_1_56, id : "6.1.56", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-56-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-56-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-56-02.json",
@@ -1500,9 +1510,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-56-18.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_57, ValidatorForTest6_1_57, id : "6.1.57", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_57, ValidatorForTest6_1_57, ExpectedResults_6_1_57, id : "6.1.57", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-57-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-57-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-57-02.json",
@@ -1517,18 +1527,18 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-57-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_58, ValidatorForTest6_1_58, id : "6.1.58", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_58, ValidatorForTest6_1_58, ExpectedResults_6_1_58, id : "6.1.58", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-58-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-58-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-58-11.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-58-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_59, ValidatorForTest6_1_59, id : "6.1.59", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_59, ValidatorForTest6_1_59, ExpectedResults_6_1_59, id : "6.1.59", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-59-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-59-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-59-02.json",
@@ -1541,9 +1551,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-59-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_60_1, ValidatorForTest6_1_60_1, id : "6.1.60.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_60_1, ValidatorForTest6_1_60_1, ExpectedResults_6_1_60_1, id : "6.1.60.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-01-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-01-02.json",
@@ -1554,9 +1564,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-01-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_60_2, ValidatorForTest6_1_60_2, id : "6.1.60.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_60_2, ValidatorForTest6_1_60_2, ExpectedResults_6_1_60_2, id : "6.1.60.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-02-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-02-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-02-02.json",
@@ -1567,9 +1577,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-02-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_60_3, ValidatorForTest6_1_60_3, id : "6.1.60.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_60_3, ValidatorForTest6_1_60_3, ExpectedResults_6_1_60_3, id : "6.1.60.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-03-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-03-02.json",
@@ -1580,9 +1590,9 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-60-03-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_1_61, ValidatorForTest6_1_61, id : "6.1.61", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_1_61, ValidatorForTest6_1_61, ExpectedResults_6_1_61, id : "6.1.61", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-61-01.json",
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-61-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-61-02.json",
@@ -1595,39 +1605,39 @@ crate::macros::define_csaf_test!(
     "mandatory/oasis_csaf_tc-csaf_2_1-2024-6-1-61-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_1, ValidatorForTest6_2_1, id : "6.2.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_1, ValidatorForTest6_2_1, ExpectedResults_6_2_1, id : "6.2.1", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-01-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-01-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-01-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-01-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_2, ValidatorForTest6_2_2, id : "6.2.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_2, ValidatorForTest6_2_2, ExpectedResults_6_2_2, id : "6.2.2", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-02-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-02-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_3, ValidatorForTest6_2_3, id : "6.2.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_3, ValidatorForTest6_2_3, ExpectedResults_6_2_3, id : "6.2.3", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-03-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-03-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_4, ValidatorForTest6_2_4, id : "6.2.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_4, ValidatorForTest6_2_4, ExpectedResults_6_2_4, id : "6.2.4", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_5, ValidatorForTest6_2_5, id : "6.2.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_5, ValidatorForTest6_2_5, ExpectedResults_6_2_5, id : "6.2.5", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-05-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-05-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-05-02.json",
@@ -1638,9 +1648,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-05-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_6, ValidatorForTest6_2_6, id : "6.2.6", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_6, ValidatorForTest6_2_6, ExpectedResults_6_2_6, id : "6.2.6", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-06-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-06-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-06-02.json",
@@ -1655,16 +1665,16 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-06-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_7, ValidatorForTest6_2_7, id : "6.2.7", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_7, ValidatorForTest6_2_7, ExpectedResults_6_2_7, id : "6.2.7", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-07-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-07-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_8, ValidatorForTest6_2_8, id : "6.2.8", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_8, ValidatorForTest6_2_8, ExpectedResults_6_2_8, id : "6.2.8", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-08-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-08-02.json",
@@ -1673,9 +1683,9 @@ crate::macros::define_csaf_test!(
     "recommended/csaf-rs_csaf-csaf_2_1-6-2-08-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_9, ValidatorForTest6_2_9, id : "6.2.9", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_9, ValidatorForTest6_2_9, ExpectedResults_6_2_9, id : "6.2.9", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-09-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-09-02.json",
@@ -1684,9 +1694,9 @@ crate::macros::define_csaf_test!(
     "recommended/csaf-rs_csaf-csaf_2_1-6-2-09-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_11, ValidatorForTest6_2_11, id : "6.2.11", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_11, ValidatorForTest6_2_11, ExpectedResults_6_2_11, id : "6.2.11", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-11-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-11-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-11-02.json",
@@ -1701,23 +1711,23 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-11-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_12, ValidatorForTest6_2_12, id : "6.2.12", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_12, ValidatorForTest6_2_12, ExpectedResults_6_2_12, id : "6.2.12", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_13, ValidatorForTest6_2_13, id : "6.2.13", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_13, ValidatorForTest6_2_13, ExpectedResults_6_2_13, id : "6.2.13", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-13-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-13-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_14, ValidatorForTest6_2_14, id : "6.2.14", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_14, ValidatorForTest6_2_14, ExpectedResults_6_2_14, id : "6.2.14", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-14-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-14-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-14-02.json",
@@ -1744,9 +1754,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-14-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_15, ValidatorForTest6_2_15, id : "6.2.15", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_15, ValidatorForTest6_2_15, ExpectedResults_6_2_15, id : "6.2.15", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-15-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-15-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-15-02.json",
@@ -1761,9 +1771,9 @@ crate::macros::define_csaf_test!(
     "recommended/csaf-rs_csaf-csaf_2_1-6-2-15-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_16, ValidatorForTest6_2_16, id : "6.2.16", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_16, ValidatorForTest6_2_16, ExpectedResults_6_2_16, id : "6.2.16", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-16-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-16-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-16-02.json",
@@ -1772,27 +1782,27 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-16-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_17, ValidatorForTest6_2_17, id : "6.2.17", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_17, ValidatorForTest6_2_17, ExpectedResults_6_2_17, id : "6.2.17", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-17-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-17-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-17-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-17-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_18, ValidatorForTest6_2_18, id : "6.2.18", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_18, ValidatorForTest6_2_18, ExpectedResults_6_2_18, id : "6.2.18", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-18-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-18-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-18-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-18-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_19, ValidatorForTest6_2_19, id : "6.2.19", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_19, ValidatorForTest6_2_19, ExpectedResults_6_2_19, id : "6.2.19", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-19-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-19-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-19-02.json",
@@ -1829,9 +1839,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-19-19.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_20, ValidatorForTest6_2_20, id : "6.2.20", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_20, ValidatorForTest6_2_20, ExpectedResults_6_2_20, id : "6.2.20", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-02.json",
@@ -1842,9 +1852,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-20-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_21, ValidatorForTest6_2_21, id : "6.2.21", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_21, ValidatorForTest6_2_21, ExpectedResults_6_2_21, id : "6.2.21", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-21-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-21-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-21-02.json",
@@ -1863,9 +1873,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-21-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_22, ValidatorForTest6_2_22, id : "6.2.22", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_22, ValidatorForTest6_2_22, ExpectedResults_6_2_22, id : "6.2.22", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-22-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-22-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-22-02.json",
@@ -1880,9 +1890,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-22-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_23, ValidatorForTest6_2_23, id : "6.2.23", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_23, ValidatorForTest6_2_23, ExpectedResults_6_2_23, id : "6.2.23", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-23-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-23-02.json",
@@ -1897,9 +1907,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-23-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_24, ValidatorForTest6_2_24, id : "6.2.24", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_24, ValidatorForTest6_2_24, ExpectedResults_6_2_24, id : "6.2.24", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-24-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-24-02.json",
@@ -1918,9 +1928,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-24-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_25, ValidatorForTest6_2_25, id : "6.2.25", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_25, ValidatorForTest6_2_25, ExpectedResults_6_2_25, id : "6.2.25", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-25-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-25-02.json",
@@ -1939,9 +1949,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-25-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_26, ValidatorForTest6_2_26, id : "6.2.26", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_26, ValidatorForTest6_2_26, ExpectedResults_6_2_26, id : "6.2.26", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-26-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-26-02.json",
@@ -1956,9 +1966,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-26-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_27, ValidatorForTest6_2_27, id : "6.2.27", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_27, ValidatorForTest6_2_27, ExpectedResults_6_2_27, id : "6.2.27", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-27-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-27-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-27-02.json",
@@ -1973,9 +1983,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-27-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_28, ValidatorForTest6_2_28, id : "6.2.28", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_28, ValidatorForTest6_2_28, ExpectedResults_6_2_28, id : "6.2.28", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-28-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-28-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-28-11.json",
@@ -1984,9 +1994,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-28-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_29, ValidatorForTest6_2_29, id : "6.2.29", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_29, ValidatorForTest6_2_29, ExpectedResults_6_2_29, id : "6.2.29", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-29-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-29-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-29-11.json",
@@ -1995,9 +2005,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-29-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_30, ValidatorForTest6_2_30, id : "6.2.30", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_30, ValidatorForTest6_2_30, ExpectedResults_6_2_30, id : "6.2.30", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-30-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-30-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-30-11.json",
@@ -2006,9 +2016,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-30-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_31, ValidatorForTest6_2_31, id : "6.2.31", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_31, ValidatorForTest6_2_31, ExpectedResults_6_2_31, id : "6.2.31", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-31-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-31-01.json"), (case_s01, "s01",
     "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-31-s01.json",
@@ -2021,9 +2031,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-31-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_32, ValidatorForTest6_2_32, id : "6.2.32", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_32, ValidatorForTest6_2_32, ExpectedResults_6_2_32, id : "6.2.32", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-32-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-32-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-32-02.json",
@@ -2040,9 +2050,9 @@ crate::macros::define_csaf_test!(
     "recommended/csaf-rs_csaf-csaf_2_1-6-2-32-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_33, ValidatorForTest6_2_33, id : "6.2.33", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_33, ValidatorForTest6_2_33, ExpectedResults_6_2_33, id : "6.2.33", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-33-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-33-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-33-02.json",
@@ -2057,9 +2067,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-33-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_34, ValidatorForTest6_2_34, id : "6.2.34", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_34, ValidatorForTest6_2_34, ExpectedResults_6_2_34, id : "6.2.34", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-34-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-34-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-34-02.json",
@@ -2074,9 +2084,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-34-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_35, ValidatorForTest6_2_35, id : "6.2.35", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_35, ValidatorForTest6_2_35, ExpectedResults_6_2_35, id : "6.2.35", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-35-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-35-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-35-11.json",
@@ -2085,9 +2095,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-35-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_36, ValidatorForTest6_2_36, id : "6.2.36", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_36, ValidatorForTest6_2_36, ExpectedResults_6_2_36, id : "6.2.36", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-36-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-36-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-36-02.json",
@@ -2100,9 +2110,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-36-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_37, ValidatorForTest6_2_37, id : "6.2.37", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_37, ValidatorForTest6_2_37, ExpectedResults_6_2_37, id : "6.2.37", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-37-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-37-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-37-02.json",
@@ -2117,9 +2127,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-37-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_38, ValidatorForTest6_2_38, id : "6.2.38", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_38, ValidatorForTest6_2_38, ExpectedResults_6_2_38, id : "6.2.38", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-38-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-38-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-38-02.json",
@@ -2134,9 +2144,9 @@ crate::macros::define_csaf_test!(
     "recommended/csaf-rs_csaf-csaf_2_1-6-2-38-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_39_1, ValidatorForTest6_2_39_1, id : "6.2.39.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_39_1, ValidatorForTest6_2_39_1, ExpectedResults_6_2_39_1, id : "6.2.39.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-01-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-01-02.json",
@@ -2149,27 +2159,27 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-01-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_39_2, ValidatorForTest6_2_39_2, id : "6.2.39.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_39_2, ValidatorForTest6_2_39_2, ExpectedResults_6_2_39_2, id : "6.2.39.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-02-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-02-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-02-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-02-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_39_3, ValidatorForTest6_2_39_3, id : "6.2.39.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_39_3, ValidatorForTest6_2_39_3, ExpectedResults_6_2_39_3, id : "6.2.39.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-03-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-03-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-03-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-03-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_39_4, ValidatorForTest6_2_39_4, id : "6.2.39.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_39_4, ValidatorForTest6_2_39_4, ExpectedResults_6_2_39_4, id : "6.2.39.4",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-04-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-04-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-04-11.json",
@@ -2178,9 +2188,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-04-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_39_5, ValidatorForTest6_2_39_5, id : "6.2.39.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_39_5, ValidatorForTest6_2_39_5, ExpectedResults_6_2_39_5, id : "6.2.39.5",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-05-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-05-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-05-02.json",
@@ -2191,9 +2201,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-39-05-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_40, ValidatorForTest6_2_40, id : "6.2.40", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_40, ValidatorForTest6_2_40, ExpectedResults_6_2_40, id : "6.2.40", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-40-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-40-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-40-02.json",
@@ -2208,9 +2218,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-40-13.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_41, ValidatorForTest6_2_41, id : "6.2.41", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_41, ValidatorForTest6_2_41, ExpectedResults_6_2_41, id : "6.2.41", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-41-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-41-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-41-02.json",
@@ -2221,9 +2231,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-41-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_42, ValidatorForTest6_2_42, id : "6.2.42", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_42, ValidatorForTest6_2_42, ExpectedResults_6_2_42, id : "6.2.42", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-42-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-42-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-42-02.json",
@@ -2234,18 +2244,18 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-42-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_43, ValidatorForTest6_2_43, id : "6.2.43", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_43, ValidatorForTest6_2_43, ExpectedResults_6_2_43, id : "6.2.43", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-43-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-43-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-43-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-43-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_44, ValidatorForTest6_2_44, id : "6.2.44", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_44, ValidatorForTest6_2_44, ExpectedResults_6_2_44, id : "6.2.44", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-44-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-44-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-44-02.json",
@@ -2256,9 +2266,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-44-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_45, ValidatorForTest6_2_45, id : "6.2.45", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_45, ValidatorForTest6_2_45, ExpectedResults_6_2_45, id : "6.2.45", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-45-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-45-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-45-02.json",
@@ -2269,18 +2279,18 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-45-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_46, ValidatorForTest6_2_46, id : "6.2.46", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_46, ValidatorForTest6_2_46, ExpectedResults_6_2_46, id : "6.2.46", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-46-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-46-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-46-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-46-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_47, ValidatorForTest6_2_47, id : "6.2.47", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_47, ValidatorForTest6_2_47, ExpectedResults_6_2_47, id : "6.2.47", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-47-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-47-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-47-02.json",
@@ -2291,9 +2301,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-47-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_48, ValidatorForTest6_2_48, id : "6.2.48", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_48, ValidatorForTest6_2_48, ExpectedResults_6_2_48, id : "6.2.48", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-48-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-48-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-48-02.json",
@@ -2310,9 +2320,9 @@ crate::macros::define_csaf_test!(
     "recommended/csaf-rs_csaf-csaf_2_1-6-2-48-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_49, ValidatorForTest6_2_49, id : "6.2.49", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_49, ValidatorForTest6_2_49, ExpectedResults_6_2_49, id : "6.2.49", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-49-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-49-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-49-02.json",
@@ -2333,27 +2343,27 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-49-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_50_1, ValidatorForTest6_2_50_1, id : "6.2.50.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_50_1, ValidatorForTest6_2_50_1, ExpectedResults_6_2_50_1, id : "6.2.50.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-01-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-01-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-01-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-01-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_50_2, ValidatorForTest6_2_50_2, id : "6.2.50.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_50_2, ValidatorForTest6_2_50_2, ExpectedResults_6_2_50_2, id : "6.2.50.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-02-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-02-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-02-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-02-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_50_3, ValidatorForTest6_2_50_3, id : "6.2.50.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_50_3, ValidatorForTest6_2_50_3, ExpectedResults_6_2_50_3, id : "6.2.50.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-03-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-03-02.json",
@@ -2364,9 +2374,9 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-50-03-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_51, ValidatorForTest6_2_51, id : "6.2.51", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_51, ValidatorForTest6_2_51, ExpectedResults_6_2_51, id : "6.2.51", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-51-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-51-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-51-11.json",
@@ -2375,63 +2385,63 @@ crate::macros::define_csaf_test!(
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-51-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_52, ValidatorForTest6_2_52, id : "6.2.52", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_52, ValidatorForTest6_2_52, ExpectedResults_6_2_52, id : "6.2.52", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-52-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-52-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-52-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-52-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_53, ValidatorForTest6_2_53, id : "6.2.53", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_53, ValidatorForTest6_2_53, ExpectedResults_6_2_53, id : "6.2.53", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-53-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_54_1, ValidatorForTest6_2_54_1, id : "6.2.54.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_54_1, ValidatorForTest6_2_54_1, ExpectedResults_6_2_54_1, id : "6.2.54.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-01-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-01-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-01-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-01-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_54_2, ValidatorForTest6_2_54_2, id : "6.2.54.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_54_2, ValidatorForTest6_2_54_2, ExpectedResults_6_2_54_2, id : "6.2.54.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-02-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-02-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-02-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-02-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_54_3, ValidatorForTest6_2_54_3, id : "6.2.54.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_54_3, ValidatorForTest6_2_54_3, ExpectedResults_6_2_54_3, id : "6.2.54.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-03-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-03-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-03-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-03-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_2_54_4, ValidatorForTest6_2_54_4, id : "6.2.54.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_2_54_4, ValidatorForTest6_2_54_4, ExpectedResults_6_2_54_4, id : "6.2.54.4",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-04-01.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-04-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-04-11.json",
     "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-54-04-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_1, ValidatorForTest6_3_1, id : "6.3.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_1, ValidatorForTest6_3_1, ExpectedResults_6_3_1, id : "6.3.1", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-02.json",
@@ -2450,9 +2460,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-01-14.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_2, ValidatorForTest6_3_2, id : "6.3.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_2, ValidatorForTest6_3_2, ExpectedResults_6_3_2, id : "6.3.2", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-02.json",
@@ -2463,9 +2473,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-02-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_3, ValidatorForTest6_3_3, id : "6.3.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_3, ValidatorForTest6_3_3, ExpectedResults_6_3_3, id : "6.3.3", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-02.json",
@@ -2476,9 +2486,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_4, ValidatorForTest6_3_4, id : "6.3.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_4, ValidatorForTest6_3_4, ExpectedResults_6_3_4, id : "6.3.4", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-02.json",
@@ -2489,16 +2499,16 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-04-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_5, ValidatorForTest6_3_5, id : "6.3.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_5, ValidatorForTest6_3_5, ExpectedResults_6_3_5, id : "6.3.5", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_6, ValidatorForTest6_3_6, id : "6.3.6", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_6, ValidatorForTest6_3_6, ExpectedResults_6_3_6, id : "6.3.6", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-02.json",
@@ -2507,18 +2517,18 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-06-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_7, ValidatorForTest6_3_7, id : "6.3.7", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_7, ValidatorForTest6_3_7, ExpectedResults_6_3_7, id : "6.3.7", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-07-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_8, ValidatorForTest6_3_8, id : "6.3.8", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_8, ValidatorForTest6_3_8, ExpectedResults_6_3_8, id : "6.3.8", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-02.json",
@@ -2529,9 +2539,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-08-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_9, ValidatorForTest6_3_9, id : "6.3.9", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_9, ValidatorForTest6_3_9, ExpectedResults_6_3_9, id : "6.3.9", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-09-02.json",
@@ -2560,27 +2570,27 @@ crate::macros::define_csaf_test!(
     "informative/csaf-rs_csaf-csaf_2_1-6-3-09-s11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_10, ValidatorForTest6_3_10, id : "6.3.10", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_10, ValidatorForTest6_3_10, ExpectedResults_6_3_10, id : "6.3.10", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_11, ValidatorForTest6_3_11, id : "6.3.11", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_11, ValidatorForTest6_3_11, ExpectedResults_6_3_11, id : "6.3.11", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-11-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_12, ValidatorForTest6_3_12, id : "6.3.12", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_12, ValidatorForTest6_3_12, ExpectedResults_6_3_12, id : "6.3.12", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-02.json",
@@ -2607,27 +2617,27 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-12-16.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_13, ValidatorForTest6_3_13, id : "6.3.13", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_13, ValidatorForTest6_3_13, ExpectedResults_6_3_13, id : "6.3.13", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-13-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-13-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-13-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-13-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_14, ValidatorForTest6_3_14, id : "6.3.14", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_14, ValidatorForTest6_3_14, ExpectedResults_6_3_14, id : "6.3.14", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-14-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-14-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-14-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-14-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_15, ValidatorForTest6_3_15, id : "6.3.15", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_15, ValidatorForTest6_3_15, ExpectedResults_6_3_15, id : "6.3.15", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-15-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-15-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-15-02.json",
@@ -2636,54 +2646,54 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-15-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_16, ValidatorForTest6_3_16, id : "6.3.16", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_16, ValidatorForTest6_3_16, ExpectedResults_6_3_16, id : "6.3.16", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-16-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-16-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-16-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-16-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_17, ValidatorForTest6_3_17, id : "6.3.17", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_17, ValidatorForTest6_3_17, ExpectedResults_6_3_17, id : "6.3.17", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-17-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-17-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-17-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-17-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_18, ValidatorForTest6_3_18, id : "6.3.18", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_18, ValidatorForTest6_3_18, ExpectedResults_6_3_18, id : "6.3.18", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-18-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-18-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-18-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-18-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_19_1, ValidatorForTest6_3_19_1, id : "6.3.19.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_19_1, ValidatorForTest6_3_19_1, ExpectedResults_6_3_19_1, id : "6.3.19.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-01-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-01-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-01-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-01-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_19_2, ValidatorForTest6_3_19_2, id : "6.3.19.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_19_2, ValidatorForTest6_3_19_2, ExpectedResults_6_3_19_2, id : "6.3.19.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-02-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-02-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-02-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-02-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_19_3, ValidatorForTest6_3_19_3, id : "6.3.19.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_19_3, ValidatorForTest6_3_19_3, ExpectedResults_6_3_19_3, id : "6.3.19.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-03-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-03-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-03-02.json",
@@ -2694,9 +2704,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-03-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_19_4, ValidatorForTest6_3_19_4, id : "6.3.19.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_19_4, ValidatorForTest6_3_19_4, ExpectedResults_6_3_19_4, id : "6.3.19.4",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-02.json",
@@ -2707,9 +2717,9 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-04-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_19_5, ValidatorForTest6_3_19_5, id : "6.3.19.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_19_5, ValidatorForTest6_3_19_5, ExpectedResults_6_3_19_5, id : "6.3.19.5",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-02.json",
@@ -2720,18 +2730,18 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-19-05-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_20, ValidatorForTest6_3_20, id : "6.3.20", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_20, ValidatorForTest6_3_20, ExpectedResults_6_3_20, id : "6.3.20", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-20-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-20-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-20-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-20-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_1, ValidatorForTest6_3_21_1, id : "6.3.21.1", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_1, ValidatorForTest6_3_21_1, ExpectedResults_6_3_21_1, id : "6.3.21.1",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-01-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-01-01.json"), (case_02, "02",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-01-02.json",
@@ -2742,81 +2752,81 @@ crate::macros::define_csaf_test!(
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-01-12.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_2, ValidatorForTest6_3_21_2, id : "6.3.21.2", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_2, ValidatorForTest6_3_21_2, ExpectedResults_6_3_21_2, id : "6.3.21.2",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-02-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-02-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-02-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-02-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_3, ValidatorForTest6_3_21_3, id : "6.3.21.3", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_3, ValidatorForTest6_3_21_3, ExpectedResults_6_3_21_3, id : "6.3.21.3",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-03-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-03-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-03-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-03-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_4, ValidatorForTest6_3_21_4, id : "6.3.21.4", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_4, ValidatorForTest6_3_21_4, ExpectedResults_6_3_21_4, id : "6.3.21.4",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-04-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-04-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-04-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-04-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_5, ValidatorForTest6_3_21_5, id : "6.3.21.5", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_5, ValidatorForTest6_3_21_5, ExpectedResults_6_3_21_5, id : "6.3.21.5",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-05-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-05-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-05-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-05-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_6, ValidatorForTest6_3_21_6, id : "6.3.21.6", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_6, ValidatorForTest6_3_21_6, ExpectedResults_6_3_21_6, id : "6.3.21.6",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-06-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-06-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-06-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-06-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_7, ValidatorForTest6_3_21_7, id : "6.3.21.7", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_7, ValidatorForTest6_3_21_7, ExpectedResults_6_3_21_7, id : "6.3.21.7",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-07-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-07-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-07-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-07-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_8, ValidatorForTest6_3_21_8, id : "6.3.21.8", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_8, ValidatorForTest6_3_21_8, ExpectedResults_6_3_21_8, id : "6.3.21.8",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-08-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-08-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-08-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-08-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_21_9, ValidatorForTest6_3_21_9, id : "6.3.21.9", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_21_9, ValidatorForTest6_3_21_9, ExpectedResults_6_3_21_9, id : "6.3.21.9",
+    doc_type : crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version
+    : "V2_1", cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-09-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-09-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-09-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-21-09-11.json")]
 );
 crate::macros::define_csaf_test!(
-    Test6_3_22, ValidatorForTest6_3_22, id : "6.3.22", doc_type : crate
-    ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1", cases :
-    [(case_01, "01",
+    Test6_3_22, ValidatorForTest6_3_22, ExpectedResults_6_3_22, id : "6.3.22", doc_type :
+    crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
+    cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-22-01.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-22-01.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-22-11.json",

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -76,7 +76,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
     }
 
     fn run_test(&self, test_id: &str) -> TestResult {
-        let mandatory_result = to_test_result(
+        to_test_result(
             test_id,
             match test_id {
                 // mandatory tests
@@ -161,16 +161,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.1.60.2" => None, // Some(ValidatorForTest6_1_60_2.validate(self)),
                 "6.1.60.3" => None, // Some(ValidatorForTest6_1_60_3.validate(self)),
                 "6.1.61" => Some(ValidatorForTest6_1_61.validate(self)),
-                _ => None,
-            },
-        );
-        if TestResultStatus::NotFound != mandatory_result.status {
-            return mandatory_result;
-        }
-
-        let recommended_result = to_test_result(
-            test_id,
-            match test_id {
                 // recommended tests
                 "6.2.1" => Some(ValidatorForTest6_2_1.validate(self)),
                 "6.2.2" => Some(ValidatorForTest6_2_2.validate(self)),
@@ -241,16 +231,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.2.51" => None,   // Some(ValidatorForTest6_2_51.validate(self)),
                 "6.2.52" => Some(ValidatorForTest6_2_52.validate(self)),
                 "6.2.53" => Some(ValidatorForTest6_2_53.validate(self)),
-                _ => None,
-            },
-        );
-        if TestResultStatus::NotFound != recommended_result.status {
-            return recommended_result;
-        }
-
-        to_test_result(
-            test_id,
-            match test_id {
                 // informative tests
                 "6.3.1" => None, // Some(ValidatorForTest6_3_1.validate(self)),
                 "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
@@ -280,13 +260,10 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 
 impl RawValidatable for RawDocument<CommonSecurityAdvisoryFramework> {
     fn run_raw_test(&self, test_id: &str) -> TestResult {
-        if test_id == "schema" {
-            return to_test_result(test_id, Some(validate_schema_csaf_2_1(self)));
-        }
-
         to_test_result(
             test_id,
             match test_id {
+                "schema" => Some(validate_schema_csaf_2_1(self)),
                 "6.2.13" => Some(ValidatorForTest6_2_13.validate(self)),
                 "6.2.20" => Some(ValidatorForTest6_2_20.validate(self)),
                 _ => None,

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -2,40 +2,31 @@ use crate::csaf::raw::{RawDocument, RawValidatable};
 use crate::csaf2_1::testcases::*;
 use crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework;
 use crate::test_validation::TestValidator;
-use crate::validation::{TestResult, TestResultStatus, Validatable};
+use crate::validation::{TestFinding, TestResult, TestResultStatus, Validatable, ValidationError};
 use crate::validations::test_schema::validate_schema_csaf_2_1;
-enum Severity {
-    Error,
-    Warning,
-    Info,
-}
 
-fn to_test_result(
-    test_id: &str,
-    severity: Severity,
-    result: Option<Result<(), Vec<crate::validation::ValidationError>>>,
-) -> TestResult {
+fn to_test_result(test_id: &str, result: Option<Result<(), Vec<crate::validation::TestFinding>>>) -> TestResult {
     TestResult {
         test_id: test_id.to_string(),
         status: match result {
             None => TestResultStatus::NotFound,
             Some(Ok(())) => TestResultStatus::Success,
-            Some(Err(data)) => match severity {
-                Severity::Error => TestResultStatus::Failure {
-                    errors: data,
-                    warnings: vec![],
-                    infos: vec![],
-                },
-                Severity::Warning => TestResultStatus::Failure {
-                    errors: vec![],
-                    warnings: data,
-                    infos: vec![],
-                },
-                Severity::Info => TestResultStatus::Failure {
-                    errors: vec![],
-                    warnings: vec![],
-                    infos: data,
-                },
+            Some(Err(data)) => TestResultStatus::Failure {
+                errors: data
+                    .iter()
+                    .filter(|f| matches!(f, TestFinding::Error(_)))
+                    .map(ValidationError::from)
+                    .collect(),
+                warnings: data
+                    .iter()
+                    .filter(|f| matches!(f, TestFinding::Warning(_)))
+                    .map(ValidationError::from)
+                    .collect(),
+                infos: data
+                    .iter()
+                    .filter(|f| matches!(f, TestFinding::Information(_)))
+                    .map(ValidationError::from)
+                    .collect(),
             },
         },
     }
@@ -87,7 +78,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
     fn run_test(&self, test_id: &str) -> TestResult {
         let mandatory_result = to_test_result(
             test_id,
-            Severity::Error,
             match test_id {
                 // mandatory tests
                 "6.1.1" => Some(ValidatorForTest6_1_1.validate(self)),
@@ -180,7 +170,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 
         let recommended_result = to_test_result(
             test_id,
-            Severity::Warning,
             match test_id {
                 // recommended tests
                 "6.2.1" => Some(ValidatorForTest6_2_1.validate(self)),
@@ -261,7 +250,6 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 
         to_test_result(
             test_id,
-            Severity::Info,
             match test_id {
                 // informative tests
                 "6.3.1" => None, // Some(ValidatorForTest6_3_1.validate(self)),
@@ -293,12 +281,11 @@ impl Validatable for CommonSecurityAdvisoryFramework {
 impl RawValidatable for RawDocument<CommonSecurityAdvisoryFramework> {
     fn run_raw_test(&self, test_id: &str) -> TestResult {
         if test_id == "schema" {
-            return to_test_result(test_id, Severity::Error, Some(validate_schema_csaf_2_1(self)));
+            return to_test_result(test_id, Some(validate_schema_csaf_2_1(self)));
         }
 
         to_test_result(
             test_id,
-            Severity::Warning,
             match test_id {
                 "6.2.13" => Some(ValidatorForTest6_2_13.validate(self)),
                 "6.2.20" => Some(ValidatorForTest6_2_20.validate(self)),

--- a/csaf-rs/src/cvss/mod.rs
+++ b/csaf-rs/src/cvss/mod.rs
@@ -3,7 +3,8 @@ pub mod v3;
 pub mod v4;
 
 use crate::csaf_traits::ContentTrait;
-use crate::validation::ValidationError;
+use crate::validation::TestFinding;
+use crate::validation::TestFindingData;
 use cvss_rs::Cvss;
 use cvss_rs::Severity;
 use cvss_rs::Version;
@@ -15,7 +16,7 @@ use strum::{AsRefStr, Display};
 pub fn validate_content_scores(
     content: &impl ContentTrait,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     if let Some(cvss_v2_map) = content.get_cvss_v2() {
         validate_scores(cvss_v2_map, instance_path, errors, Version::V2);
@@ -32,7 +33,7 @@ pub fn validate_content_scores(
 pub fn validate_content_consistency(
     content: &impl ContentTrait,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     if let Some(cvss_map) = content.get_cvss_v2() {
         validate_consistency(cvss_map, instance_path, errors, Version::V2);
@@ -52,7 +53,7 @@ pub fn validate_content_consistency(
 fn validate_scores(
     cvss_map: &serde_json::Map<String, Value>,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
     expected_version: Version,
 ) {
     let Some(cvss_deserialized) = deserialize_cvss(cvss_map, instance_path, errors) else {
@@ -88,7 +89,7 @@ fn validate_scores(
 fn validate_consistency(
     cvss_map: &serde_json::Map<String, Value>,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
     expected_version: Version,
 ) {
     let Some(cvss_deserialized) = deserialize_cvss(cvss_map, instance_path, errors) else {
@@ -124,11 +125,11 @@ pub enum ScoreType {
     Environmental,
 }
 
-pub fn create_deserialization_error(error_message: String, instance_path: String) -> ValidationError {
-    ValidationError {
+pub fn create_deserialization_error(error_message: String, instance_path: String) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Error deserializing CVSS metric: {error_message}"),
         instance_path,
-    }
+    })
 }
 
 pub fn create_vector_parse_error(
@@ -136,16 +137,16 @@ pub fn create_vector_parse_error(
     version: Version,
     parse_error: &cvss_rs::ParseError,
     instance_path: &str,
-) -> ValidationError {
+) -> TestFinding {
     let version_str = match version {
         Version::V2 => "2.0",
         Version::V4 => "4.0",
         _ => "3.x",
     };
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!("Could not parse vector string \"{vector_string}\" as CVSS {version_str}: {parse_error}"),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 /// Attempts to deserialize a csaf-rs/csaf CVSS JSON map into a scm-rs/cvss-rs [Cvss] enum.
@@ -153,7 +154,7 @@ pub fn create_vector_parse_error(
 pub fn deserialize_cvss(
     cvss_map: &serde_json::Map<String, Value>,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) -> Option<Cvss> {
     match Cvss::deserialize(cvss_map) {
         Ok(cvss) => Some(cvss),
@@ -171,14 +172,14 @@ pub fn create_score_mismatch_error(
     actual: f64,
     score_type: ScoreType,
     instance_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "{score_type} score does not match the expected value calculated from the vector. \
              Expected: {calculated}, found: {actual}"
         ),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 /// Compares an actual score against a calculated score and adds a validation error if they differ.
@@ -187,7 +188,7 @@ pub fn check_score_mismatch(
     calculated: f64,
     score_type: ScoreType,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     // compare scores as scaled integers
     if (actual * 10.0).round() as i8 != (calculated * 10.0).round() as i8 {
@@ -205,14 +206,14 @@ pub fn create_severity_mismatch_error(
     actual: &Severity,
     score_type: ScoreType,
     instance_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "{score_type} severity does not match the expected value calculated from the vector. \
              Expected: {calculated:?}, found: {actual:?}"
         ),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 /// Compares an actual severity against a calculated severity and adds a validation error if they
@@ -222,7 +223,7 @@ pub fn check_severity_mismatch(
     calculated: &Severity,
     score_type: ScoreType,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     if actual != calculated {
         errors.get_or_insert_default().push(create_severity_mismatch_error(
@@ -254,40 +255,40 @@ pub fn create_field_value_mismatch_error<T: std::fmt::Display>(
     json_val: &T,
     vec_val: &T,
     instance_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Property \"{field_name}\" does not match the value from the vector string. \
              Expected: {vec_val}, found: {json_val}"
         ),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 pub fn create_field_missing_in_vector_error<T: std::fmt::Display>(
     field_name: &str,
     json_val: &T,
     instance_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Property \"{field_name}\" is present in the object ({json_val}) but missing in the vector string"
         ),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 pub fn create_field_missing_in_object_error<T: std::fmt::Display>(
     field_name: &str,
     vec_val: &T,
     instance_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Property \"{field_name}\" is missing in the object but present in the vector string ({vec_val})"
         ),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 /// Checks whether an enum variant represents "not defined" by inspecting its
@@ -307,7 +308,7 @@ pub fn check_optional_field_mismatch<T: PartialEq + std::fmt::Display + std::fmt
     json_value: &Option<T>,
     vector_value: &Option<T>,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     // Normalize: treat Some(NotDefined) as None
     let json_effective = json_value.as_ref().filter(|v| !is_not_defined(*v));

--- a/csaf-rs/src/cvss/v2.rs
+++ b/csaf-rs/src/cvss/v2.rs
@@ -4,7 +4,7 @@ use cvss_rs::v2_0::CvssV2;
 use serde_json::Value;
 
 use super::{ScoreType, check_optional_field_mismatch, check_score_mismatch, create_vector_parse_error};
-use crate::validation::ValidationError;
+use crate::validation::TestFinding;
 use cvss_rs::Version;
 
 /// Validates CVSS v2 scores.
@@ -17,7 +17,7 @@ pub fn validate_scores(
     cvss2: &CvssV2,
     cvss_map: &serde_json::Map<String, Value>,
     instance_path: &str,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     // Parse vector string to get a struct with populated metrics for calculation
     let parsed = match CvssV2::from_str(&cvss2.vector_string) {
@@ -57,7 +57,7 @@ pub fn validate_scores(
 /// The `vectorString` is taken as authoritative. Each metric property declared in the JSON
 /// is compared against the value parsed from the vector string, and mismatches are reported.
 /// Mismatches include the value being present in either the JSON or vector string and missing in the other.
-pub fn validate_consistency(cvss2: &CvssV2, instance_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+pub fn validate_consistency(cvss2: &CvssV2, instance_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     // Parse vector string to get a struct with populated metrics for calculation
     let parsed = match CvssV2::from_str(&cvss2.vector_string) {
         Ok(p) => p,

--- a/csaf-rs/src/cvss/v3.rs
+++ b/csaf-rs/src/cvss/v3.rs
@@ -8,7 +8,7 @@ use super::{
     ScoreType, check_optional_field_mismatch, check_score_mismatch, check_severity_mismatch, create_vector_parse_error,
     map_score_to_severity,
 };
-use crate::validation::ValidationError;
+use crate::validation::TestFinding;
 
 /// Converts a version-specific CVSS v3 [V3Severity] to the unified [Severity].
 /// The [CvssV3] implementation does not provide this only for base_score.
@@ -29,7 +29,7 @@ fn to_unified(severity: &V3Severity) -> Severity {
 ///
 /// Checked score fields: `baseScore`, `temporalScore`, `environmentalScore`
 /// Checked severity fields: `baseSeverity`, `temporalSeverity`, `environmentalSeverity`
-pub fn validate_scores(cvss3: &CvssV3, instance_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+pub fn validate_scores(cvss3: &CvssV3, instance_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     // Parse vector string to get a struct with populated metrics for calculation
     let parsed = match CvssV3::from_str(&cvss3.vector_string) {
         Ok(p) => p,
@@ -102,7 +102,7 @@ pub fn validate_scores(cvss3: &CvssV3, instance_path: &str, errors: &mut Option<
 /// The `vectorString` is taken as authoritative. Each metric property declared in the JSON
 /// is compared against the value parsed from the vector string, and mismatches are reported.
 /// Mismatches include the value being present in either the JSON or vector string and missing in the other.
-pub fn validate_consistency(cvss3: &CvssV3, instance_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+pub fn validate_consistency(cvss3: &CvssV3, instance_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     // Parse vector string to get a struct with populated metrics for calculation
     let parsed = match CvssV3::from_str(&cvss3.vector_string) {
         Ok(p) => p,

--- a/csaf-rs/src/cvss/v4.rs
+++ b/csaf-rs/src/cvss/v4.rs
@@ -7,7 +7,7 @@ use super::{
     ScoreType, check_optional_field_mismatch, check_score_mismatch, check_severity_mismatch, create_vector_parse_error,
     map_score_to_severity,
 };
-use crate::validation::ValidationError;
+use crate::validation::TestFinding;
 
 /// Validates CVSS v4 base score and base severity.
 ///
@@ -15,7 +15,7 @@ use crate::validation::ValidationError;
 /// which are then compared against the values declared in the JSON.
 ///
 /// Checked fields: `baseScore`, `baseSeverity`
-pub fn validate_scores(cvss4: &CvssV4, instance_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+pub fn validate_scores(cvss4: &CvssV4, instance_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     // Parse vector string to get a struct with populated metrics for calculation
     let parsed = match CvssV4::from_str(&cvss4.vector_string) {
         Ok(p) => p,
@@ -50,7 +50,7 @@ pub fn validate_scores(cvss4: &CvssV4, instance_path: &str, errors: &mut Option<
 /// The `vectorString` is taken as authoritative. Each metric property declared in the JSON
 /// is compared against the value parsed from the vector string, and mismatches are reported.
 /// Mismatches include the value being present in either the JSON or vector string and missing in the other.
-pub fn validate_consistency(cvss4: &CvssV4, instance_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+pub fn validate_consistency(cvss4: &CvssV4, instance_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     // Parse vector string to get a struct with populated metrics for calculation
     let parsed = match CvssV4::from_str(&cvss4.vector_string) {
         Ok(p) => p,

--- a/csaf-rs/src/macros/test_gen.rs
+++ b/csaf-rs/src/macros/test_gen.rs
@@ -59,11 +59,11 @@ macro_rules! define_csaf_test {
             ///
             /// # Returns
             /// * `Ok(())` if validation passes
-            /// * `Err(Vec<ValidationError>)` if validation fails
+            /// * `Err(Vec<TestFinding>)` if validation fails
             pub fn validate(
                 &self,
                 doc: &crate::csaf::raw::RawDocument<$doc_type>,
-            ) -> Result<(), Vec<crate::validation::ValidationError>> {
+            ) -> Result<(), Vec<crate::validation::TestFinding>> {
                 let validator = V::default();
                 validator.validate(doc)
             }
@@ -74,7 +74,7 @@ macro_rules! define_csaf_test {
         #[derive(Debug)]
         #[allow(non_camel_case_types)]
         pub struct $expect_name {
-            $(pub $case_name: Result<(), Vec<crate::validation::ValidationError>>,)*
+            $(pub $case_name: Result<(), Vec<crate::validation::TestFinding>>,)*
         }
 
         #[cfg(test)]

--- a/csaf-rs/src/macros/test_gen.rs
+++ b/csaf-rs/src/macros/test_gen.rs
@@ -11,7 +11,7 @@
 /// # Usage
 /// ```ignore
 /// define_csaf_test!(
-///     Test6_1_1, ValidatorForTest6_1_1,
+///     Test6_1_1, ValidatorForTest6_1_1, ExpectedResults_6_1_1,
 ///     id: "6.1.1",
 ///     doc_type: crate::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework,
 ///     version: "V2_0",
@@ -23,7 +23,7 @@
 /// ```
 macro_rules! define_csaf_test {
     (
-        $struct_name:ident, $validator_name:ident,
+        $struct_name:ident, $validator_name:ident, $expect_name:ident,
         id: $id:literal,
         doc_type: $doc_type:ty,
         version: $version:literal,
@@ -69,6 +69,14 @@ macro_rules! define_csaf_test {
             }
         }
 
+        /// Expected results for each test case of this test, keyed by case name.
+        #[cfg(test)]
+        #[derive(Debug)]
+        #[allow(non_camel_case_types)]
+        pub struct $expect_name {
+            $(pub $case_name: Result<(), Vec<crate::validation::ValidationError>>,)*
+        }
+
         #[cfg(test)]
         impl<
             V: crate::test_validation::TestValidator<
@@ -81,14 +89,12 @@ macro_rules! define_csaf_test {
             /// the validation function on each one, comparing actual vs expected results.
             ///
             /// # Arguments
-            /// * One parameter per test case document with the expected result
+            /// * `expected` - The expected result for each test case, one field per case
             ///
             /// # Panics
             /// Panics if any test case fails to load, parse, or doesn't match the expected result
-            pub fn expect(
-                &self,
-                $($case_name: Result<(), Vec<crate::validation::ValidationError>>),*
-            ) {
+            pub fn expect(&self, expected: $expect_name) {
+                let $expect_name { $($case_name),* } = expected;
                 let test_cases = vec![
                     $({
                         let content = std::fs::read_to_string($path)

--- a/csaf-rs/src/test_result_comparison.rs
+++ b/csaf-rs/src/test_result_comparison.rs
@@ -3,7 +3,7 @@
 //! This module contains logic for comparing actual validation results against
 //! expected results, with support for comparing validation errors while ignoring order.
 
-use crate::validation::ValidationError;
+use crate::validation::TestFinding;
 
 /// Compare actual and expected test results.
 ///
@@ -12,8 +12,8 @@ use crate::validation::ValidationError;
 /// When both actual and expected are errors, this function compares the error lists
 /// ignoring the order of errors, but ensuring all expected errors are present.
 pub fn compare_test_results(
-    actual: &Result<(), Vec<ValidationError>>,
-    expected: &Result<(), Vec<ValidationError>>,
+    actual: &Result<(), Vec<TestFinding>>,
+    expected: &Result<(), Vec<TestFinding>>,
     csaf_version: &str,
     test_id: &str,
     case_num: &str,
@@ -23,35 +23,48 @@ pub fn compare_test_results(
             // Both pass - good
             Ok(())
         },
-        (Err(actual_errs), Err(expected_errs)) => {
+        (Err(actual_findings), Err(expected_findings)) => {
             // Both fail - compare errors ignoring order
             let mut errors: Vec<String> = Vec::new();
-            if actual_errs.len() != expected_errs.len() {
+            if actual_findings.len() != expected_findings.len() {
                 errors.push(format!(
                     "CSAF {csaf_version}: Test {test_id} case {case_num}: Error count mismatch - expected {} error(s) but got {}",
-                    expected_errs.len(),
-                    actual_errs.len()
+                    expected_findings.len(),
+                    actual_findings.len()
                 ));
             }
 
             // Check that all expected errors exist in actual errors (ignoring order)
-            for expected_err in expected_errs {
-                if !actual_errs.iter().any(|actual_err| {
-                    actual_err.message == expected_err.message && actual_err.instance_path == expected_err.instance_path
-                }) {
+            for expected_finding in expected_findings {
+                if !actual_findings
+                    .iter()
+                    .any(|actual_finding| match (actual_finding, expected_finding) {
+                        (TestFinding::Error(actual), TestFinding::Error(expected)) => actual == expected,
+                        (TestFinding::Warning(actual), TestFinding::Warning(expected)) => actual == expected,
+                        (TestFinding::Information(actual), TestFinding::Information(expected)) => actual == expected,
+                        _ => false,
+                    })
+                {
                     errors.push(format!(
                         "CSAF {csaf_version}: Test {test_id} case {case_num}: Expected error not found: '{}', path: '{}'",
-                        expected_err.message, expected_err.instance_path
+                        expected_finding.get_data().message, expected_finding.get_data().instance_path
                     ));
                 }
             }
-            for actual_err in actual_errs {
-                if !expected_errs.iter().any(|expected_err| {
-                    expected_err.message == actual_err.message && expected_err.instance_path == actual_err.instance_path
-                }) {
+            for actual_finding in actual_findings {
+                if !expected_findings
+                    .iter()
+                    .any(|expected_finding| match (expected_finding, actual_finding) {
+                        (TestFinding::Error(expected), TestFinding::Error(actual)) => expected == actual,
+                        (TestFinding::Warning(expected), TestFinding::Warning(actual)) => expected == actual,
+                        (TestFinding::Information(expected), TestFinding::Information(actual)) => expected == actual,
+                        _ => false,
+                    })
+                {
                     errors.push(format!(
                         "CSAF {csaf_version}: Test {test_id} case {case_num}: Found unexpected error: '{}', path: '{}'",
-                        actual_err.message, actual_err.instance_path
+                        actual_finding.get_data().message,
+                        actual_finding.get_data().instance_path
                     ));
                 }
             }
@@ -61,29 +74,31 @@ pub fn compare_test_results(
                 Err(errors.join("\n"))
             }
         },
-        (Ok(()), Err(expected_errors)) => {
+        (Ok(()), Err(expected_findings)) => {
             let mut errors: Vec<String> = Vec::new();
             errors.push(format!(
                 "CSAF {csaf_version}: Test {test_id} case {case_num}: Expected failure but validation passed."
             ));
-            for err in expected_errors {
+            for finding in expected_findings {
                 errors.push(format!(
                     "CSAF {csaf_version}: Test {test_id} case {case_num}: Expected error: '{}', path: '{}'",
-                    err.message, err.instance_path
+                    finding.get_data().message,
+                    finding.get_data().instance_path
                 ));
             }
             Err(errors.join("\n"))
         },
-        (Err(actual_errs), Ok(())) => {
+        (Err(actual_findings), Ok(())) => {
             let mut errors: Vec<String> = Vec::new();
             errors.push(format!(
                 "CSAF {csaf_version}: Test {test_id} case {case_num}: Expected success but validation failed with {} error(s).",
-                actual_errs.len()
+                actual_findings.len()
             ));
-            for err in actual_errs {
+            for finding in actual_findings {
                 errors.push(format!(
                     "CSAF {csaf_version}: Test {test_id} case {case_num}: Not expected error: '{}', path: '{}'",
-                    err.message, err.instance_path
+                    finding.get_data().message,
+                    finding.get_data().instance_path
                 ));
             }
             Err(errors.join("\n"))

--- a/csaf-rs/src/test_validation.rs
+++ b/csaf-rs/src/test_validation.rs
@@ -1,4 +1,4 @@
-use crate::validation::ValidationError;
+use crate::validation::TestFinding;
 
 /// Trait for test validation logic.
 ///
@@ -13,8 +13,8 @@ pub trait TestValidator<Doc> {
     ///
     /// # Returns
     /// * `Ok(())` if validation passes
-    /// * `Err(Vec<ValidationError>)` if validation fails
-    fn validate(&self, doc: &Doc) -> Result<(), Vec<ValidationError>>;
+    /// * `Err(Vec<TestFinding>)` if validation fails
+    fn validate(&self, doc: &Doc) -> Result<(), Vec<TestFinding>>;
 }
 
 /// Macro to generate the boilerplate `TestValidator<CommonSecurityAdvisoryFramework>` impl blocks
@@ -48,7 +48,7 @@ macro_rules! impl_validator {
             fn validate(
                 &self,
                 doc: &crate::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework,
-            ) -> Result<(), Vec<crate::validation::ValidationError>> {
+            ) -> Result<(), Vec<crate::validation::TestFinding>> {
                 $validate_fn(doc)
             }
         }
@@ -60,7 +60,7 @@ macro_rules! impl_validator {
             fn validate(
                 &self,
                 doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
-            ) -> Result<(), Vec<crate::validation::ValidationError>> {
+            ) -> Result<(), Vec<crate::validation::TestFinding>> {
                 $validate_fn(doc)
             }
         }
@@ -104,7 +104,7 @@ macro_rules! impl_raw_json_validator {
                 document: &crate::csaf::raw::RawDocument<
                     crate::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework,
                 >,
-            ) -> Result<(), Vec<crate::validation::ValidationError>> {
+            ) -> Result<(), Vec<crate::validation::TestFinding>> {
                 $validate_fn(document.get_json())
             }
         }
@@ -120,7 +120,7 @@ macro_rules! impl_raw_json_validator {
                 document: &crate::csaf::raw::RawDocument<
                     crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
                 >,
-            ) -> Result<(), Vec<crate::validation::ValidationError>> {
+            ) -> Result<(), Vec<crate::validation::TestFinding>> {
                 $validate_fn(document.get_json())
             }
         }

--- a/csaf-rs/src/validation.rs
+++ b/csaf-rs/src/validation.rs
@@ -51,11 +51,6 @@ impl std::fmt::Display for ValidationError {
     }
 }
 
-/// Trait for types that can be converted into a [`ValidationError`] by providing an instance path.
-pub trait IntoValidationError {
-    fn into_validation_error(self, instance_path: &str) -> ValidationError;
-}
-
 pub trait IntoTestFindingError {
     fn into_test_finding_error(self, instance_path: &str) -> TestFinding;
 }

--- a/csaf-rs/src/validation.rs
+++ b/csaf-rs/src/validation.rs
@@ -5,9 +5,44 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct TestFindingData {
+    pub message: String,
+    pub instance_path: String,
+}
+
+#[derive(Serialize, Debug, PartialEq, Eq, Hash, Clone, Deserialize)]
+#[serde(tag = "severity", rename_all = "camelCase")]
+pub enum TestFinding {
+    Information(TestFindingData),
+    Warning(TestFindingData),
+    Error(TestFindingData),
+}
+
+impl TestFinding {
+    pub fn get_data(&self) -> &TestFindingData {
+        match self {
+            TestFinding::Information(data) => data,
+            TestFinding::Warning(data) => data,
+            TestFinding::Error(data) => data,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ValidationError {
     pub message: String,
     pub instance_path: String,
+}
+
+impl From<&TestFinding> for ValidationError {
+    fn from(finding: &TestFinding) -> Self {
+        let data = finding.get_data();
+        ValidationError {
+            message: data.message.clone(),
+            instance_path: data.instance_path.clone(),
+        }
+    }
 }
 
 impl std::fmt::Display for ValidationError {
@@ -19,6 +54,10 @@ impl std::fmt::Display for ValidationError {
 /// Trait for types that can be converted into a [`ValidationError`] by providing an instance path.
 pub trait IntoValidationError {
     fn into_validation_error(self, instance_path: &str) -> ValidationError;
+}
+
+pub trait IntoTestFindingError {
+    fn into_test_finding_error(self, instance_path: &str) -> TestFinding;
 }
 
 /// Result of executing a single test

--- a/csaf-rs/src/validations/test_6_1_01.rs
+++ b/csaf-rs/src/validations/test_6_1_01.rs
@@ -32,21 +32,23 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_1, validate_missing_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_1 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_1 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_6_1_01() {
-        TESTS_2_0.test_6_1_1.expect(
-            Err(vec![
+        TESTS_2_0.test_6_1_1.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![
                 generate_err_msg("CSAFPID-9080700", "/product_tree/product_groups/0/product_ids/0"),
                 generate_err_msg("CSAFPID-9080701", "/product_tree/product_groups/0/product_ids/1"),
             ]),
-            Err(vec![
+            case_02: Err(vec![
                 generate_err_msg("CSAFPID-9080701", "/vulnerabilities/0/flags/0/product_ids/1"),
                 generate_err_msg("CSAFPID-9080702", "/vulnerabilities/1/flags/0/product_ids/0"),
             ]),
-            Err(vec![
+            case_s01: Err(vec![
                 generate_err_msg("CSAFPID-9080701", "/product_tree/relationships/0/product_reference"),
                 generate_err_msg(
                     "CSAFPID-9080702",
@@ -70,16 +72,16 @@ mod tests {
                 generate_err_msg("CSAFPID-9080705", "/vulnerabilities/0/scores/0/products/0"),
                 generate_err_msg("CSAFPID-9080706", "/vulnerabilities/0/threats/0/product_ids/0"),
             ]),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_1.expect(
-            Err(vec![
+        TESTS_2_1.test_6_1_1.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![
                 generate_err_msg("CSAFPID-9080700", "/product_tree/product_groups/0/product_ids/0"),
                 generate_err_msg("CSAFPID-9080701", "/product_tree/product_groups/0/product_ids/1"),
             ]),
-            Err(vec![
+            case_02: Err(vec![
                 generate_err_msg("CSAFPID-9080701", "/document/notes/0/product_ids/1"),
                 generate_err_msg("CSAFPID-9080702", "/document/notes/0/product_ids/2"),
                 generate_err_msg("CSAFPID-9080703", "/document/notes/0/product_ids/3"),
@@ -135,14 +137,14 @@ mod tests {
                     "/product_tree/product_paths/2/subpaths/0/next_product_reference",
                 ),
             ]),
-            Err(vec![
+            case_03: Err(vec![
                 generate_err_msg("CSAFPID-9080710", "/vulnerabilities/0/ids/0/product_ids/0"),
                 generate_err_msg("CSAFPID-9080711", "/vulnerabilities/0/ids/0/product_ids/1"),
                 generate_err_msg("CSAFPID-9080712", "/vulnerabilities/0/ids/1/product_ids/0"),
                 generate_err_msg("CSAFPID-9080714", "/vulnerabilities/0/ids/1/product_ids/2"),
                 generate_err_msg("CSAFPID-9080715", "/vulnerabilities/0/ids/2/product_ids/0"),
             ]),
-            Err(vec![
+            case_s01: Err(vec![
                 generate_err_msg("CSAFPID-9080701", "/document/notes/0/product_ids/0"),
                 generate_err_msg(
                     "CSAFPID-9080703",
@@ -178,9 +180,9 @@ mod tests {
                     "/vulnerabilities/0/first_known_exploitation_dates/0/product_ids/0",
                 ),
             ]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_01.rs
+++ b/csaf-rs/src/validations/test_6_1_01.rs
@@ -1,8 +1,8 @@
 use crate::csaf_traits::{CsafTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
-fn validate_missing_product_id<Doc: CsafTrait>(doc: &Doc) -> Result<(), Vec<ValidationError>> {
+fn validate_missing_product_id<Doc: CsafTrait>(doc: &Doc) -> Result<(), Vec<TestFinding>> {
     let mut definitions_set = HashSet::<String>::new();
     if let Some(tree) = doc.get_product_tree().as_ref() {
         tree.visit_all_products(&mut |fpn, _path| {
@@ -11,7 +11,7 @@ fn validate_missing_product_id<Doc: CsafTrait>(doc: &Doc) -> Result<(), Vec<Vali
     }
 
     let references = doc.get_all_product_references();
-    let mut errors: Option<Vec<ValidationError>> = Option::None;
+    let mut errors: Option<Vec<TestFinding>> = Option::None;
     for (ref_id, ref_path) in &references {
         if !definitions_set.contains(ref_id) {
             errors.get_or_insert_default().push(generate_err_msg(ref_id, ref_path));
@@ -20,11 +20,11 @@ fn validate_missing_product_id<Doc: CsafTrait>(doc: &Doc) -> Result<(), Vec<Vali
     errors.map_or(Ok(()), Err)
 }
 
-fn generate_err_msg(ref_id: &str, ref_path: &str) -> ValidationError {
-    ValidationError {
+fn generate_err_msg(ref_id: &str, ref_path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Missing definition of product_id: {ref_id}"),
         instance_path: ref_path.to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_1, validate_missing_product_id);

--- a/csaf-rs/src/validations/test_6_1_02.rs
+++ b/csaf-rs/src/validations/test_6_1_02.rs
@@ -1,9 +1,9 @@
 use crate::csaf_traits::{CsafTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
-pub fn test_6_1_02_multiple_definition_of_product_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_02_multiple_definition_of_product_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(tree) = doc.get_product_tree() {
         // Map to store each key with all of its paths
@@ -28,11 +28,11 @@ pub fn test_6_1_02_multiple_definition_of_product_id(doc: &impl CsafTrait) -> Re
     errors.map_or(Ok(()), Err)
 }
 
-fn generate_err_msg(product_id: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_err_msg(product_id: &str, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Duplicate definition for product ID {product_id}"),
         instance_path: format!("{path}/product_id"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_2, test_6_1_02_multiple_definition_of_product_id);

--- a/csaf-rs/src/validations/test_6_1_02.rs
+++ b/csaf-rs/src/validations/test_6_1_02.rs
@@ -40,7 +40,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_2, test_6_1_02_multi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_2 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_2 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -68,7 +70,13 @@ mod tests {
             generate_err_msg("CSAFPID-9080700", "/product_tree/branches/1/branches/1/product"),
             generate_err_msg("CSAFPID-9080701", "/product_tree/product_paths/2/full_product_name"),
         ]);
-        TESTS_2_0.test_6_1_2.expect(shared_error_01.clone(), error_02_v2_0);
-        TESTS_2_1.test_6_1_2.expect(shared_error_01, error_02_v2_1);
+        TESTS_2_0.test_6_1_2.expect(ExpectedResults_2_0 {
+            case_01: shared_error_01.clone(),
+            case_s01: error_02_v2_0,
+        });
+        TESTS_2_1.test_6_1_2.expect(ExpectedResults_2_1 {
+            case_01: shared_error_01,
+            case_s01: error_02_v2_1,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_03.rs
+++ b/csaf-rs/src/validations/test_6_1_03.rs
@@ -147,7 +147,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_3, test_6_1_03_circu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_3 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_3 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -181,11 +183,11 @@ mod tests {
             ),
         ]);
 
-        TESTS_2_0.test_6_1_3.expect(
-            csaf_20_case_01_self_ref_via_relates_to_product_ref,
-            csaf_20_case_s01_self_ref_via_product_ref,
-            csaf_20_case_s02_cycle,
-        );
+        TESTS_2_0.test_6_1_3.expect(ExpectedResults_2_0 {
+            case_01: csaf_20_case_01_self_ref_via_relates_to_product_ref,
+            case_s01: csaf_20_case_s01_self_ref_via_product_ref,
+            case_s02: csaf_20_case_s02_cycle,
+        });
 
         let csaf_21_case_01_self_ref_via_product_path_next_ref = Err(vec![generate_self_reference_relates_to_error(
             CsafVersion::X21,
@@ -223,14 +225,14 @@ mod tests {
         // Case 12: multiple paths, no cycle
         // Case 13: multiple paths with different subpath categories, no cycle
 
-        TESTS_2_1.test_6_1_3.expect(
-            csaf_21_case_01_self_ref_via_product_path_next_ref,
-            csaf_21_case_02_cycle,
-            csaf_21_case_s01_self_ref_via_product_path_beginning_ref,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_3.expect(ExpectedResults_2_1 {
+            case_01: csaf_21_case_01_self_ref_via_product_path_next_ref,
+            case_02: csaf_21_case_02_cycle,
+            case_s01: csaf_21_case_s01_self_ref_via_product_path_beginning_ref,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 
     #[test]

--- a/csaf-rs/src/validations/test_6_1_03.rs
+++ b/csaf-rs/src/validations/test_6_1_03.rs
@@ -1,38 +1,38 @@
 use crate::csaf_traits::{CsafTrait, CsafVersion, DocumentTrait, ProductPathTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::{HashMap, HashSet};
 
-fn generate_self_reference_product_error(version: CsafVersion, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_self_reference_product_error(version: CsafVersion, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: if version == CsafVersion::X21 {
             "Product path references itself via 'beginning product reference'".to_string()
         } else {
             "Relationship references itself via 'product reference'".to_string()
         },
         instance_path: path.to_string(),
-    }
+    })
 }
 
-fn generate_self_reference_relates_to_error(version: CsafVersion, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_self_reference_relates_to_error(version: CsafVersion, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: if version == CsafVersion::X21 {
             "Product path references itself via 'next product reference'".to_string()
         } else {
             "Relationship references itself via 'relates to product reference'".to_string()
         },
         instance_path: path.to_string(),
-    }
+    })
 }
 
-fn generate_cycle_error(version: CsafVersion, cycle: &[String], path: String) -> ValidationError {
-    ValidationError {
+fn generate_cycle_error(version: CsafVersion, cycle: &[String], path: String) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: if version == CsafVersion::X21 {
             format!("Found cycle in product path definitions: {}", cycle.join(" -> "))
         } else {
             format!("Found cycle in relationship definitions: {}", cycle.join(" -> "))
         },
         instance_path: path,
-    }
+    })
 }
 
 /// Find the first cycle in the given `relation_map`, if any.
@@ -73,9 +73,9 @@ pub fn find_cycle<'a>(
     None
 }
 
-pub fn test_6_1_03_circular_definition_of_product_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_03_circular_definition_of_product_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let version = doc.get_document().get_csaf_version();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     if let Some(tree) = doc.get_product_tree() {
         let mut relation_map = HashMap::<String, HashMap<String, String>>::new();
         for (pp_i, pp) in tree.get_product_paths().iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_04.rs
+++ b/csaf-rs/src/validations/test_6_1_04.rs
@@ -36,7 +36,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_4 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_4 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -74,20 +76,20 @@ mod tests {
             generate_err_msg("CSAFPID-9080700", "/vulnerabilities/0/ids/2/group_ids/0"),
         ]);
 
-        TESTS_2_0.test_6_1_4.expect(
-            case_threats.clone(), // threats
-            case_flags,           // flags
-            case_remediations,    // remediations
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_1_4.expect(
-            case_threats,         // threats
-            case_vulnerabilities, // vulnerabilities
-            case_vuln_id,         // vulnerability ids
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_4.expect(ExpectedResults_2_0 {
+            case_01: case_threats.clone(), // threats
+            case_02: case_flags,           // flags
+            case_s01: case_remediations,   // remediations
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_1_4.expect(ExpectedResults_2_1 {
+            case_01: case_threats,         // threats
+            case_02: case_vulnerabilities, // vulnerabilities
+            case_03: case_vuln_id,         // vulnerability ids
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_04.rs
+++ b/csaf-rs/src/validations/test_6_1_04.rs
@@ -1,16 +1,16 @@
 use crate::csaf_traits::{CsafTrait, ProductGroupTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
-fn generate_err_msg(ref_id: &str, ref_path: &str) -> ValidationError {
-    ValidationError {
+fn generate_err_msg(ref_id: &str, ref_path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Missing definition of product_group_id: {ref_id}"),
         instance_path: ref_path.to_owned(),
-    }
+    })
 }
 
-pub fn test_6_1_04_missing_definition_of_product_group_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = Option::None;
+pub fn test_6_1_04_missing_definition_of_product_group_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = Option::None;
     if let Some(tree) = doc.get_product_tree() {
         let mut known_groups = HashSet::<String>::new();
         for g in tree.get_product_groups() {

--- a/csaf-rs/src/validations/test_6_1_05.rs
+++ b/csaf-rs/src/validations/test_6_1_05.rs
@@ -58,7 +58,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_5 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_5 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -75,7 +77,15 @@ mod tests {
             generate_multiple_group_id_definition_error("CSAFGID-1020300", "/product_tree/product_groups/2/group_id"),
         ]);
         // Case S11: Two product groups with different group_ids
-        TESTS_2_0.test_6_1_5.expect(case_01.clone(), case_s01.clone(), Ok(()));
-        TESTS_2_1.test_6_1_5.expect(case_01, case_s01, Ok(()));
+        TESTS_2_0.test_6_1_5.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_s01: case_s01.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_5.expect(ExpectedResults_2_1 {
+            case_01,
+            case_s01,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_05.rs
+++ b/csaf-rs/src/validations/test_6_1_05.rs
@@ -1,17 +1,17 @@
 use crate::csaf_traits::{CsafTrait, ProductGroupTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
-fn generate_multiple_group_id_definition_error(group_id: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_multiple_group_id_definition_error(group_id: &str, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Duplicate definition for product group ID {group_id}"),
         instance_path: path.to_owned(),
-    }
+    })
 }
 
 /// 6.1.5 Multiple Definition of Product Group ID
 /// Checks that all product group IDs defined in the document are unique.
-pub fn test_6_1_05_multiple_definition_of_product_group_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_05_multiple_definition_of_product_group_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     // Check if there is a product tree, if there isn't, this test can be skipped
     let Some(tree) = doc.get_product_tree() else {
         // This will be WasSkipped in the future
@@ -36,7 +36,7 @@ pub fn test_6_1_05_multiple_definition_of_product_group_id(doc: &impl CsafTrait)
     }
 
     // Generate an error for each product group ID that is defined more than once
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (group_id, paths) in &product_group_ids_with_paths {
         if paths.len() > 1 {
             for path in paths {

--- a/csaf-rs/src/validations/test_6_1_06.rs
+++ b/csaf-rs/src/validations/test_6_1_06.rs
@@ -1,8 +1,8 @@
 use crate::csaf_traits::{CsafTrait, ProductGroupsByIdMap, ProductStatusGroup, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-pub fn test_6_1_06_contradicting_product_status(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_06_contradicting_product_status(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (vulnerability_index, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(product_status) = vulnerability.get_product_status() {
             let product_to_groups = ProductGroupsByIdMap::from(product_status);
@@ -31,16 +31,16 @@ pub fn test_6_1_06_contradicting_product_status(doc: &impl CsafTrait) -> Result<
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_6, test_6_1_06_contradicting_product_status);
 
-fn generate_err_msg(product_id: &str, groups: &[ProductStatusGroup], vulnerability_index: usize) -> ValidationError {
+fn generate_err_msg(product_id: &str, groups: &[ProductStatusGroup], vulnerability_index: usize) -> TestFinding {
     let group_names: Vec<String> = groups.iter().map(|g| format!("'{g}'")).collect();
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Product {} is member of contradicting product status groups: {}",
             product_id,
             group_names.join(", ")
         ),
         instance_path: format!("/vulnerabilities/{vulnerability_index}/product_status"),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/validations/test_6_1_06.rs
+++ b/csaf-rs/src/validations/test_6_1_06.rs
@@ -46,7 +46,9 @@ fn generate_err_msg(product_id: &str, groups: &[ProductStatusGroup], vulnerabili
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_6 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_6 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -98,53 +100,53 @@ mod tests {
         )]);
 
         // CSAF 2.0 has 10 test cases (01-05, 11-15)
-        TESTS_2_0.test_6_1_6.expect(
-            case_affected_not_affected.clone(),
-            case_affected_not_affected.clone(),
-            case_affected_not_affected.clone(),
-            Err(case_affected_under_investigation_vec
+        TESTS_2_0.test_6_1_6.expect(ExpectedResults_2_0 {
+            case_01: case_affected_not_affected.clone(),
+            case_02: case_affected_not_affected.clone(),
+            case_03: case_affected_not_affected.clone(),
+            case_04: Err(case_affected_under_investigation_vec
                 .clone()
                 .into_iter()
                 .chain(case_not_affected_fixed_vec.clone())
                 .collect()),
-            Err(case_affected_under_investigation_vec
+            case_05: Err(case_affected_under_investigation_vec
                 .clone()
                 .into_iter()
                 .chain(case_not_affected_under_investigation_vec.clone())
                 .chain(case_affected_fixed_vec.clone())
                 .collect()),
-            Ok(()), // know_affected(0) & recommended(0)
-            Ok(()), // first_affected(0) & known_affected(0)
-            Ok(()), // known_affected(0) & last_affected(0)
-            Ok(()), // first_fixed(1) & fixed(1) + recommended(0) & under_investigation(0)
-            Ok(()), // first_affected(0) & known_affected(0) & recommended(0) + first_fixed(2) & fixed(2) + known_not_affected(1) & recommended(1)
-        );
+            case_11: Ok(()), // know_affected(0) & recommended(0)
+            case_12: Ok(()), // first_affected(0) & known_affected(0)
+            case_13: Ok(()), // known_affected(0) & last_affected(0)
+            case_14: Ok(()), // first_fixed(1) & fixed(1) + recommended(0) & under_investigation(0)
+            case_15: Ok(()), // first_affected(0) & known_affected(0) & recommended(0) + first_fixed(2) & fixed(2) + known_not_affected(1) & recommended(1)
+        });
 
         // CSAF 2.1 has 12 test cases (01-06, 11-16)
-        TESTS_2_1.test_6_1_6.expect(
-            case_affected_not_affected.clone(),
-            case_affected_not_affected.clone(),
-            case_affected_not_affected,
-            Err(case_affected_under_investigation_vec
+        TESTS_2_1.test_6_1_6.expect(ExpectedResults_2_1 {
+            case_01: case_affected_not_affected.clone(),
+            case_02: case_affected_not_affected.clone(),
+            case_03: case_affected_not_affected,
+            case_04: Err(case_affected_under_investigation_vec
                 .clone()
                 .into_iter()
                 .chain(case_not_affected_fixed_vec)
                 .collect()),
-            Err(case_affected_under_investigation_vec
+            case_05: Err(case_affected_under_investigation_vec
                 .into_iter()
                 .chain(case_not_affected_under_investigation_vec)
                 .chain(case_affected_fixed_vec)
                 .collect()),
-            case_affected_unknown,
-            case_not_affected_unknown,
-            case_fixed_unknown,
-            case_under_investigation_unknown,
-            Ok(()), // know_affected(0) & recommended(0)
-            Ok(()), // first_affected(0) & known_affected(0)
-            Ok(()), // known_affected(0) & last_affected(0)
-            Ok(()), // first_fixed(1) & fixed(1) + recommended(0) & under_investigation(0)
-            Ok(()), // first_affected(0) & known_affected(0) & recommended(0) + first_fixed(2) & fixed(2) + known_not_affected(1) & recommended(1)
-            Ok(()),
-        );
+            case_06: case_affected_unknown,
+            case_s01: case_not_affected_unknown,
+            case_s02: case_fixed_unknown,
+            case_s03: case_under_investigation_unknown,
+            case_11: Ok(()), // know_affected(0) & recommended(0)
+            case_12: Ok(()), // first_affected(0) & known_affected(0)
+            case_13: Ok(()), // known_affected(0) & last_affected(0)
+            case_14: Ok(()), // first_fixed(1) & fixed(1) + recommended(0) & under_investigation(0)
+            case_15: Ok(()), // first_affected(0) & known_affected(0) & recommended(0) + first_fixed(2) & fixed(2) + known_not_affected(1) & recommended(1)
+            case_16: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_07.rs
+++ b/csaf-rs/src/validations/test_6_1_07.rs
@@ -98,7 +98,9 @@ fn create_validation_error(
 mod tests {
     use super::*;
     use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_7 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_7 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -289,25 +291,27 @@ mod tests {
         // Case 17: 1 vuln, CVSS v2, v3.0, v4, same product
         // Case 18: like 05, but valid
 
-        TESTS_2_0
-            .test_6_1_7
-            .expect(case_01_duplicate_cvss_v3_1_csaf_20, Ok(()), Ok(()));
+        TESTS_2_0.test_6_1_7.expect(ExpectedResults_2_0 {
+            case_01: case_01_duplicate_cvss_v3_1_csaf_20,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_7.expect(
-            case_01_duplicate_cvss_v3_1_csaf_21,
-            case_02_duplicate_cvss_v3_0_csaf_21,
-            case_03_duplicate_cvss_v2_csaf_21,
-            case_04_duplicate_cvss_v4_csaf_21,
-            case_05_duplicate_cvss_mixed_versions_with_sources,
-            case_06_duplicate_cvss_invalid_versions_with_sources,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_7.expect(ExpectedResults_2_1 {
+            case_01: case_01_duplicate_cvss_v3_1_csaf_21,
+            case_02: case_02_duplicate_cvss_v3_0_csaf_21,
+            case_03: case_03_duplicate_cvss_v2_csaf_21,
+            case_04: case_04_duplicate_cvss_v4_csaf_21,
+            case_05: case_05_duplicate_cvss_mixed_versions_with_sources,
+            case_06: case_06_duplicate_cvss_invalid_versions_with_sources,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_07.rs
+++ b/csaf-rs/src/validations/test_6_1_07.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
 /// Maps product ids to a per-metric-type, per-source list of JSON paths.
@@ -50,8 +50,8 @@ fn aggregate_product_cvss_metrics(
 ///
 /// For each item in `/vulnerabilities` it MUST be tested that the same Product ID
 /// is not a member of more than one CVSS vector with the same version and same source.
-pub fn test_6_1_07_multiple_same_scores_per_product(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_07_multiple_same_scores_per_product(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (vulnerability_index, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         let product_metrics = aggregate_product_cvss_metrics(vulnerability, vulnerability_index);
         // if there are any cvss metrics
@@ -86,12 +86,12 @@ fn create_validation_error(
     product_id: &str,
     path: String,
     source: Option<String>,
-) -> ValidationError {
+) -> TestFinding {
     let source_info = source.map_or("by author".to_string(), |s| format!("for source: {s}"));
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!("Multiple {score_type} scores are given for {product_id} {source_info}."),
         instance_path: format!("{}/{}", path, score_type.get_metric_prop_name()),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/validations/test_6_1_08.rs
+++ b/csaf-rs/src/validations/test_6_1_08.rs
@@ -101,77 +101,79 @@ fn create_validation_error(message: String, base: &str, metric: CsafVulnerabilit
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_8 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_8 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_08() {
         // CSAF 2.0 has 7 test cases (01-03, 11-14)
-        TESTS_2_0.test_6_1_8.expect(
-            Err(vec![create_validation_error(
+        TESTS_2_0.test_6_1_8.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![create_validation_error(
                 "\"baseSeverity\" is a required property".to_string(),
                 "/vulnerabilities/0/scores/0",
                 CsafVulnerabilityMetric::CvssV3("3.1".to_string()),
             )]),
-            Err(vec![create_validation_error(
+            case_02: Err(vec![create_validation_error(
                 "\"baseSeverity\" is a required property".to_string(),
                 "/vulnerabilities/0/scores/0",
                 CsafVulnerabilityMetric::CvssV3("3.0".to_string()),
             )]),
-            Err(vec![create_validation_error(
+            case_03: Err(vec![create_validation_error(
                 "\"version\" is a required property".to_string(),
                 "/vulnerabilities/0/scores/0",
                 CsafVulnerabilityMetric::CvssV2("2.0".to_string()),
             )]),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
 
         // CSAF 2.1 has 13 test cases (01-06, 11-17)
-        TESTS_2_1.test_6_1_8.expect(
-            Err(vec![create_validation_error(
+        TESTS_2_1.test_6_1_8.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![create_validation_error(
                 "\"baseSeverity\" is a required property".to_string(),
                 "/vulnerabilities/0/metrics/0/content",
                 CsafVulnerabilityMetric::CvssV3("3.1".to_string()),
             )]),
-            Err(vec![create_validation_error(
+            case_02: Err(vec![create_validation_error(
                 "\"baseSeverity\" is a required property".to_string(),
                 "/vulnerabilities/0/metrics/0/content",
                 CsafVulnerabilityMetric::CvssV3("3.0".to_string()),
             )]),
-            Err(vec![create_validation_error(
+            case_03: Err(vec![create_validation_error(
                 "\"version\" is a required property".to_string(),
                 "/vulnerabilities/0/metrics/0/content",
                 CsafVulnerabilityMetric::CvssV2("2.0".to_string()),
             )]),
-            Err(vec![create_validation_error(
+            case_04: Err(vec![create_validation_error(
                 "\"baseSeverity\" is a required property".to_string(),
                 "/vulnerabilities/0/metrics/0/content",
                 CsafVulnerabilityMetric::CvssV4("4.0".to_string()),
             )]),
-            Err(vec![
+            case_05: Err(vec![
                 create_validation_error(
                     "Unevaluated properties are not allowed ('threatScore', 'threatSeverity' were unexpected)".to_string(),
                     "/vulnerabilities/0/metrics/0/content",
                     CsafVulnerabilityMetric::CvssV4("4.0".to_string()),
                 ),
             ]),
-            Err(vec![
+            case_06: Err(vec![
                 create_validation_error(
                     "Unevaluated properties are not allowed ('threatScore', 'threatSeverity', 'environmentalScore', 'environmentalSeverity' were unexpected)".to_string(),
                     "/vulnerabilities/0/metrics/0/content",
                     CsafVulnerabilityMetric::CvssV4("4.0".to_string()),
                 ),
             ]),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14
-            Ok(()), // case_15
-            Ok(()), // case_16
-            Ok(()), // case_17
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_08.rs
+++ b/csaf-rs/src/validations/test_6_1_08.rs
@@ -6,7 +6,7 @@ use serde_json::{Map, Value};
 use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
 use crate::{
     csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait},
-    validation::ValidationError,
+    validation::{TestFinding, TestFindingData},
 };
 
 static CVSS20_VALIDATOR: LazyLock<Validator> =
@@ -20,8 +20,8 @@ static CVSS40_VALIDATOR: LazyLock<Validator> =
 
 /// 6.1.8 Invalid CVSS
 /// Invalid CVSS object according to scheme
-pub fn test_6_1_08_invalid_cvss(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_08_invalid_cvss(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {
@@ -81,7 +81,7 @@ fn evaluate_cvss(
     validator: &Validator,
     base_path: &str,
     metric: CsafVulnerabilityMetric,
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
 ) {
     let value = serde_json::to_value(cvss_value).unwrap();
     for error in validator.iter_errors(&value) {
@@ -91,11 +91,11 @@ fn evaluate_cvss(
     }
 }
 
-fn create_validation_error(message: String, base: &str, metric: CsafVulnerabilityMetric) -> ValidationError {
-    ValidationError {
+fn create_validation_error(message: String, base: &str, metric: CsafVulnerabilityMetric) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message,
         instance_path: format!("{}/{}", base, metric.get_metric_prop_name()),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/validations/test_6_1_09.rs
+++ b/csaf-rs/src/validations/test_6_1_09.rs
@@ -1,7 +1,7 @@
 use crate::{
     csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait},
     cvss,
-    validation::ValidationError,
+    validation::TestFinding,
 };
 
 /// 6.1.9 Invalid CVSS computation
@@ -10,8 +10,8 @@ use crate::{
 /// For CVSS v2.0, the base, temporal and environmental scores are checked.
 /// For CVSS v3.0 and v3.1, the base, temporal and environmental scores and severities are checked.
 /// For CVSS v4.0, the score and severity are checked
-pub fn test_6_1_09_invalid_cvss_computation(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_09_invalid_cvss_computation(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {

--- a/csaf-rs/src/validations/test_6_1_09.rs
+++ b/csaf-rs/src/validations/test_6_1_09.rs
@@ -31,7 +31,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_9, test_6_1_09_inval
 
 #[cfg(test)]
 mod tests {
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_9 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_9 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use crate::cvss::{ScoreType, create_score_mismatch_error, create_severity_mismatch_error};
     use cvss_rs::Severity;
@@ -55,14 +57,14 @@ mod tests {
         // Case 12: v3.0 correct
         // Case 13: v2.0 correct
 
-        TESTS_2_0.test_6_1_9.expect(
-            case01_3_1_base_score_and_severity_wrong_csaf_2_0,
-            case02_3_0_base_score_and_severity_wrong_csaf_2_0,
-            case03_2_0_base_score_wrong_csaf_2_0,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_9.expect(ExpectedResults_2_0 {
+            case_01: case01_3_1_base_score_and_severity_wrong_csaf_2_0,
+            case_02: case02_3_0_base_score_and_severity_wrong_csaf_2_0,
+            case_03: case03_2_0_base_score_wrong_csaf_2_0,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
 
         let path_2_1 = "/vulnerabilities/0/metrics/0/content";
 
@@ -91,18 +93,18 @@ mod tests {
         // Case 15: v4.0 correct
         // Case 16: v4.0 correct
 
-        TESTS_2_1.test_6_1_9.expect(
-            case01_3_1_base_score_and_severity_wrong_csaf_2_1,
-            case02_3_0_base_score_and_severity_wrong_csaf_2_1,
-            case03_2_0_base_score_wrong_csaf_2_1,
-            case04_4_0_base_score_wrong_csaf_2_1,
-            case05_4_0_base_score_and_severity_wrong_csaf_2_1,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_9.expect(ExpectedResults_2_1 {
+            case_01: case01_3_1_base_score_and_severity_wrong_csaf_2_1,
+            case_02: case02_3_0_base_score_and_severity_wrong_csaf_2_1,
+            case_03: case03_2_0_base_score_wrong_csaf_2_1,
+            case_04: case04_4_0_base_score_wrong_csaf_2_1,
+            case_05: case05_4_0_base_score_and_severity_wrong_csaf_2_1,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_10.rs
+++ b/csaf-rs/src/validations/test_6_1_10.rs
@@ -33,7 +33,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_10, test_6_1_10_inco
 
 #[cfg(test)]
 mod tests {
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_10 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_10 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use crate::cvss::create_field_value_mismatch_error;
 
@@ -47,7 +49,9 @@ mod tests {
             create_field_value_mismatch_error("availabilityImpact", &"L", &"H", path_2_0),
         ]);
 
-        TESTS_2_0.test_6_1_10.expect(case_01_3_1_mismatch_csaf_2_0);
+        TESTS_2_0.test_6_1_10.expect(ExpectedResults_2_0 {
+            case_01: case_01_3_1_mismatch_csaf_2_0,
+        });
 
         let path_2_1 = "/vulnerabilities/0/metrics/0/content";
 
@@ -88,15 +92,15 @@ mod tests {
         // Case 13: v2.0 correct
         // Case 14: v4.0 correct
 
-        TESTS_2_1.test_6_1_10.expect(
-            case_01_3_1_mismatch_csaf_2_1,
-            case_02_3_0_mismatch_csaf_2_1,
-            case_03_2_0_mismatch_csaf_2_1,
-            case_04_4_0_mismatch_csaf_2_1,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_10.expect(ExpectedResults_2_1 {
+            case_01: case_01_3_1_mismatch_csaf_2_1,
+            case_02: case_02_3_0_mismatch_csaf_2_1,
+            case_03: case_03_2_0_mismatch_csaf_2_1,
+            case_04: case_04_4_0_mismatch_csaf_2_1,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_10.rs
+++ b/csaf-rs/src/validations/test_6_1_10.rs
@@ -1,7 +1,7 @@
 use crate::{
     csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait},
     cvss,
-    validation::ValidationError,
+    validation::TestFinding,
 };
 
 /// 6.1.10 Inconsistent CVSS
@@ -12,8 +12,8 @@ use crate::{
 /// Generates an error if a CVSS 2.0, 3.x, 4.0 metric differs in value between the JSON and vector or is
 /// missing in either the JSON or vector and present in the other. For the latter comparison, the "NotDefined"
 /// values are normalized to be "not present".
-pub fn test_6_1_10_inconsistent_cvss(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_10_inconsistent_cvss(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {

--- a/csaf-rs/src/validations/test_6_1_11.rs
+++ b/csaf-rs/src/validations/test_6_1_11.rs
@@ -121,59 +121,63 @@ impl crate::test_validation::TestValidator<crate::schema::csaf2_1::schema::Commo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_11 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_11 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_11() {
-        TESTS_2_0.test_6_1_11.expect(Err(vec![generate_incorrect_cwe_name_error(
-            "CWE-79",
-            "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
-            "4.5",
-            "/vulnerabilities/0/cwe",
-        )]));
-        TESTS_2_1.test_6_1_11.expect(
-            Err(vec![generate_incorrect_cwe_name_error(
+        TESTS_2_0.test_6_1_11.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![generate_incorrect_cwe_name_error(
+                "CWE-79",
+                "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
+                "4.5",
+                "/vulnerabilities/0/cwe",
+            )]),
+        });
+        TESTS_2_1.test_6_1_11.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![generate_incorrect_cwe_name_error(
                 "CWE-79",
                 "Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')",
                 "4.13",
                 "/vulnerabilities/0/cwes/0",
             )]),
-            Err(vec![generate_incorrect_cwe_error(
+            case_02: Err(vec![generate_incorrect_cwe_error(
                 "CWE-1419",
                 "4.12",
                 "/vulnerabilities/0/cwes/0",
             )]),
-            Err(vec![generate_incorrect_cwe_name_error(
+            case_03: Err(vec![generate_incorrect_cwe_name_error(
                 "CWE-1324",
                 "DEPRECATED: Sensitive Information Accessible by Physical Probing of JTAG Interface",
                 "4.10",
                 "/vulnerabilities/0/cwes/0",
             )]),
-            Err(vec![generate_incorrect_cwe_name_error(
+            case_04: Err(vec![generate_incorrect_cwe_name_error(
                 "CWE-1192",
                 "System-on-Chip (SoC) Using Components without Unique, Immutable Identifiers",
                 "4.13",
                 "/vulnerabilities/0/cwes/0",
             )]),
-            Err(vec![generate_incorrect_cwe_error(
+            case_05: Err(vec![generate_incorrect_cwe_error(
                 "CWE-19",
                 "2.11",
                 "/vulnerabilities/0/cwes/0",
             )]),
-            Err(vec![generate_incorrect_cwe_error(
+            case_06: Err(vec![generate_incorrect_cwe_error(
                 "CWE-1008",
                 "4.13",
                 "/vulnerabilities/1/cwes/1",
             )]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_11.rs
+++ b/csaf-rs/src/validations/test_6_1_11.rs
@@ -3,30 +3,30 @@ use chrono::NaiveDate;
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf_traits::{CsafTrait, Cwe, DocumentTrait, TrackingTrait, VulnerabilityTrait};
 use crate::helpers::CWE_ENTRIES;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn generate_incorrect_cwe_name_error(cwe: &str, name: &str, version: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_incorrect_cwe_name_error(cwe: &str, name: &str, version: &str, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Weakness '{cwe}' exists in version {version}, however its name is '{name}'."),
         instance_path: format!("{path}/name"),
-    }
+    })
 }
 
-fn generate_incorrect_cwe_error(cwe: &str, version: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_incorrect_cwe_error(cwe: &str, version: &str, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Weakness '{cwe}' does not exist in version {version}."),
         instance_path: format!("{path}/id"),
-    }
+    })
 }
 
-fn generate_incorrect_cwe_version_error(version: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn generate_incorrect_cwe_version_error(version: &str, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Unknown CWE version {version}."),
         instance_path: format!("{path}/version"),
-    }
+    })
 }
 
-fn check_cwe(cwe: &Cwe, version: &str, path: &str, errors: &mut Option<Vec<ValidationError>>) {
+fn check_cwe(cwe: &Cwe, version: &str, path: &str, errors: &mut Option<Vec<TestFinding>>) {
     if !CWE_ENTRIES.contains_key(version) {
         errors
             .get_or_insert_default()
@@ -58,9 +58,9 @@ fn get_latest_cwe_version(date: Option<NaiveDate>) -> Option<&'static String> {
     latest.map(|(version, _)| version)
 }
 
-pub fn test_6_1_11_cwe(doc: &impl CsafTrait, use_2_1: bool) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_11_cwe(doc: &impl CsafTrait, use_2_1: bool) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // Map occurrence paths indexes to CVE identifiers
     for (i_r, vulnerability) in vulnerabilities.iter().enumerate() {
@@ -102,7 +102,7 @@ impl crate::test_validation::TestValidator<crate::schema::csaf2_0::schema::Commo
     fn validate(
         &self,
         doc: &crate::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework,
-    ) -> Result<(), Vec<ValidationError>> {
+    ) -> Result<(), Vec<TestFinding>> {
         test_6_1_11_cwe(doc, false)
     }
 }
@@ -113,7 +113,7 @@ impl crate::test_validation::TestValidator<crate::schema::csaf2_1::schema::Commo
     fn validate(
         &self,
         doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
-    ) -> Result<(), Vec<ValidationError>> {
+    ) -> Result<(), Vec<TestFinding>> {
         test_6_1_11_cwe(doc, true)
     }
 }

--- a/csaf-rs/src/validations/test_6_1_12.rs
+++ b/csaf-rs/src/validations/test_6_1_12.rs
@@ -39,7 +39,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_12, test_6_1_12_lang
 mod tests {
     use super::*;
     use crate::csaf::types::language::CsafLanguage::Invalid;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_12 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_12 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -63,22 +65,22 @@ mod tests {
         // Case S12: Both /document/lang and /document/source_lang are missing (should be skipped? #409)
         // Case S13: default language code in /document/lang
 
-        TESTS_2_0.test_6_1_12.expect(
-            case_01_lang_invalid.clone(),
-            case_s01_source_lang_invalid.clone(),
-            case_s02_both_langs_invalid.clone(),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_12.expect(ExpectedResults_2_0 {
+            case_01: case_01_lang_invalid.clone(),
+            case_s01: case_s01_source_lang_invalid.clone(),
+            case_s02: case_s02_both_langs_invalid.clone(),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_12.expect(
-            case_01_lang_invalid,
-            case_s01_source_lang_invalid,
-            case_s02_both_langs_invalid,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_12.expect(ExpectedResults_2_1 {
+            case_01: case_01_lang_invalid,
+            case_s01: case_s01_source_lang_invalid,
+            case_s02: case_s02_both_langs_invalid,
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_12.rs
+++ b/csaf-rs/src/validations/test_6_1_12.rs
@@ -1,15 +1,15 @@
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::{IntoValidationError, ValidationError};
+use crate::validation::{IntoTestFindingError, TestFinding};
 
-pub fn test_6_1_12_language(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_12_language(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     if document.get_lang().is_none() && document.get_source_lang().is_none() {
         return Ok(()); // This should be a wasSkipped later (see #409)
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     validate_language(document.get_lang(), "/document/lang", &mut errors);
     validate_language(document.get_source_lang(), "/document/source_lang", &mut errors);
 
@@ -18,18 +18,18 @@ pub fn test_6_1_12_language(doc: &impl CsafTrait) -> Result<(), Vec<ValidationEr
 
 /// Validate a language code and append the validation error to the errors vector.
 ///
-/// If the given language is [`CsafLanguage::Invalid`], a [`ValidationError`] is created
+/// If the given language is [`CsafLanguage::Invalid`], a [`TestFinding`] is created
 /// with the specified JSON path and added to the errors collection.
 ///
 /// # Arguments
 /// - `lang`: An optional language code to validate.
 /// - `json_path`: The JSON path to the language code being validated
 /// - `errors`: A mutable reference to an optional vector of validation errors.
-fn validate_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+fn validate_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     if let Some(CsafLanguage::Invalid(_, err)) = lang {
         errors
             .get_or_insert_default()
-            .push(err.into_validation_error(json_path));
+            .push(err.into_test_finding_error(json_path));
     }
 }
 
@@ -43,6 +43,7 @@ mod tests {
     use crate::csaf2_0::testcases::TESTS_2_0;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_12 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::validation::IntoTestFindingError;
 
     #[test]
     fn test_test_6_1_12() {
@@ -54,11 +55,11 @@ mod tests {
             unreachable!()
         };
 
-        let case_01_lang_invalid = Err(vec![ez_error.clone().into_validation_error("/document/lang")]);
-        let case_s01_source_lang_invalid = Err(vec![ez_error.clone().into_validation_error("/document/source_lang")]);
+        let case_01_lang_invalid = Err(vec![ez_error.clone().into_test_finding_error("/document/lang")]);
+        let case_s01_source_lang_invalid = Err(vec![ez_error.clone().into_test_finding_error("/document/source_lang")]);
         let case_s02_both_langs_invalid = Err(vec![
-            ez_error.into_validation_error("/document/lang"),
-            zzz_error.into_validation_error("/document/source_lang"),
+            ez_error.into_test_finding_error("/document/lang"),
+            zzz_error.into_test_finding_error("/document/source_lang"),
         ]);
 
         // Case S11: Valid language code in both /document/lang and /document/source_lang

--- a/csaf-rs/src/validations/test_6_1_13.rs
+++ b/csaf-rs/src/validations/test_6_1_13.rs
@@ -38,7 +38,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_13, test_6_1_13_purl
 mod tests {
     use super::*;
     use crate::csaf::types::purl::{PurlParseError, PurlParseErrorKind};
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_13 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_13 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -68,18 +70,18 @@ mod tests {
         // Case 11/S11: valid purl
         // Case 12/S12: valid purl with repo url
 
-        TESTS_2_0.test_6_1_13.expect(
-            case_01_missing_name("purl", ""),
-            case_02_or_s06_type_prohibits_namespace("purl", ""),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_13.expect(ExpectedResults_2_0 {
+            case_01: case_01_missing_name("purl", ""),
+            case_s06: case_02_or_s06_type_prohibits_namespace("purl", ""),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_13.expect(
-            case_01_missing_name("purls", "/0"),
-            case_02_or_s06_type_prohibits_namespace("purls", "/0"),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_13.expect(ExpectedResults_2_1 {
+            case_01: case_01_missing_name("purls", "/0"),
+            case_02: case_02_or_s06_type_prohibits_namespace("purls", "/0"),
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_13.rs
+++ b/csaf-rs/src/validations/test_6_1_13.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::purl::csaf_purl::CsafPurl;
 use crate::csaf_traits::{CsafTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::{IntoValidationError, ValidationError};
+use crate::validation::{IntoTestFindingError, TestFinding};
 
 /// 6.1.13 PURL
 ///
@@ -10,8 +10,8 @@ use crate::validation::{IntoValidationError, ValidationError};
 ///
 /// In this test, we just check if any purls are [CsafPurl::Invalid] and report the errors found.
 /// If a purl failed the respective regex, the schema validation failed already, so this test (currently) does not run.
-pub fn test_6_1_13_purl(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_13_purl(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {
@@ -22,7 +22,7 @@ pub fn test_6_1_13_purl(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>
                     if let CsafPurl::Invalid(e) = purl {
                         errors
                             .get_or_insert_default()
-                            .push(e.into_validation_error(&helper.get_purls_json_path(path, i_p)))
+                            .push(e.into_test_finding_error(&helper.get_purls_json_path(path, i_p)))
                     }
                 }
             }
@@ -42,26 +42,27 @@ mod tests {
     use crate::csaf2_0::testcases::TESTS_2_0;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_13 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::validation::IntoTestFindingError;
 
     #[test]
     fn test_test_6_1_13() {
         // Shared expected results (only "purl"/"purls" field name differs between 2.0 and 2.1)
-        let case_01_missing_name = |field: &str, idx: &str| -> Result<(), Vec<ValidationError>> {
+        let case_01_missing_name = |field: &str, idx: &str| -> Result<(), Vec<TestFinding>> {
             Err(vec![
                 PurlParseError::new_for_test("pkg:maven/@1.3.4", PurlParseErrorKind::MissingName)
-                    .into_validation_error(&format!(
+                    .into_test_finding_error(&format!(
                         "/product_tree/full_product_names/0/product_identification_helper/{field}{idx}"
                     )),
             ])
         };
 
-        let case_02_or_s06_type_prohibits_namespace = |field: &str, idx: &str| -> Result<(), Vec<ValidationError>> {
+        let case_02_or_s06_type_prohibits_namespace = |field: &str, idx: &str| -> Result<(), Vec<TestFinding>> {
             Err(vec![
                 PurlParseError::new_for_test(
                     "pkg:oci/com.example/product-A@sha256%3Add134261219b2",
                     PurlParseErrorKind::TypeProhibitsNamespace("oci".to_string()),
                 )
-                .into_validation_error(&format!(
+                .into_test_finding_error(&format!(
                     "/product_tree/full_product_names/0/product_identification_helper/{field}{idx}"
                 )),
             ])

--- a/csaf-rs/src/validations/test_6_1_14.rs
+++ b/csaf-rs/src/validations/test_6_1_14.rs
@@ -44,7 +44,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_14, test_6_1_14_sort
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_14 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_14 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -52,51 +54,51 @@ mod tests {
         // Error cases
         let case_error = Err(vec![create_revision_history_error()]);
 
-        TESTS_2_0.test_6_1_14.expect(
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14
-            Ok(()), // case_15
-            Ok(()), // case_16
-            Ok(()), // case_17
-            Ok(()), // case_18
-            Ok(()), // case_19
-            Ok(()), // case_s11 mixed versioning
-        );
+        TESTS_2_0.test_6_1_14.expect(ExpectedResults_2_0 {
+            case_01: case_error.clone(),
+            case_02: case_error.clone(),
+            case_03: case_error.clone(),
+            case_04: case_error.clone(),
+            case_05: case_error.clone(),
+            case_06: case_error.clone(),
+            case_07: case_error.clone(),
+            case_08: case_error.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+            case_19: Ok(()),
+            case_s11: Ok(()), // mixed versioning
+        });
 
-        TESTS_2_1.test_6_1_14.expect(
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error.clone(),
-            case_error,
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14
-            Ok(()), // case_15
-            Ok(()), // case_16
-            Ok(()), // case_17
-            Ok(()), // case_18
-            Ok(()), // case_19
-            Ok(()), // case_31
-            Ok(()), // case_32
-            Ok(()), // case_s11 mixed versioning
-            Ok(()), // case_s12 invalid version number is ignored
-        );
+        TESTS_2_1.test_6_1_14.expect(ExpectedResults_2_1 {
+            case_01: case_error.clone(),
+            case_02: case_error.clone(),
+            case_03: case_error.clone(),
+            case_04: case_error.clone(),
+            case_05: case_error.clone(),
+            case_06: case_error.clone(),
+            case_07: case_error.clone(),
+            case_08: case_error.clone(),
+            case_09: case_error.clone(),
+            case_21: case_error,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+            case_19: Ok(()),
+            case_31: Ok(()),
+            case_32: Ok(()),
+            case_s11: Ok(()), // mixed versioning
+            case_s12: Ok(()), // invalid version number is ignored
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_14.rs
+++ b/csaf-rs/src/validations/test_6_1_14.rs
@@ -1,11 +1,11 @@
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_revision_history_error() -> ValidationError {
-    ValidationError {
+fn create_revision_history_error() -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "items must be in ascending order when sorted by `date` and `number`".to_string(),
         instance_path: "/document/tracking/revision_history".to_string(),
-    }
+    })
 }
 
 /// 6.1.14 Sorted Revision History
@@ -14,7 +14,7 @@ fn create_revision_history_error() -> ValidationError {
 /// must be in the same order as when sorted by their `/document/tracking/revision_history[]/number` field.
 /// If the version numbers are mixed between semantic versioning and non-semantic versioning,
 /// the non-semantic versioning numbers are interpreted as semantic versioning numbers.
-pub fn test_6_1_14_sorted_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_14_sorted_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     // Generate tuples of (revision history path index, date, number)
     let mut rev_history_tuples_sort_by_date = doc.get_document().get_tracking().aggregate_revision_history();
     let mut rev_history_tuples_sort_by_number = rev_history_tuples_sort_by_date.clone();

--- a/csaf-rs/src/validations/test_6_1_15.rs
+++ b/csaf-rs/src/validations/test_6_1_15.rs
@@ -1,17 +1,19 @@
 use crate::csaf_traits::{CsafTrait, DocumentTrait, PublisherTrait};
 use crate::schema::csaf2_1::schema::CategoryOfPublisher;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::sync::LazyLock;
 
-static MISSING_SOURCE_LANG_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "source_lang is required when the publisher category is 'translator'".to_string(),
-    instance_path: "/document/source_lang".to_string(),
+static MISSING_SOURCE_LANG_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: "source_lang is required when the publisher category is 'translator'".to_string(),
+        instance_path: "/document/source_lang".to_string(),
+    })
 });
 
 /// 6.1.15 Translator
 ///
 /// If the `/document/publisher/category` is "translator", then the `/document/source_lang` must be present and set.
-pub fn test_6_1_15_translator(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_15_translator(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     // This test only applies if the publisher category is "translator"

--- a/csaf-rs/src/validations/test_6_1_15.rs
+++ b/csaf-rs/src/validations/test_6_1_15.rs
@@ -32,7 +32,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_15, test_6_1_15_tran
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_15 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_15 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -46,20 +48,20 @@ mod tests {
         // case 12: translator category with source_lang and lang field is present
         // case S11: source_lang is missing, but category is not translator (should be skipped)
 
-        TESTS_2_0.test_6_1_15.expect(
-            missing_source_lang_error.clone(),
-            missing_source_lang_error.clone(),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_15.expect(ExpectedResults_2_0 {
+            case_01: missing_source_lang_error.clone(),
+            case_02: missing_source_lang_error.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_15.expect(
-            missing_source_lang_error.clone(),
-            missing_source_lang_error,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_15.expect(ExpectedResults_2_1 {
+            case_01: missing_source_lang_error.clone(),
+            case_02: missing_source_lang_error,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_16.rs
+++ b/csaf-rs/src/validations/test_6_1_16.rs
@@ -72,7 +72,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_16, test_6_1_16_late
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_16 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_16 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -123,26 +125,26 @@ mod tests {
             )]);
 
         // CSAF 2.0 has 18 test cases (01-08, 11-19, 31)
-        TESTS_2_0.test_6_1_16.expect(
-            case_intver_history_greater_document_version.clone(),
-            case_intver_history_greater_document_version_same_date.clone(),
-            case_intver_history_greater_document_version_same_date_wrong_order.clone(),
-            case_semver_history_greater_document_version.clone(),
-            case_semver_history_greater_document_version_same_date.clone(),
-            case_intver_history_greater_document_version_same_date_multiple_versions.clone(),
-            case_semver_history_greater_document_version_same_date_multiple_versions.clone(),
-            case_intver_history_greater_document_version_same_date_higher_precision.clone(),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14
-            Ok(()), // case_15
-            Ok(()), // case_16
-            Ok(()), // case_17
-            Ok(()), // case_18
-            Ok(()), // case_19
-            Ok(()), // case_31
-        );
+        TESTS_2_0.test_6_1_16.expect(ExpectedResults_2_0 {
+            case_01: case_intver_history_greater_document_version.clone(),
+            case_02: case_intver_history_greater_document_version_same_date.clone(),
+            case_03: case_intver_history_greater_document_version_same_date_wrong_order.clone(),
+            case_04: case_semver_history_greater_document_version.clone(),
+            case_05: case_semver_history_greater_document_version_same_date.clone(),
+            case_06: case_intver_history_greater_document_version_same_date_multiple_versions.clone(),
+            case_07: case_semver_history_greater_document_version_same_date_multiple_versions.clone(),
+            case_08: case_intver_history_greater_document_version_same_date_higher_precision.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+            case_19: Ok(()),
+            case_31: Ok(()),
+        });
 
         let case_intver_history_greater_document_version_wrong_order = Err(vec![test_6_1_16_err_generator(
             &CsafVersionNumber::from("2"),
@@ -151,27 +153,27 @@ mod tests {
         )]);
 
         // CSAF 2.1 has 20 test cases (01-09, 11-19, 31-32)
-        TESTS_2_1.test_6_1_16.expect(
-            case_intver_history_greater_document_version,
-            case_intver_history_greater_document_version_same_date,
-            case_intver_history_greater_document_version_same_date_wrong_order,
-            case_semver_history_greater_document_version,
-            case_semver_history_greater_document_version_same_date,
-            case_intver_history_greater_document_version_same_date_multiple_versions,
-            case_semver_history_greater_document_version_same_date_multiple_versions,
-            case_intver_history_greater_document_version_same_date_higher_precision,
-            case_intver_history_greater_document_version_wrong_order,
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14
-            Ok(()), // case_15
-            Ok(()), // case_16
-            Ok(()), // case_17
-            Ok(()), // case_18
-            Ok(()), // case_19
-            Ok(()), // case_31
-            Ok(()), // case_32
-        );
+        TESTS_2_1.test_6_1_16.expect(ExpectedResults_2_1 {
+            case_01: case_intver_history_greater_document_version,
+            case_02: case_intver_history_greater_document_version_same_date,
+            case_03: case_intver_history_greater_document_version_same_date_wrong_order,
+            case_04: case_semver_history_greater_document_version,
+            case_05: case_semver_history_greater_document_version_same_date,
+            case_06: case_intver_history_greater_document_version_same_date_multiple_versions,
+            case_07: case_semver_history_greater_document_version_same_date_multiple_versions,
+            case_08: case_intver_history_greater_document_version_same_date_higher_precision,
+            case_09: case_intver_history_greater_document_version_wrong_order,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+            case_19: Ok(()),
+            case_31: Ok(()),
+            case_32: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_16.rs
+++ b/csaf-rs/src/validations/test_6_1_16.rs
@@ -1,14 +1,14 @@
 use crate::csaf::types::version_number::CsafVersionNumber;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
 use crate::schema::csaf2_1::schema::DocumentStatus;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.1.16 Latest Document Version
 ///
 /// `/document/tracking/version` must be equal to the last `/document/tracking/revision_history[]/number` when
 /// sorting the revision history ascending by `date`. Build metadata is ignored. Pre-release parts are ignored
 /// if `/document/status` is "draft".
-pub fn test_6_1_16_latest_document_version(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_16_latest_document_version(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let tracking = doc.get_document().get_tracking();
 
     let mut revision_history = tracking.aggregate_revision_history();
@@ -58,13 +58,13 @@ fn test_6_1_16_err_generator(
     doc_version: &CsafVersionNumber,
     latest_number: &CsafVersionNumber,
     doc_status: &DocumentStatus,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document version '{doc_version}' is not equal to the latest revision history number '{latest_number}' in document with status '{doc_status}'"
         ),
         instance_path: "/document/tracking/version".to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_16, test_6_1_16_latest_document_version);

--- a/csaf-rs/src/validations/test_6_1_17.rs
+++ b/csaf-rs/src/validations/test_6_1_17.rs
@@ -87,7 +87,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_17, test_6_1_17_docu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_17 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_17 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use crate::schema::csaf2_1::schema::DocumentStatus;
 
@@ -141,31 +143,31 @@ mod tests {
         // Case S13: document status is "draft", version has prerelease (should be skipped)
         // Case S14: document status is "final", version has metadata
 
-        TESTS_2_0.test_6_1_17.expect(
-            case_final_with_semver_0.clone(),
-            case_final_with_semver_0_ignored_metadata.clone(),
-            case_final_with_semver_prerelease.clone(),
-            case_final_with_semver_0_prerelease.clone(),
-            case_interim_with_semver_0.clone(),
-            case_final_with_intver_0.clone(),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_1_17.expect(
-            case_final_with_semver_0,
-            case_final_with_semver_0_ignored_metadata,
-            case_final_with_semver_prerelease,
-            case_final_with_semver_0_prerelease,
-            case_interim_with_semver_0,
-            case_final_with_intver_0,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_17.expect(ExpectedResults_2_0 {
+            case_01: case_final_with_semver_0.clone(),
+            case_s01: case_final_with_semver_0_ignored_metadata.clone(),
+            case_s02: case_final_with_semver_prerelease.clone(),
+            case_s03: case_final_with_semver_0_prerelease.clone(),
+            case_s04: case_interim_with_semver_0.clone(),
+            case_s05: case_final_with_intver_0.clone(),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+            case_s14: Ok(()),
+            case_s15: Ok(()),
+        });
+        TESTS_2_1.test_6_1_17.expect(ExpectedResults_2_1 {
+            case_01: case_final_with_semver_0,
+            case_s01: case_final_with_semver_0_ignored_metadata,
+            case_s02: case_final_with_semver_prerelease,
+            case_s03: case_final_with_semver_0_prerelease,
+            case_s04: case_interim_with_semver_0,
+            case_s05: case_final_with_intver_0,
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+            case_s14: Ok(()),
+            case_s15: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_17.rs
+++ b/csaf-rs/src/validations/test_6_1_17.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::version_number::CsafVersionNumber;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
 use crate::schema::csaf2_1::schema::DocumentStatus;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use strum::{AsRefStr, Display};
 
 #[derive(Display, AsRefStr)]
@@ -18,13 +18,13 @@ fn generate_status_version_error(
     version: &CsafVersionNumber,
     status: &DocumentStatus,
     reason: &DocumentStatusDraftErrorReason,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document version is '{version}' but the document status is '{status}'. {reason} reserved for document status 'Draft'"
         ),
         instance_path: "/document/tracking/version".to_string(),
-    }
+    })
 }
 
 /// 6.1.17 Document Status Draft
@@ -37,7 +37,7 @@ fn generate_status_version_error(
 /// and this test can only pass, so we can return early.
 /// If not, we know the secondary criteria is not fulfilled, and we can check if `/document/version`
 /// meets one of the failing criteria and generate the corresponding error(s).
-pub fn test_6_1_17_document_status_draft(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_17_document_status_draft(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let tracking = doc.get_document().get_tracking();
 
     // This is explicitly **NOT** a wasSkipped. The test prose does not mention skipping,
@@ -61,7 +61,7 @@ pub fn test_6_1_17_document_status_draft(doc: &impl CsafTrait) -> Result<(), Vec
             }
         },
         CsafVersionNumber::SemVer(semver) => {
-            let mut errors: Option<Vec<ValidationError>> = None;
+            let mut errors: Option<Vec<TestFinding>> = None;
             if semver.get_major() == 0 {
                 errors.get_or_insert_default().push(generate_status_version_error(
                     &doc_version,

--- a/csaf-rs/src/validations/test_6_1_18.rs
+++ b/csaf-rs/src/validations/test_6_1_18.rs
@@ -2,34 +2,34 @@ use crate::csaf::macros::skip_if_document_status_is_not::skip_if_document_status
 use crate::csaf::types::version_number::CsafVersionNumber;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionTrait, TrackingTrait};
 use crate::schema::csaf2_1::schema::DocumentStatus;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_revision_history_error(status: &DocumentStatus, number: &CsafVersionNumber, index: usize) -> ValidationError {
+fn create_revision_history_error(status: &DocumentStatus, number: &CsafVersionNumber, index: usize) -> TestFinding {
     let reason = match number {
         CsafVersionNumber::IntVer(_) => "Version 0 is",
         CsafVersionNumber::SemVer(_) => "Versions 0.y.z are",
         CsafVersionNumber::Invalid(i) => panic!("Invalid version number '{i}'."), // this is fine as it should only be called with valid version numbers
     };
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with status '{status}' contains a revision history item with number '{number}', {reason} forbidden"
         ),
         instance_path: format!("/document/tracking/revision_history/{index}/number"),
-    }
+    })
 }
 
 /// 6.1.18 Released Revision History
 ///
 /// For documents with `/document/status` "final" or "interim", no item in `/document/tracking/revision_history[]`
 /// may have the version 0 or 0.y.z.
-pub fn test_6_1_18_released_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_18_released_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let tracking = doc.get_document().get_tracking();
 
     let status = tracking.get_status();
     skip_if_document_status_is_not!(status, Final, Interim);
 
     // Check that no revision history item has version 0 or 0.y.z
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     let revision_history = tracking.get_revision_history();
     for (revision_index, revision) in revision_history.iter().enumerate() {
         let number = revision.get_number();

--- a/csaf-rs/src/validations/test_6_1_18.rs
+++ b/csaf-rs/src/validations/test_6_1_18.rs
@@ -51,7 +51,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_18, test_6_1_18_rele
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_18 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_18 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -68,13 +70,15 @@ mod tests {
         )]);
 
         // Case S11: Document status draft, revision history item with version 0.y.z
-        TESTS_2_0.test_6_1_18.expect(
-            case_intver_zero_status_final.clone(),
-            case_semver_zero_status_final.clone(),
-            Ok(()),
-        );
-        TESTS_2_1
-            .test_6_1_18
-            .expect(case_intver_zero_status_final, case_semver_zero_status_final, Ok(()));
+        TESTS_2_0.test_6_1_18.expect(ExpectedResults_2_0 {
+            case_01: case_intver_zero_status_final.clone(),
+            case_s01: case_semver_zero_status_final.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_18.expect(ExpectedResults_2_1 {
+            case_01: case_intver_zero_status_final,
+            case_s01: case_semver_zero_status_final,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_19.rs
+++ b/csaf-rs/src/validations/test_6_1_19.rs
@@ -1,12 +1,12 @@
 use crate::csaf::types::version_number::{CsafVersionNumber, SemVerVersion};
 use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_prerelease_version_error(number: &SemVerVersion, index: usize) -> ValidationError {
-    ValidationError {
+fn create_prerelease_version_error(number: &SemVerVersion, index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("revision history item number '{number}' contains a pre-release part"),
         instance_path: format!("/document/tracking/revision_history/{index}/number"),
-    }
+    })
 }
 
 /// 6.1.19 Revision History Entries for Pre-release Versions
@@ -14,9 +14,9 @@ fn create_prerelease_version_error(number: &SemVerVersion, index: usize) -> Vali
 /// No item in `/document/tracking/revision_history[]` may have a version with a pre-release part (i.e. "1.0.0-rc1").
 pub fn test_6_1_19_revision_history_entries_for_prerelease_versions(
     doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     // Check that no revision history item has a pre-release part
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     let revision_history = doc.get_document().get_tracking().get_revision_history();
     for (revision_index, revision) in revision_history.iter().enumerate() {
         match revision.get_number() {

--- a/csaf-rs/src/validations/test_6_1_19.rs
+++ b/csaf-rs/src/validations/test_6_1_19.rs
@@ -43,7 +43,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_19 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_19 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use semver::Version;
     use std::str::FromStr;
@@ -58,7 +60,13 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_1_19.expect(has_pre.clone(), has_pre.clone());
-        TESTS_2_1.test_6_1_19.expect(has_pre.clone(), has_pre);
+        TESTS_2_0.test_6_1_19.expect(ExpectedResults_2_0 {
+            case_01: has_pre.clone(),
+            case_02: has_pre.clone(),
+        });
+        TESTS_2_1.test_6_1_19.expect(ExpectedResults_2_1 {
+            case_01: has_pre.clone(),
+            case_02: has_pre,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_20.rs
+++ b/csaf-rs/src/validations/test_6_1_20.rs
@@ -2,22 +2,22 @@ use crate::csaf::macros::skip_if_document_status_is_not::skip_if_document_status
 use crate::csaf::types::version_number::{CsafVersionNumber, SemVerVersion};
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
 use crate::schema::csaf2_1::schema::DocumentStatus;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_status_version_error(status: &DocumentStatus, version: &SemVerVersion) -> ValidationError {
-    ValidationError {
+fn create_status_version_error(status: &DocumentStatus, version: &SemVerVersion) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document status is {status} but the document version {version} contains a pre-release part"
         ),
         instance_path: "/document/tracking/version".to_string(),
-    }
+    })
 }
 
 /// 6.1.20 Non-draft Document Version
 ///
 /// For documents with status "final" or "interim", the `/document/tracking/version` field must not contain
 /// a pre-release part (e.g. "1.0.0-alpha").
-pub fn test_6_1_20_non_draft_document_version(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_20_non_draft_document_version(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let tracking = doc.get_document().get_tracking();
 
     let status = tracking.get_status();

--- a/csaf-rs/src/validations/test_6_1_20.rs
+++ b/csaf-rs/src/validations/test_6_1_20.rs
@@ -42,7 +42,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_20, test_6_1_20_non_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_20 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_20 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use crate::schema::csaf2_1::schema::DocumentStatus;
     use semver::Version;
@@ -59,9 +61,15 @@ mod tests {
             &SemVerVersion::from(Version::from_str("1.0.0-alpha").unwrap()),
         )]);
 
-        TESTS_2_0
-            .test_6_1_20
-            .expect(case_interim.clone(), case_final.clone(), Ok(()));
-        TESTS_2_1.test_6_1_20.expect(case_interim, case_final, Ok(()));
+        TESTS_2_0.test_6_1_20.expect(ExpectedResults_2_0 {
+            case_01: case_interim.clone(),
+            case_s01: case_final.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_20.expect(ExpectedResults_2_1 {
+            case_01: case_interim,
+            case_s01: case_final,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_21.rs
+++ b/csaf-rs/src/validations/test_6_1_21.rs
@@ -199,7 +199,9 @@ fn test_6_1_21_err_missing_version_between(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_21 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_21 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -292,44 +294,44 @@ mod tests {
         // case s12: valid intver interim start with 1
         // case s13: mixed versioning 1,2,3
 
-        TESTS_2_0.test_6_1_21.expect(
-            case_intver_missing_2_at_all.clone(),
-            case_intver_2_3_wrong_first_and_missing_1_at_all.clone(),
-            case_semver_missing_2_at_all.clone(),
-            case_semver_2_3_missing_1_at_all.clone(),
-            case_s03_intver_1_3_2_missing_2_between,
-            case_s04_semver_1_3_2_missing_2_between,
-            case_s05_intver_3_1_missing_1_before_2_at_all,
-            case_s06_semver_3_1_missing_1_before_2_at_all,
-            case_mixed_versions_start_with_intver_missing_2_at_all.clone(),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_s11
-            Ok(()), // case_s12
-            Ok(()), // case_s13
-        );
+        TESTS_2_0.test_6_1_21.expect(ExpectedResults_2_0 {
+            case_01: case_intver_missing_2_at_all.clone(),
+            case_02: case_intver_2_3_wrong_first_and_missing_1_at_all.clone(),
+            case_s01: case_semver_missing_2_at_all.clone(),
+            case_s02: case_semver_2_3_missing_1_at_all.clone(),
+            case_s03: case_s03_intver_1_3_2_missing_2_between,
+            case_s04: case_s04_semver_1_3_2_missing_2_between,
+            case_s05: case_s05_intver_3_1_missing_1_before_2_at_all,
+            case_s06: case_s06_semver_3_1_missing_1_before_2_at_all,
+            case_s07: case_mixed_versions_start_with_intver_missing_2_at_all.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_21.expect(
-            case_intver_missing_2_at_all.clone(),
-            case_intver_2_3_wrong_first_and_missing_1_at_all,
-            case_intver_missing_2_at_all.clone(),
-            case_semver_missing_2_at_all,
-            case_intver_wrong_first_missing_1_and_2_before_4_between,
-            case_semver_wrong_first_missing_1_and_2_before_4_between,
-            case_intver_missing_2_at_all,
-            case_semver_2_3_missing_1_at_all,
-            case_mixed_versions_start_with_intver_missing_2_at_all,
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_13
-            Ok(()), // case_14 only wrong ordering in json
-            Ok(()), // case_15 only wrong ordering in json due to timezones
-            Ok(()), // case_16 only wrong ordering in json due to timezones
-            Ok(()), // case_17 1&2 have same date
-            Ok(()), // case_s11
-            Ok(()), // case_s12
-            Ok(()), // case_s13
-        );
+        TESTS_2_1.test_6_1_21.expect(ExpectedResults_2_1 {
+            case_01: case_intver_missing_2_at_all.clone(),
+            case_02: case_intver_2_3_wrong_first_and_missing_1_at_all,
+            case_03: case_intver_missing_2_at_all.clone(),
+            case_04: case_semver_missing_2_at_all,
+            case_05: case_intver_wrong_first_missing_1_and_2_before_4_between,
+            case_06: case_semver_wrong_first_missing_1_and_2_before_4_between,
+            case_07: case_intver_missing_2_at_all,
+            case_s01: case_semver_2_3_missing_1_at_all,
+            case_s02: case_mixed_versions_start_with_intver_missing_2_at_all,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()), // only wrong ordering in json
+            case_15: Ok(()), // only wrong ordering in json due to timezones
+            case_16: Ok(()), // only wrong ordering in json due to timezones
+            case_17: Ok(()), // 1&2 have same date
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_21.rs
+++ b/csaf-rs/src/validations/test_6_1_21.rs
@@ -4,7 +4,7 @@ use crate::csaf::aggregation::revision_history::CsafRevisionHistoryItem;
 use crate::csaf::types::csaf_datetime::CsafDateTime;
 use crate::csaf::types::version_number::{CsafVersionNumber, CsafVersionNumberError};
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.1.21 Missing Item in Revision History
 ///
@@ -12,8 +12,8 @@ use crate::validation::ValidationError;
 /// In the case of semantic versioning, this applies only to the Major version.
 /// It MUST also be tested that the first item in such a sorted list has either the version number 0 or 1 in
 /// the case of integer versioning or a Major version of 0 or 1 in the case of semantic versioning.
-pub fn test_6_1_21_missing_item_in_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_21_missing_item_in_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     struct MissingVersionMetadata {
         found: bool,
@@ -149,7 +149,7 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_21, test_6_1_21_miss
 
 const REVISION_HISTORY_PATH: &str = "/document/tracking/revision_history";
 
-fn test_6_1_21_err_wrong_first_version(version: &CsafVersionNumber) -> ValidationError {
+fn test_6_1_21_err_wrong_first_version(version: &CsafVersionNumber) -> TestFinding {
     let expected_version = match version {
         CsafVersionNumber::IntVer(_) => "`0` or `1`",
         CsafVersionNumber::SemVer(_) => "`0.y.z` or `1.y.z`",
@@ -157,43 +157,40 @@ fn test_6_1_21_err_wrong_first_version(version: &CsafVersionNumber) -> Validatio
     }
     .to_string();
 
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         instance_path: REVISION_HISTORY_PATH.to_string(),
         message: format!(
             "revision history does not start with a version of {expected_version} when sorted by date (was `{version}`)"
         ),
-    }
+    })
 }
 
-fn test_6_1_21_err_missing_version_at_all(missing_version: &CsafVersionNumber) -> ValidationError {
-    ValidationError {
+fn test_6_1_21_err_missing_version_at_all(missing_version: &CsafVersionNumber) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         instance_path: REVISION_HISTORY_PATH.to_string(),
         message: format!("missing revision history item with number `{missing_version}` at all"),
-    }
+    })
 }
 
-fn test_6_1_21_err_missing_version_before(
-    missing_version: &CsafVersionNumber,
-    start: &CsafDateTime,
-) -> ValidationError {
+fn test_6_1_21_err_missing_version_before(missing_version: &CsafVersionNumber, start: &CsafDateTime) -> TestFinding {
     let start = start.get_raw_string();
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         instance_path: REVISION_HISTORY_PATH.to_string(),
         message: format!("missing revision history item with number `{missing_version}` before `{start}`"),
-    }
+    })
 }
 
 fn test_6_1_21_err_missing_version_between(
     missing_version: &CsafVersionNumber,
     start: &CsafDateTime,
     end: &CsafDateTime,
-) -> ValidationError {
+) -> TestFinding {
     let start = start.get_raw_string();
     let end = end.get_raw_string();
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         instance_path: REVISION_HISTORY_PATH.to_string(),
         message: format!("missing revision history item with number `{missing_version}` between `{start}` and `{end}`"),
-    }
+    })
 }
 
 #[cfg(test)]

--- a/csaf-rs/src/validations/test_6_1_22.rs
+++ b/csaf-rs/src/validations/test_6_1_22.rs
@@ -1,23 +1,23 @@
 use crate::csaf::types::version_number::CsafVersionNumber;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
-fn generate_duplicate_revision_error(number: &CsafVersionNumber, path: &usize) -> ValidationError {
-    ValidationError {
+fn generate_duplicate_revision_error(number: &CsafVersionNumber, path: &usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Duplicate definition of revision history number {number}"),
         instance_path: format!("/document/tracking/revision_history/{path}/number"),
-    }
+    })
 }
 
 /// Test 6.1.22: Multiple Definition in Revision History
 ///
 /// Items of the revision history must not contain the same value in the
 /// `/document/tracking/revision_history[]/number` field.
-pub fn test_6_1_22_multiple_definition_in_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_22_multiple_definition_in_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let revision_history = doc.get_document().get_tracking().get_revision_history();
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // Map occurrence paths indexes to revision numbers
     let mut number_revision_index_map: HashMap<CsafVersionNumber, Vec<usize>> = HashMap::new();
     for (i_r, revision) in revision_history.iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_22.rs
+++ b/csaf-rs/src/validations/test_6_1_22.rs
@@ -48,7 +48,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_22 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_22 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -76,17 +78,17 @@ mod tests {
         ]);
 
         // Both CSAF 2.0 and 2.1 have 1 test case
-        TESTS_2_0.test_6_1_22.expect(
-            case_intver.clone(),
-            case_semver.clone(),
-            case_intver_double_duplicates.clone(),
-            case_semver_double_duplicates.clone(),
-        );
-        TESTS_2_1.test_6_1_22.expect(
-            case_intver,
-            case_semver,
-            case_intver_double_duplicates,
-            case_semver_double_duplicates,
-        );
+        TESTS_2_0.test_6_1_22.expect(ExpectedResults_2_0 {
+            case_01: case_intver.clone(),
+            case_s01: case_semver.clone(),
+            case_s02: case_intver_double_duplicates.clone(),
+            case_s03: case_semver_double_duplicates.clone(),
+        });
+        TESTS_2_1.test_6_1_22.expect(ExpectedResults_2_1 {
+            case_01: case_intver,
+            case_s01: case_semver,
+            case_s02: case_intver_double_duplicates,
+            case_s03: case_semver_double_duplicates,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_23.rs
+++ b/csaf-rs/src/validations/test_6_1_23.rs
@@ -1,18 +1,18 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
-fn generate_duplicate_cve_error(cve: &str, path: usize) -> ValidationError {
-    ValidationError {
+fn generate_duplicate_cve_error(cve: &str, path: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Duplicate usage of same CVE identifier '{cve}'"),
         instance_path: format!("/vulnerabilities/{path}/cve"),
-    }
+    })
 }
 
 /// Test 6.1.23: Multiple Use of Same CVE
 ///
 /// Vulnerability items must not contain the same string in the `/vulnerabilities[]/cve` field.
-pub fn test_6_1_23_multiple_use_of_same_cve(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_23_multiple_use_of_same_cve(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
 
     // Check if there are any vulnerabilities, if there aren't, this test can be skipped
@@ -38,7 +38,7 @@ pub fn test_6_1_23_multiple_use_of_same_cve(doc: &impl CsafTrait) -> Result<(), 
     }
 
     // Generate errors for CVE identifiers with multiple occurrence paths indexes
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (cve, paths) in &cve_paths {
         if paths.len() > 1 {
             errors

--- a/csaf-rs/src/validations/test_6_1_23.rs
+++ b/csaf-rs/src/validations/test_6_1_23.rs
@@ -55,7 +55,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_23, test_6_1_23_mult
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_23 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_23 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -86,15 +88,19 @@ mod tests {
         ]);
         // Case S11: Two vulnerabilities, different CVE identifiers (valid)
 
-        TESTS_2_0.test_6_1_23.expect(
-            case_01.clone(),
-            case_s01.clone(),
-            case_s02.clone(),
-            case_s03.clone(),
-            Ok(()),
-        );
-        TESTS_2_1
-            .test_6_1_23
-            .expect(case_01, case_s01, case_s02, case_s03, Ok(()));
+        TESTS_2_0.test_6_1_23.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_s01: case_s01.clone(),
+            case_s02: case_s02.clone(),
+            case_s03: case_s03.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_23.expect(ExpectedResults_2_1 {
+            case_01,
+            case_s01,
+            case_s02,
+            case_s03,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_24.rs
+++ b/csaf-rs/src/validations/test_6_1_24.rs
@@ -2,7 +2,7 @@ use crate::csaf::types::csaf_datetime::CsafDateTime::{Invalid, Valid};
 use crate::csaf::types::csaf_datetime::ValidCsafDateTime;
 use crate::csaf_traits::{CsafTrait, InvolvementTrait, VulnerabilityTrait, WithOptionalDate};
 use crate::schema::csaf2_1::schema::PartyCategory;
-use crate::validation::{IntoValidationError, ValidationError};
+use crate::validation::{IntoTestFindingError, TestFinding, TestFindingData};
 use std::collections::HashMap;
 
 fn generate_duplicate_involvement_error(
@@ -10,21 +10,21 @@ fn generate_duplicate_involvement_error(
     party: &PartyCategory,
     vul_r: usize,
     inv_r: usize,
-) -> ValidationError {
+) -> TestFinding {
     let date_str = date
         .as_ref()
         .map_or("none (optional property not present)".to_string(), |d| d.to_string());
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!("Duplicate usage of tuple of involvement date '{date_str}' and party '{party}'"),
         instance_path: format!("/vulnerabilities/{vul_r}/involvements/{inv_r}"),
-    }
+    })
 }
 
 /// Test 6.1.24: Multiple Definition in Involvements
 ///
 /// Vulnerability items must not contain the same tuples of the `/vulnerabilities[]/involvements[]/date`
 /// and `/vulnerabilities[]/involvements[]/party` fields.
-pub fn test_6_1_24_multiple_definition_in_involvements(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_24_multiple_definition_in_involvements(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
 
     // Check if there are any vulnerabilities, if there aren't, this test can be skipped
@@ -33,7 +33,7 @@ pub fn test_6_1_24_multiple_definition_in_involvements(doc: &impl CsafTrait) -> 
         return Ok(());
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // Iterate over all vulnerabilities and their involvements
     for (vuln_i, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(involvements) = vulnerability.get_involvements() {
@@ -50,7 +50,9 @@ pub fn test_6_1_24_multiple_definition_in_involvements(doc: &impl CsafTrait) -> 
                     // while for 2.0, we will need to do that precondition check here (and throw the respective errors, while for 2.1 warnings should be sufficient)
                     Some(Invalid(err)) => {
                         errors.get_or_insert_default().push(
-                            err.into_validation_error(&format!("/vulnerabilities/{vuln_i}/involvements/{inv_i}/date")),
+                            err.into_test_finding_error(&format!(
+                                "/vulnerabilities/{vuln_i}/involvements/{inv_i}/date"
+                            )),
                         );
                         continue;
                     },
@@ -96,6 +98,7 @@ mod tests {
     use crate::csaf2_0::testcases::TESTS_2_0;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_24 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::validation::IntoTestFindingError;
     use std::str::FromStr;
 
     #[test]
@@ -135,7 +138,7 @@ mod tests {
             unreachable!()
         };
         let case_s02 = Err(vec![
-            case_s02_err.into_validation_error("/vulnerabilities/0/involvements/0/date"),
+            case_s02_err.into_test_finding_error("/vulnerabilities/0/involvements/0/date"),
         ]);
 
         TESTS_2_0.test_6_1_24.expect(ExpectedResults_2_0 {

--- a/csaf-rs/src/validations/test_6_1_24.rs
+++ b/csaf-rs/src/validations/test_6_1_24.rs
@@ -92,7 +92,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_24, test_6_1_24_mult
 mod tests {
     use super::*;
     use crate::csaf::types::csaf_datetime::CsafDateTime::{self, Invalid};
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_24 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_24 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -136,68 +138,60 @@ mod tests {
             case_s02_err.into_validation_error("/vulnerabilities/0/involvements/0/date"),
         ]);
 
-        TESTS_2_0.test_6_1_24.expect(
-            // case_01
-            Err(vec![
+        TESTS_2_0.test_6_1_24.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![
                 generate_duplicate_involvement_error(&default_date_csaf_20, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&default_date_csaf_20, &vendor, 0, 1),
             ]),
-            // case_02
-            Err(vec![
+            case_02: Err(vec![
                 generate_duplicate_involvement_error(&default_date_csaf_20, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&default_date_csaf_20, &vendor, 0, 1),
             ]),
-            case_s01.clone(),
-            case_s02.clone(),
-            // case_s03
-            Err(vec![
+            case_s01: case_s01.clone(),
+            case_s02: case_s02.clone(),
+            case_s03: Err(vec![
                 generate_duplicate_involvement_error(&alternate_date_csaf_20, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&alternate_date_csaf_20, &vendor, 0, 1),
             ]),
-            // case_s04
-            Err(vec![
+            case_s04: Err(vec![
                 generate_duplicate_involvement_error(&default_date_csaf_20, &discoverer, 0, 1),
                 generate_duplicate_involvement_error(&default_date_csaf_20, &discoverer, 0, 3),
                 generate_duplicate_involvement_error(&alternate_date_csaf_20, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&alternate_date_csaf_20, &vendor, 0, 2),
             ]),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_s11
-            Ok(()), // case_s12
-            Ok(()), // case_s13
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_24.expect(
-            // case_01
-            Err(vec![
+        TESTS_2_1.test_6_1_24.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![
                 generate_duplicate_involvement_error(&default_date_csaf_21, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&default_date_csaf_21, &vendor, 0, 1),
             ]),
-            // case_02
-            Err(vec![
+            case_02: Err(vec![
                 generate_duplicate_involvement_error(&default_date_csaf_21, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&default_date_csaf_21, &vendor, 0, 1),
             ]),
             case_s01,
             case_s02,
-            // case_s03
-            Err(vec![
+            case_s03: Err(vec![
                 generate_duplicate_involvement_error(&alternate_date_csaf_21, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&alternate_date_csaf_21, &vendor, 0, 1),
             ]),
-            // case_s04
-            Err(vec![
+            case_s04: Err(vec![
                 generate_duplicate_involvement_error(&default_date_csaf_21, &discoverer, 0, 1),
                 generate_duplicate_involvement_error(&default_date_csaf_21, &discoverer, 0, 3),
                 generate_duplicate_involvement_error(&alternate_date_csaf_21, &vendor, 0, 0),
                 generate_duplicate_involvement_error(&alternate_date_csaf_21, &vendor, 0, 2),
             ]),
-            Ok(()), // case_11
-            Ok(()), // case_12
-            Ok(()), // case_s11
-            Ok(()), // case_s12
-            Ok(()), // case_s13
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_25.rs
+++ b/csaf-rs/src/validations/test_6_1_25.rs
@@ -87,7 +87,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_25, test_6_1_25_mult
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_25 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_25 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -175,22 +177,22 @@ mod tests {
             ),
         ]);
 
-        TESTS_2_0.test_6_1_25.expect(
-            one_file_hash_two_hashes_same_algo.clone(),
-            three_elements_two_same_algo.clone(),
-            three_elements_all_same_algo.clone(),
-            two_elements_same_algo_different_casing,
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_1_25.expect(
-            one_file_hash_two_hashes_same_algo,
-            three_elements_two_same_algo,
-            three_elements_all_same_algo,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_25.expect(ExpectedResults_2_0 {
+            case_01: one_file_hash_two_hashes_same_algo.clone(),
+            case_s01: three_elements_two_same_algo.clone(),
+            case_s02: three_elements_all_same_algo.clone(),
+            case_s03: two_elements_same_algo_different_casing,
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
+        TESTS_2_1.test_6_1_25.expect(ExpectedResults_2_1 {
+            case_01: one_file_hash_two_hashes_same_algo,
+            case_s01: three_elements_two_same_algo,
+            case_s02: three_elements_all_same_algo,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_25.rs
+++ b/csaf-rs/src/validations/test_6_1_25.rs
@@ -2,7 +2,7 @@ use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
 use crate::csaf_traits::{
     CsafTrait, FileHashTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
 /// Test 6.1.25: Multiple Use of the Same Hash Algorithm
@@ -14,13 +14,13 @@ use std::collections::HashMap;
 /// `/product_tree/branches[](/branches[])*/product/product_identification_helper/hashes[]/file_hashes[]`
 /// `/product_tree/full_product_names[]/product_identification_helper/hashes[]/file_hashes[]`
 /// `/product_tree/relationships[]/full_product_name/product_identification_helper/hashes[]/file_hashes[]`
-pub fn test_6_1_25_multiple_use_of_same_hash_algorithm(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_25_multiple_use_of_same_hash_algorithm(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     // TODO: This can be a wasSkipped later
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(());
     };
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // Visit all products in the product tree
     product_tree.visit_all_products(&mut |product, path| {
         // Check all file_hashes in all hashes in all product identification helpers
@@ -67,19 +67,19 @@ fn test_6_1_25_err_generator(
     path: String,
     hash_i: String,
     file_hash_i: String,
-) -> ValidationError {
+) -> TestFinding {
     let message = match original_algo {
         Some(original) => format!(
             "Multiple use of the same hash algorithm '{normalized_algo}' (written as '{original}') in file_hashes"
         ),
         None => format!("Multiple use of the same hash algorithm '{normalized_algo}' in file_hashes"),
     };
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message,
         instance_path: format!(
             "{path}/product_identification_helper/hashes/{hash_i}/file_hashes/{file_hash_i}/algorithm"
         ),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_25, test_6_1_25_multiple_use_of_same_hash_algorithm);

--- a/csaf-rs/src/validations/test_6_1_26.rs
+++ b/csaf-rs/src/validations/test_6_1_26.rs
@@ -1,9 +1,9 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, CsafVersion, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.1.26 Prohibited Document Category Name
-pub fn test_6_1_26_prohibited_document_category(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_26_prohibited_document_category(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_version = doc.get_document().get_csaf_version();
     let doc_category = doc.get_document().get_category();
 
@@ -14,7 +14,7 @@ pub fn test_6_1_26_prohibited_document_category(doc: &impl CsafTrait) -> Result<
 fn validate_document_category(
     doc_category: &CsafDocumentCategory,
     doc_version: CsafVersion,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     // skip test for known profiles and categories
     if doc_category.is_known_profile(doc_version) {
         return Ok(());
@@ -45,26 +45,26 @@ fn validate_document_category(
 fn test_6_1_26_err_generator_starts_with_csaf(
     doc_category: &CsafDocumentCategory,
     version: CsafVersion,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document category '{doc_category}' is prohibited. Only the following values starting with 'csaf_' (or similar) are allowed: {}",
             CsafDocumentCategory::known_profile_concat(version)
         ),
         instance_path: "/document/category".to_string(),
-    }
+    })
 }
 
 fn test_6_1_26_err_generator_too_similar(
     doc_category: &CsafDocumentCategory,
     known_category: &CsafDocumentCategory,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document category '{doc_category}' is prohibited. It is too similar to the known category: {known_category}",
         ),
         instance_path: "/document/category".to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_26, test_6_1_26_prohibited_document_category);

--- a/csaf-rs/src/validations/test_6_1_26.rs
+++ b/csaf-rs/src/validations/test_6_1_26.rs
@@ -72,7 +72,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_26, test_6_1_26_proh
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_26 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_26 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -142,31 +144,31 @@ mod tests {
             CsafVersion::X20,
         )]);
 
-        TESTS_2_0.test_6_1_26.expect(
-            case_01_shared.clone(),
-            case_02_csaf20,
-            case_03_csaf20,
-            case_04_csaf20,
-            deprecated_sec_advisory_csaf20,
-            withdrawn_csaf20,
-            superseded_csaf20,
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_1_26.expect(
-            case_01_shared,
-            case_02_csaf21,
-            case_03_csaf21,
-            case_04_csaf21,
-            case_05_csaf21,
-            case_06_csaf21,
-            case_07_csaf21,
-            case_08_csaf21,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_26.expect(ExpectedResults_2_0 {
+            case_01: case_01_shared.clone(),
+            case_02: case_02_csaf20,
+            case_03: case_03_csaf20,
+            case_04: case_04_csaf20,
+            case_s01: deprecated_sec_advisory_csaf20,
+            case_s02: withdrawn_csaf20,
+            case_s03: superseded_csaf20,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_1_26.expect(ExpectedResults_2_1 {
+            case_01: case_01_shared,
+            case_02: case_02_csaf21,
+            case_03: case_03_csaf21,
+            case_04: case_04_csaf21,
+            case_05: case_05_csaf21,
+            case_06: case_06_csaf21,
+            case_07: case_07_csaf21,
+            case_08: case_08_csaf21,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 
     // Additional unit tests from the editorial version of CSAF 2.1

--- a/csaf-rs/src/validations/test_6_1_27_01.rs
+++ b/csaf-rs/src/validations/test_6_1_27_01.rs
@@ -1,16 +1,16 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
 use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_note_error(doc_category: CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_note_error(doc_category: CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{doc_category}' must have at least one document note with category 'description', 'details', 'general' or 'summary'"
         ),
         instance_path: "/document/notes".to_string(),
-    }
+    })
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConfig::new().shared(&[
@@ -25,7 +25,7 @@ const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConf
 ///
 /// Documents with these categories must have at least one entry in `/document/notes` with `category` values
 /// of `description`, `details`, `general` or `summary`.
-pub fn test_6_1_27_01_document_notes(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_01_document_notes(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_01.rs
+++ b/csaf-rs/src/validations/test_6_1_27_01.rs
@@ -61,7 +61,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_1, test_6_1_27_01
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_1 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_1 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -70,11 +72,11 @@ mod tests {
             CsafDocumentCategory::CsafSecurityIncidentResponse,
         )]);
 
-        TESTS_2_0
-            .test_6_1_27_1
-            .expect(case_security_incident_response_no_valid_note.clone());
-        TESTS_2_1
-            .test_6_1_27_1
-            .expect(case_security_incident_response_no_valid_note);
+        TESTS_2_0.test_6_1_27_1.expect(ExpectedResults_2_0 {
+            case_01: case_security_incident_response_no_valid_note.clone(),
+        });
+        TESTS_2_1.test_6_1_27_1.expect(ExpectedResults_2_1 {
+            case_01: case_security_incident_response_no_valid_note,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_02.rs
+++ b/csaf-rs/src/validations/test_6_1_27_02.rs
@@ -55,7 +55,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_2, test_6_1_27_02
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_2 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_2 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -64,7 +66,11 @@ mod tests {
             &CsafDocumentCategory::CsafInformationalAdvisory,
         )]);
 
-        TESTS_2_0.test_6_1_27_2.expect(case_informational_advisory.clone());
-        TESTS_2_1.test_6_1_27_2.expect(case_informational_advisory);
+        TESTS_2_0.test_6_1_27_2.expect(ExpectedResults_2_0 {
+            case_01: case_informational_advisory.clone(),
+        });
+        TESTS_2_1.test_6_1_27_2.expect(ExpectedResults_2_1 {
+            case_01: case_informational_advisory,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_02.rs
+++ b/csaf-rs/src/validations/test_6_1_27_02.rs
@@ -1,16 +1,16 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ReferenceTrait};
 use crate::schema::csaf2_1::schema::CategoryOfReference;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_external_reference_error(doc_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_external_reference_error(doc_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{doc_category}' must have at least one reference with category 'external'"
         ),
         instance_path: "/document/references".to_string(),
-    }
+    })
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConfig::new().shared(&[
@@ -24,7 +24,7 @@ const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConf
 /// or `csaf_security_incident_response`.
 ///
 /// Documents with these categories must have at least one entry in `/document/references` with an external reference.
-pub fn test_6_1_27_02_document_references(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_02_document_references(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_03.rs
+++ b/csaf-rs/src/validations/test_6_1_27_03.rs
@@ -1,13 +1,13 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_must_not_have_vuln_element_error(doc_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_must_not_have_vuln_element_error(doc_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Document with category '{doc_category}' must not have a '/vulnerabilities' element"),
         instance_path: "/vulnerabilities".to_string(),
-    }
+    })
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConfig::new()
@@ -24,7 +24,7 @@ const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConf
 /// value `csaf_withdrawn` and `csaf_superseded` for `/document/csaf_version` `2.1`.
 ///
 /// Documents with this category must not have a `/vulnerabilities` element.
-pub fn test_6_1_27_03_vulnerability(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_03_vulnerability(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
     // check if document has a relevant category for this test
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_03.rs
+++ b/csaf-rs/src/validations/test_6_1_27_03.rs
@@ -44,7 +44,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_3, test_6_1_27_03
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_3 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_3 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -58,14 +60,16 @@ mod tests {
         let case_superseded = Err(vec![create_must_not_have_vuln_element_error(
             &CsafDocumentCategory::CsafSuperseded,
         )]);
-        TESTS_2_0.test_6_1_27_3.expect(case_informational_advisory.clone());
-        TESTS_2_1.test_6_1_27_3.expect(
-            case_informational_advisory,
-            case_withdrawn,
-            case_superseded,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_27_3.expect(ExpectedResults_2_0 {
+            case_01: case_informational_advisory.clone(),
+        });
+        TESTS_2_1.test_6_1_27_3.expect(ExpectedResults_2_1 {
+            case_01: case_informational_advisory,
+            case_02: case_withdrawn,
+            case_03: case_superseded,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_04.rs
+++ b/csaf-rs/src/validations/test_6_1_27_04.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.4 Product Tree
@@ -10,7 +10,7 @@ use crate::validations::utils::document_category_test_config::DocumentCategoryTe
 /// value `csaf_deprecated_security_advisory` for `/document/csaf_version` `2.1`.
 ///
 /// Documents with this category must have a `/product_tree` element.
-pub fn test_6_1_27_04_product_tree(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_04_product_tree(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
@@ -32,11 +32,11 @@ const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConf
     ])
     .csaf21(&[CsafDocumentCategory::CsafDeprecatedSecurityAdvisory]);
 
-fn test_6_1_27_04_err_generator(document_category: CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn test_6_1_27_04_err_generator(document_category: CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Document with category '{document_category}' must have a '/product_tree' element"),
         instance_path: "/product_tree".to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_4, test_6_1_27_04_product_tree);

--- a/csaf-rs/src/validations/test_6_1_27_04.rs
+++ b/csaf-rs/src/validations/test_6_1_27_04.rs
@@ -44,7 +44,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_4, test_6_1_27_04
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_4 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_4 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -57,9 +59,13 @@ mod tests {
             CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
         )]);
 
-        TESTS_2_0.test_6_1_27_4.expect(case_security_advisory.clone());
-        TESTS_2_1
-            .test_6_1_27_4
-            .expect(case_security_advisory, case_vex, case_deprecated_security_advisory);
+        TESTS_2_0.test_6_1_27_4.expect(ExpectedResults_2_0 {
+            case_01: case_security_advisory.clone(),
+        });
+        TESTS_2_1.test_6_1_27_4.expect(ExpectedResults_2_1 {
+            case_01: case_security_advisory,
+            case_02: case_vex,
+            case_03: case_deprecated_security_advisory,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_05.rs
+++ b/csaf-rs/src/validations/test_6_1_27_05.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.5 Vulnerability Notes
@@ -10,14 +10,14 @@ use crate::validations::utils::document_category_test_config::DocumentCategoryTe
 /// value `csaf_deprecated_security_advisory` for `/document/csaf_version` `2.1`.
 ///
 /// Documents with these categories must have a `/vulnerabilities[]/notes` element.
-pub fn test_6_1_27_05_vulnerability_notes(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_05_vulnerability_notes(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // return error if there are vulnerabilities without notes
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if vulnerability.get_notes().is_none() {
@@ -37,13 +37,13 @@ const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConf
     ])
     .csaf21(&[CsafDocumentCategory::CsafDeprecatedSecurityAdvisory]);
 
-fn test_6_1_27_05_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> ValidationError {
-    ValidationError {
+fn test_6_1_27_05_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{document_category}' must have a notes element in each vulnerability"
         ),
         instance_path: format!("/vulnerabilities/{vuln_path_index}/notes"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_5, test_6_1_27_05_vulnerability_notes);
@@ -63,11 +63,10 @@ mod tests {
             &0,
         )]);
         let case_vex = Err(vec![test_6_1_27_05_err_generator(&CsafDocumentCategory::CsafVex, &0)]);
-        let case_deprecated_security_advisory: Result<(), Vec<ValidationError>> =
-            Err(vec![test_6_1_27_05_err_generator(
-                &CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
-                &0,
-            )]);
+        let case_deprecated_security_advisory: Result<(), Vec<TestFinding>> = Err(vec![test_6_1_27_05_err_generator(
+            &CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
+            &0,
+        )]);
 
         TESTS_2_0.test_6_1_27_5.expect(ExpectedResults_2_0 {
             case_01: case_security_advisory.clone(),

--- a/csaf-rs/src/validations/test_6_1_27_05.rs
+++ b/csaf-rs/src/validations/test_6_1_27_05.rs
@@ -51,7 +51,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_5, test_6_1_27_05
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_5 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_5 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -67,11 +69,14 @@ mod tests {
                 &0,
             )]);
 
-        TESTS_2_0
-            .test_6_1_27_5
-            .expect(case_security_advisory.clone(), case_vex.clone());
-        TESTS_2_1
-            .test_6_1_27_5
-            .expect(case_security_advisory, case_vex, case_deprecated_security_advisory);
+        TESTS_2_0.test_6_1_27_5.expect(ExpectedResults_2_0 {
+            case_01: case_security_advisory.clone(),
+            case_s01: case_vex.clone(),
+        });
+        TESTS_2_1.test_6_1_27_5.expect(ExpectedResults_2_1 {
+            case_01: case_security_advisory,
+            case_02: case_vex,
+            case_03: case_deprecated_security_advisory,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_06.rs
+++ b/csaf-rs/src/validations/test_6_1_27_06.rs
@@ -48,7 +48,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_6, test_6_1_27_06
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_6 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_6 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -62,11 +64,13 @@ mod tests {
             &0,
         )]);
 
-        TESTS_2_0.test_6_1_27_6.expect(case_security_advisory.clone());
-        TESTS_2_1.test_6_1_27_6.expect(
-            case_security_advisory.clone(),
-            case_security_advisory,
-            case_deprecated_security_advisory,
-        );
+        TESTS_2_0.test_6_1_27_6.expect(ExpectedResults_2_0 {
+            case_01: case_security_advisory.clone(),
+        });
+        TESTS_2_1.test_6_1_27_6.expect(ExpectedResults_2_1 {
+            case_01: case_security_advisory.clone(),
+            case_02: case_security_advisory,
+            case_03: case_deprecated_security_advisory,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_06.rs
+++ b/csaf-rs/src/validations/test_6_1_27_06.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.6 Product Status
@@ -10,14 +10,14 @@ use crate::validations::utils::document_category_test_config::DocumentCategoryTe
 /// value `csaf_deprecated_security_advisory` for `/document/csaf_version` `2.1`.
 ///
 /// Documents with these categories must have a `/vulnerabilities[]/product_status` element.
-pub fn test_6_1_27_06_product_status(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_06_product_status(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // return error if there are vulnerabilities without product_status
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if vulnerability.get_product_status().is_none() {
@@ -34,13 +34,13 @@ const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig = DocumentCategoryTestConf
     .shared(&[CsafDocumentCategory::CsafSecurityAdvisory])
     .csaf21(&[CsafDocumentCategory::CsafDeprecatedSecurityAdvisory]);
 
-fn test_6_1_27_06_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> ValidationError {
-    ValidationError {
+fn test_6_1_27_06_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{document_category}' must have a product_status element in each vulnerability"
         ),
         instance_path: format!("/vulnerabilities/{vuln_path_index}/product_status"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_6, test_6_1_27_06_product_status);

--- a/csaf-rs/src/validations/test_6_1_27_07.rs
+++ b/csaf-rs/src/validations/test_6_1_27_07.rs
@@ -51,14 +51,22 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_7, test_6_1_27_07
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_7 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_7 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_27_07() {
         let case_01 = Err(vec![test_6_1_27_07_err_generator(&CsafDocumentCategory::CsafVex, &0)]);
 
-        TESTS_2_0.test_6_1_27_7.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_1_27_7.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_1_27_7.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_27_7.expect(ExpectedResults_2_1 {
+            case_01,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_07.rs
+++ b/csaf-rs/src/validations/test_6_1_27_07.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.7 VEX Product Status
@@ -9,14 +9,14 @@ use crate::validations::utils::document_category_test_config::DocumentCategoryTe
 ///
 /// In documents with this category each `/vulnerabilities[]/product_status` must have at least one
 /// of the elements: `fixed`, `known_affected`, `known_not_affected` or `under_investigation`
-pub fn test_6_1_27_07_vex_product_status(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_07_vex_product_status(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category(&doc_category) {
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // return error if there are vulnerabilities without fixed, known_affected, known_not_affected or under_investigation in product_status
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(product_status) = vulnerability.get_product_status()
@@ -37,13 +37,13 @@ pub fn test_6_1_27_07_vex_product_status(doc: &impl CsafTrait) -> Result<(), Vec
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =
     DocumentCategoryTestConfig::new().shared(&[CsafDocumentCategory::CsafVex]);
 
-fn test_6_1_27_07_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> ValidationError {
-    ValidationError {
+fn test_6_1_27_07_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{document_category}' must provide at least one fixed, known_affected, known_unaffected or under_investigation product_status in each vulnerability"
         ),
         instance_path: format!("/vulnerabilities/{vuln_path_index}/product_status"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_7, test_6_1_27_07_vex_product_status);

--- a/csaf-rs/src/validations/test_6_1_27_08.rs
+++ b/csaf-rs/src/validations/test_6_1_27_08.rs
@@ -51,22 +51,25 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_8, test_6_1_27_08
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_8 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_8 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_27_08() {
         let case_vex_without_cve_or_id = Err(vec![test_6_1_27_08_err_generator(&CsafDocumentCategory::CsafVex, &0)]);
 
-        TESTS_2_0
-            .test_6_1_27_8
-            .expect(case_vex_without_cve_or_id.clone(), Ok(()));
-        TESTS_2_1.test_6_1_27_8.expect(
-            case_vex_without_cve_or_id,
-            Ok(()), // TODO: Adapt once check condition is implemented #694
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_27_8.expect(ExpectedResults_2_0 {
+            case_01: case_vex_without_cve_or_id.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_27_8.expect(ExpectedResults_2_1 {
+            case_01: case_vex_without_cve_or_id,
+            case_02: Ok(()), // TODO: Adapt once check condition is implemented #694
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_08.rs
+++ b/csaf-rs/src/validations/test_6_1_27_08.rs
@@ -1,6 +1,6 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 /// 6.1.27.8 Vulnerability ID
@@ -9,14 +9,14 @@ use crate::validations::utils::document_category_test_config::DocumentCategoryTe
 ///
 /// In documents with this category each `/vulnerabilities[]` item must have at the `cve` or the `ids`
 /// element.
-pub fn test_6_1_27_08_vulnerability_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_08_vulnerability_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category(&doc_category) {
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // return error if there are vulnerabilities without either cve or ids
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if vulnerability.get_cve().is_none() && vulnerability.get_ids().is_none() {
@@ -37,13 +37,13 @@ pub fn test_6_1_27_08_vulnerability_id(doc: &impl CsafTrait) -> Result<(), Vec<V
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =
     DocumentCategoryTestConfig::new().shared(&[CsafDocumentCategory::CsafVex]);
 
-fn test_6_1_27_08_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> ValidationError {
-    ValidationError {
+fn test_6_1_27_08_err_generator(document_category: &CsafDocumentCategory, vuln_path_index: &usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{document_category}' must provide at least either cve or ids in each vulnerability"
         ),
         instance_path: format!("/vulnerabilities/{vuln_path_index}/product_status"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_8, test_6_1_27_08_vulnerability_id);

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -115,7 +115,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_9, test_6_1_27_09
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_9 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_9 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -134,35 +136,35 @@ mod tests {
         let case_one_not_covered_by_threat_with_wrong_category =
             Err(vec![test_6_1_27_09_err_generator("CSAFPID-9080702".to_string(), 0, 2)]);
 
-        TESTS_2_0.test_6_1_27_9.expect(
-            case_group_covered_by_threats.clone(),
-            case_group_covered_by_flag.clone(),
-            case_products_covered_by_threats.clone(),
-            case_products_covered_by_flags.clone(),
-            case_products_covered_by_flags_or_threats.clone(),
-            case_one_not_covered_with_multiple_vulnerabilities.clone(),
-            case_one_not_covered_by_threat_with_wrong_category.clone(),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_1_27_9.expect(
-            case_group_covered_by_threats,
-            case_group_covered_by_flag,
-            case_products_covered_by_threats,
-            case_products_covered_by_flags,
-            case_products_covered_by_flags_or_threats,
-            case_one_not_covered_with_multiple_vulnerabilities,
-            case_one_not_covered_by_threat_with_wrong_category,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_27_9.expect(ExpectedResults_2_0 {
+            case_01: case_group_covered_by_threats.clone(),
+            case_02: case_group_covered_by_flag.clone(),
+            case_03: case_products_covered_by_threats.clone(),
+            case_04: case_products_covered_by_flags.clone(),
+            case_05: case_products_covered_by_flags_or_threats.clone(),
+            case_06: case_one_not_covered_with_multiple_vulnerabilities.clone(),
+            case_s01: case_one_not_covered_by_threat_with_wrong_category.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+        });
+        TESTS_2_1.test_6_1_27_9.expect(ExpectedResults_2_1 {
+            case_01: case_group_covered_by_threats,
+            case_02: case_group_covered_by_flag,
+            case_03: case_products_covered_by_threats,
+            case_04: case_products_covered_by_flags,
+            case_05: case_products_covered_by_flags_or_threats,
+            case_06: case_one_not_covered_with_multiple_vulnerabilities,
+            case_s01: case_one_not_covered_by_threat_with_wrong_category,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_09.rs
+++ b/csaf-rs/src/validations/test_6_1_27_09.rs
@@ -5,7 +5,7 @@ use crate::csaf_traits::{
     WithOptionalProductIds,
 };
 use crate::schema::csaf2_1::schema::CategoryOfTheThreat;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 use std::collections::{HashMap, HashSet};
 
@@ -16,7 +16,7 @@ use std::collections::{HashMap, HashSet};
 /// Each item in `/vulnerabilities[]/product_status/known_not_affected` must have a corresponding
 /// impact statement in `/vulnerabilities[]/flags` or `/vulnerabilities[]/threats`. For impact statements under
 /// `threats`, the category must be `impact`.
-pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
     let vulnerabilities = doc.get_vulnerabilities();
 
@@ -26,7 +26,7 @@ pub fn test_6_1_27_09_impact_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // for each vulnerability
     for (v_i, vulnerability) in vulnerabilities.iter().enumerate() {
         // generate hashmap of all known_not_affected product or group ids with value of known_not_affected path index
@@ -99,15 +99,15 @@ fn test_6_1_27_09_err_generator(
     product_or_group_id: String,
     vuln_path_index: usize,
     known_not_affected_path_index: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "No impact statement found for 'known_not_affected' product status entry '{product_or_group_id}'."
         ),
         instance_path: format!(
             "/vulnerabilities/{vuln_path_index}/product_status/known_not_affected/{known_not_affected_path_index}"
         ),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_9, test_6_1_27_09_impact_statement);

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -97,7 +97,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_10, test_6_1_27_1
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_10 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_10 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -112,19 +114,19 @@ mod tests {
             test_6_1_27_10_err_generator("CSAFPID-9080702".to_string(), 0, 2),
         ]);
 
-        TESTS_2_0.test_6_1_27_10.expect(
-            case_one_product_missing_from_group.clone(),
-            case_missing_remediation.clone(),
-            case_one_product_missing_from_products.clone(),
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_1_27_10.expect(
-            case_one_product_missing_from_group,
-            case_missing_remediation,
-            case_one_product_missing_from_products,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_27_10.expect(ExpectedResults_2_0 {
+            case_01: case_one_product_missing_from_group.clone(),
+            case_s01: case_missing_remediation.clone(),
+            case_s02: case_one_product_missing_from_products.clone(),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
+        TESTS_2_1.test_6_1_27_10.expect(ExpectedResults_2_1 {
+            case_01: case_one_product_missing_from_group,
+            case_s01: case_missing_remediation,
+            case_s02: case_one_product_missing_from_products,
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -1,7 +1,7 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::resolve_product_groups;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 use std::collections::{HashMap, HashSet};
 
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 /// Each item in `/vulnerabilities[]/product_status/known_affected` must have a corresponding
 /// action statement in `/vulnerabilities[]/remediations`
 ///
-pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
     let vulnerabilities = doc.get_vulnerabilities();
 
@@ -22,7 +22,7 @@ pub fn test_6_1_27_10_action_statement(doc: &impl CsafTrait) -> Result<(), Vec<V
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // for each vulnerability
     for (v_i, vulnerability) in vulnerabilities.iter().enumerate() {
         // generate hashmap of all known_affected product or group ids with value of known_not_affected path index
@@ -81,15 +81,15 @@ fn test_6_1_27_10_err_generator(
     product_or_group_id: String,
     vuln_path_index: usize,
     known_affected_path_index: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "No action statement found for 'known_affected' product status entry '{product_or_group_id}'."
         ),
         instance_path: format!(
             "/vulnerabilities/{vuln_path_index}/product_status/known_affected/{known_affected_path_index}"
         ),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_1_27_10, test_6_1_27_10_action_statement);

--- a/csaf-rs/src/validations/test_6_1_27_11.rs
+++ b/csaf-rs/src/validations/test_6_1_27_11.rs
@@ -1,13 +1,13 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_vulnerabilities_error(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_vulnerabilities_error(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Document with category '{document_category}' must have a '/vulnerabilities' element"),
         instance_path: "/vulnerabilities".to_string(),
-    }
+    })
 }
 
 /// 6.1.27.11 Vulnerabilities
@@ -17,7 +17,7 @@ fn create_missing_vulnerabilities_error(document_category: &CsafDocumentCategory
 /// value `csaf_deprecated_security_advisory` for `/document/csaf_version` `2.1`.
 ///
 /// In documents with this category a `/vulnerabilities[]` element must exist.
-pub fn test_6_1_27_11_vulnerabilities(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_11_vulnerabilities(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_11.rs
+++ b/csaf-rs/src/validations/test_6_1_27_11.rs
@@ -43,7 +43,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_27_11, test_6_1_27_1
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_27_11 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_11 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -58,16 +60,19 @@ mod tests {
             &CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
         )]);
 
-        TESTS_2_0
-            .test_6_1_27_11
-            .expect(case_security_advisory.clone(), case_vex.clone(), Ok(()), Ok(()));
+        TESTS_2_0.test_6_1_27_11.expect(ExpectedResults_2_0 {
+            case_01: case_security_advisory.clone(),
+            case_s01: case_vex.clone(),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_27_11.expect(
-            case_security_advisory,
-            case_vex,
-            case_deprecated_security_advisory,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_27_11.expect(ExpectedResults_2_1 {
+            case_01: case_security_advisory,
+            case_02: case_vex,
+            case_03: case_deprecated_security_advisory,
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_12.rs
+++ b/csaf-rs/src/validations/test_6_1_27_12.rs
@@ -52,6 +52,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_27_12, test
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_12 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -65,12 +66,12 @@ mod tests {
             create_missing_affected_products_error(&CsafDocumentCategory::CsafSecurityAdvisory, 1),
         ]);
 
-        TESTS_2_1.test_6_1_27_12.expect(
-            case_security_advisory_missing_affected.clone(),
-            case_security_advisory_missing_affected,
-            case_security_advisory_two_vulnerabilities_missing_affected,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_27_12.expect(ExpectedResults {
+            case_01: case_security_advisory_missing_affected.clone(),
+            case_s01: case_security_advisory_missing_affected,
+            case_s02: case_security_advisory_two_vulnerabilities_missing_affected,
+            case_11: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_12.rs
+++ b/csaf-rs/src/validations/test_6_1_27_12.rs
@@ -1,18 +1,18 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
 fn create_missing_affected_products_error(
     document_category: &CsafDocumentCategory,
     vulnerability_index: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category '{document_category}' must have a '/vulnerabilities[]/product_status/known_affected' element"
         ),
         instance_path: format!("/vulnerabilities[{vulnerability_index}]/product_status/known_affected"),
-    }
+    })
 }
 
 /// 6.1.27.12 Affected Products
@@ -20,14 +20,14 @@ fn create_missing_affected_products_error(
 /// This test only applies to documents with `/document/category` with value `csaf_security_advisory`.
 ///
 /// For each item in `/vulnerabilities[]` it MUST be tested that the element `product_status/known_affected` exists.
-pub fn test_6_1_27_12_affected_products(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_12_affected_products(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
         return Ok(()); // ToDo generate skipped https://github.com/csaf-rs/csaf/issues/409
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     let vulnerabilities = doc.get_vulnerabilities();
     for (v_i, vulnerability) in vulnerabilities.iter().enumerate() {
         if vulnerability

--- a/csaf-rs/src/validations/test_6_1_27_14.rs
+++ b/csaf-rs/src/validations/test_6_1_27_14.rs
@@ -52,6 +52,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_14 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -63,8 +64,12 @@ mod tests {
             &CsafDocumentCategory::CsafSuperseded,
         )]);
 
-        TESTS_2_1
-            .test_6_1_27_14
-            .expect(fail_withdrawn.clone(), fail_superseded, fail_withdrawn, Ok(()), Ok(()));
+        TESTS_2_1.test_6_1_27_14.expect(ExpectedResults {
+            case_01: fail_withdrawn.clone(),
+            case_02: fail_superseded,
+            case_s01: fail_withdrawn,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_14.rs
+++ b/csaf-rs/src/validations/test_6_1_27_14.rs
@@ -1,16 +1,16 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
 use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_description_note(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_description_note(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document does not contain a note with category `description` which is required for documents with category {document_category}"
         ),
         instance_path: "/document/notes".to_string(),
-    }
+    })
 }
 
 /// 6.1.27.14 Document Notes
@@ -18,7 +18,7 @@ fn create_missing_description_note(document_category: &CsafDocumentCategory) -> 
 /// This test only applies to documents with `/document/category` with value `csaf_withdrawn` or `csaf_superseded`.
 ///
 /// There must be at least one item in `/document/notes[]` with category `description`.
-pub fn test_6_1_27_14_document_notes_with_description(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_14_document_notes_with_description(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_15.rs
+++ b/csaf-rs/src/validations/test_6_1_27_15.rs
@@ -1,15 +1,15 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_product_tree_exists_error(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_product_tree_exists_error(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document contains a product tree which is prohibited for documents with category {document_category}"
         ),
         instance_path: "/product_tree".to_string(),
-    }
+    })
 }
 
 /// 6.1.27.15 Product tree
@@ -17,7 +17,7 @@ fn create_product_tree_exists_error(document_category: &CsafDocumentCategory) ->
 /// This test only applies to documents with `/document/category` with value `csaf_withdrawn` or `csaf_superseded`.
 ///
 /// An item `/product_tree` shall not exist.
-pub fn test_6_1_27_15_product_tree(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_15_product_tree(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_15.rs
+++ b/csaf-rs/src/validations/test_6_1_27_15.rs
@@ -40,6 +40,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_27_15, test
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_15 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -52,8 +53,11 @@ mod tests {
         )]);
         // Case 11: category csaf_withdrawn, no product tree
         // Case 12: category csaf_superseded, no product tree
-        TESTS_2_1
-            .test_6_1_27_15
-            .expect(fail_withdrawn, fail_superseded, Ok(()), Ok(()));
+        TESTS_2_1.test_6_1_27_15.expect(ExpectedResults {
+            case_01: fail_withdrawn,
+            case_02: fail_superseded,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_16.rs
+++ b/csaf-rs/src/validations/test_6_1_27_16.rs
@@ -1,15 +1,15 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_revision_history_only_one_entry_error(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_revision_history_only_one_entry_error(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The revision history contains only one entry which is prohibited for documents with category {document_category}"
         ),
         instance_path: "/document/tracking/revision_history".to_string(),
-    }
+    })
 }
 
 /// 6.1.27.16 Revision history
@@ -17,7 +17,7 @@ fn create_revision_history_only_one_entry_error(document_category: &CsafDocument
 /// This test only applies to documents with `/document/category` with value `csaf_withdrawn` or `csaf_superseded`.
 ///
 /// The revision history shall not contain only one entry.
-pub fn test_6_1_27_16_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_16_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {

--- a/csaf-rs/src/validations/test_6_1_27_16.rs
+++ b/csaf-rs/src/validations/test_6_1_27_16.rs
@@ -40,6 +40,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_27_16, test
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_16 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -54,8 +55,13 @@ mod tests {
         // Case 12: document status is final, category is csaf_withdrawn, two revision history elements
         // Case 13: document status is final, category is csaf_superseded, two revision history elements
         // Case 14: document status is draft, category is csaf_superseded, two revision history elements, one of which is a draft
-        TESTS_2_1
-            .test_6_1_27_16
-            .expect(fail_withdrawn, fail_superseded, Ok(()), Ok(()), Ok(()), Ok(()));
+        TESTS_2_1.test_6_1_27_16.expect(ExpectedResults {
+            case_01: fail_withdrawn,
+            case_02: fail_superseded,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_17.rs
+++ b/csaf-rs/src/validations/test_6_1_27_17.rs
@@ -2,32 +2,32 @@ use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
 use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document does not contain a note with title `Reasoning for Withdrawal` and category `description`  which is required for documents with category {document_category}"
         ),
         instance_path: "/document/notes".to_string(),
-    }
+    })
 }
 
-fn create_duplicated_reasoning_error(document_category: &CsafDocumentCategory, note_index: usize) -> ValidationError {
-    ValidationError {
+fn create_duplicated_reasoning_error(document_category: &CsafDocumentCategory, note_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Duplicate note with title `Reasoning for Withdrawal` found while only one is allowed for documents with category {document_category}"
         ),
         instance_path: format!("/document/notes[{note_index}]"),
-    }
+    })
 }
 
-fn create_incorrect_category_error(note_index: usize) -> ValidationError {
-    ValidationError {
+fn create_incorrect_category_error(note_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "The note has the correct title. However it uses the wrong category.".to_string(),
         instance_path: format!("/document/notes[{note_index}]"),
-    }
+    })
 }
 
 /// 6.1.27.17 Reasoning for withdrawal
@@ -36,7 +36,7 @@ fn create_incorrect_category_error(note_index: usize) -> ValidationError {
 ///
 /// If the document language is English or unspecified, it MUST be tested that exactly one item in document notes exists that has the title Reasoning for Withdrawal.
 /// The category of this item MUST be description.
-pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
@@ -49,7 +49,7 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
         None => {},    // no language set
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     let mut withdrawals = Vec::new();
 
     if let Some(notes) = doc.get_document().get_notes() {

--- a/csaf-rs/src/validations/test_6_1_27_17.rs
+++ b/csaf-rs/src/validations/test_6_1_27_17.rs
@@ -92,6 +92,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_17 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -105,17 +106,17 @@ mod tests {
         let undefined_lang_missing_reasoning = Err(vec![create_missing_reasoning_error(
             &CsafDocumentCategory::CsafWithdrawn,
         )]);
-        TESTS_2_1.test_6_1_27_17.expect(
-            undefined_lang_wrong_category.clone(),
-            undefined_lang_duplicate_title.clone(),
-            undefined_lang_wrong_category,
-            undefined_lang_duplicate_title,
-            lang_en_us_wrong_category,
-            undefined_lang_missing_reasoning.clone(),
-            undefined_lang_missing_reasoning,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_27_17.expect(ExpectedResults {
+            case_01: undefined_lang_wrong_category.clone(),
+            case_02: undefined_lang_duplicate_title.clone(),
+            case_03: undefined_lang_wrong_category,
+            case_04: undefined_lang_duplicate_title,
+            case_05: lang_en_us_wrong_category,
+            case_s01: undefined_lang_missing_reasoning.clone(),
+            case_s02: undefined_lang_missing_reasoning,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_18.rs
+++ b/csaf-rs/src/validations/test_6_1_27_18.rs
@@ -92,6 +92,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_18 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -105,17 +106,17 @@ mod tests {
         let lang_en_gb_missing_reasoning = Err(vec![create_missing_reasoning_error(
             &CsafDocumentCategory::CsafSuperseded,
         )]);
-        TESTS_2_1.test_6_1_27_18.expect(
-            undefined_lang_wrong_category.clone(),
-            undefined_lang_duplicate_title.clone(),
-            undefined_lang_wrong_category,
-            undefined_lang_duplicate_title,
-            lang_en_us_wrong_category,
-            lang_en_gb_missing_reasoning.clone(),
-            lang_en_gb_missing_reasoning,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_27_18.expect(ExpectedResults {
+            case_01: undefined_lang_wrong_category.clone(),
+            case_02: undefined_lang_duplicate_title.clone(),
+            case_03: undefined_lang_wrong_category,
+            case_04: undefined_lang_duplicate_title,
+            case_05: lang_en_us_wrong_category,
+            case_s01: lang_en_gb_missing_reasoning.clone(),
+            case_s02: lang_en_gb_missing_reasoning,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_27_18.rs
+++ b/csaf-rs/src/validations/test_6_1_27_18.rs
@@ -2,32 +2,32 @@ use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
 use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The document does not contain a note with title `Reasoning for Withdrawal` and category `description`  which is required for documents with category {document_category}"
         ),
         instance_path: "/document/notes".to_string(),
-    }
+    })
 }
 
-fn create_duplicated_reasoning_error(document_category: &CsafDocumentCategory, note_index: usize) -> ValidationError {
-    ValidationError {
+fn create_duplicated_reasoning_error(document_category: &CsafDocumentCategory, note_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Duplicate note with title `Reasoning for Withdrawal` found while only one is allowed for documents with category {document_category}"
         ),
         instance_path: format!("/document/notes[{note_index}]"),
-    }
+    })
 }
 
-fn create_incorrect_category_error(note_index: usize) -> ValidationError {
-    ValidationError {
+fn create_incorrect_category_error(note_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "The note has the correct title. However it uses the wrong category.".to_string(),
         instance_path: format!("/document/notes[{note_index}]"),
-    }
+    })
 }
 
 /// 6.1.27.18 Reasoning for supersession
@@ -36,7 +36,7 @@ fn create_incorrect_category_error(note_index: usize) -> ValidationError {
 ///
 /// If the document language is English or unspecified, it MUST be tested that exactly one item in document notes exists that has the title Reasoning for Supersession.
 /// The category of this item MUST be description.
-pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
@@ -49,7 +49,7 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
         None => {},    // no language set
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     let mut supersessions = Vec::new();
 
     if let Some(notes) = doc.get_document().get_notes() {

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -2,23 +2,23 @@ use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ReferenceTrait};
 use crate::schema::csaf2_1::schema::CategoryOfReference;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_missing_reference_error(document_category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_missing_reference_error(document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Document with category `{document_category}' must have at least one reference whose summary starts with `Superseding Document` and has the category `external`"
         ),
         instance_path: "/document/references".to_string(),
-    }
+    })
 }
 
-fn create_incorrect_category_error(reference_index: usize) -> ValidationError {
-    ValidationError {
+fn create_incorrect_category_error(reference_index: usize) -> TestFinding {
+    TestFinding::Error ( TestFindingData {
         message: "The reference summary starts with the correct string \"Superseding Document\". However it uses the wrong category.".to_string(),
         instance_path: format!("/document/references/{reference_index}"),
-    }
+    })
 }
 
 /// 6.1.27.19 Reference to superseding document
@@ -27,7 +27,7 @@ fn create_incorrect_category_error(reference_index: usize) -> ValidationError {
 ///
 /// It MUST be tested that at least one item in document references exists that has a summary starting with "Superseding Document".
 /// The category of this item MUST be external.
-pub fn test_6_1_27_19_reference_to_superseding_document(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_27_19_reference_to_superseding_document(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let doc_category = doc.get_document().get_category();
 
     if !PROFILE_TEST_CONFIG.matches_category_with_csaf_version(doc.get_document().get_csaf_version(), &doc_category) {
@@ -41,7 +41,7 @@ pub fn test_6_1_27_19_reference_to_superseding_document(doc: &impl CsafTrait) ->
     }
 
     let mut has_external_reference_with_correct_summary = false;
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // Check for summary starting with "Superseding Document" and category external
     if let Some(references) = doc.get_document().get_references() {
         for (r_i, reference) in references.iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -86,6 +86,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_27_19 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -94,15 +95,15 @@ mod tests {
         let lang_en_missing_category = Err(vec![create_missing_reference_error(
             &CsafDocumentCategory::CsafSuperseded,
         )]);
-        TESTS_2_1.test_6_1_27_19.expect(
-            undefined_lang_wrong_category.clone(),
-            Ok(()), // ToDo this test case is currently marked as failing, but the data is valid see https://github.com/oasis-tcs/csaf/issues/1359
-            undefined_lang_wrong_category,
-            lang_en_missing_category,
-            Ok(()), // lang: unspecified, single correct reference
-            Ok(()), // lang: en-us, multiple correct references
-            Ok(()), // lang: de-DE is ignored
-            Ok(()), // lang: en-us, wrong category
-        );
+        TESTS_2_1.test_6_1_27_19.expect(ExpectedResults {
+            case_01: undefined_lang_wrong_category.clone(),
+            case_02: Ok(()), // ToDo this test case is currently marked as failing, but the data is valid see https://github.com/oasis-tcs/csaf/issues/1359
+            case_s01: undefined_lang_wrong_category,
+            case_s02: lang_en_missing_category,
+            case_11: Ok(()),  // lang: unspecified, single correct reference
+            case_12: Ok(()),  // lang: en-us, multiple correct references
+            case_13: Ok(()),  // lang: de-DE is ignored
+            case_s11: Ok(()), // lang: en-us, wrong category
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_28.rs
+++ b/csaf-rs/src/validations/test_6_1_28.rs
@@ -33,7 +33,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_28, test_6_1_28_tran
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_28 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_28 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -47,11 +49,15 @@ mod tests {
 
         // Case 11: /document/lang and /document/source_lang are set to different values
 
-        TESTS_2_0
-            .test_6_1_28
-            .expect(case_01_same_value.clone(), case_s01_default_casing.clone(), Ok(()));
-        TESTS_2_1
-            .test_6_1_28
-            .expect(case_01_same_value, case_s01_default_casing, Ok(()));
+        TESTS_2_0.test_6_1_28.expect(ExpectedResults_2_0 {
+            case_01: case_01_same_value.clone(),
+            case_s01: case_s01_default_casing.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_28.expect(ExpectedResults_2_1 {
+            case_01: case_01_same_value,
+            case_s01: case_s01_default_casing,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_28.rs
+++ b/csaf-rs/src/validations/test_6_1_28.rs
@@ -1,18 +1,18 @@
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_same_language_error(lang: &CsafLanguage) -> ValidationError {
-    ValidationError {
+fn create_same_language_error(lang: &CsafLanguage) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("document language and source language have the same value '{lang}'"),
         instance_path: "/document/source_lang".to_string(),
-    }
+    })
 }
 
 /// 6.1.28 Translation
 ///
 /// `/document/lang` and `/document/source_lang` must have different values
-pub fn test_6_1_28_translation(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_28_translation(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     // Check if both lang and source_lang are present

--- a/csaf-rs/src/validations/test_6_1_29.rs
+++ b/csaf-rs/src/validations/test_6_1_29.rs
@@ -1,17 +1,17 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait, WithOptionalGroupIds, WithOptionalProductIds};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_missing_product_reference_error(vulnerability_index: usize, remediation_index: usize) -> ValidationError {
-    ValidationError {
+fn create_missing_product_reference_error(vulnerability_index: usize, remediation_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "A remediation needs to at least have one of the elements group_ids or product_ids".to_string(),
         instance_path: format!("/vulnerabilities/{vulnerability_index}/remediations/{remediation_index}"),
-    }
+    })
 }
 
 /// 6.1.29 Remediation without Product Reference
 ///
 /// Each item in `/vulnerabilities[]/remediations[]` must have at least one of the elements group_ids or product_ids.
-pub fn test_6_1_29_remediation_without_product_reference(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_29_remediation_without_product_reference(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
 
     // Check if there are vulnerability, if not, this test can be skipped
@@ -20,7 +20,7 @@ pub fn test_6_1_29_remediation_without_product_reference(doc: &impl CsafTrait) -
         return Ok(());
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // Check vulnerabilities and each remediation in them
     for (vuln_i, vulnerability) in vulnerabilities.iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_29.rs
+++ b/csaf-rs/src/validations/test_6_1_29.rs
@@ -46,7 +46,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_29 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_29 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -66,11 +68,21 @@ mod tests {
         // Case S12: A remediation with both group_ids and product_ids
 
         // Both CSAF 2.0 and 2.1 have 6 test cases
-        TESTS_2_0
-            .test_6_1_29
-            .expect(case_01.clone(), case_s01.clone(), Ok(()), Ok(()), Ok(()), Ok(()));
-        TESTS_2_1
-            .test_6_1_29
-            .expect(case_01, case_s01, Ok(()), Ok(()), Ok(()), Ok(()));
+        TESTS_2_0.test_6_1_29.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_s01: case_s01.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
+        TESTS_2_1.test_6_1_29.expect(ExpectedResults_2_1 {
+            case_01,
+            case_s01,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_30.rs
+++ b/csaf-rs/src/validations/test_6_1_30.rs
@@ -66,7 +66,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_30 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_30 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -77,19 +79,19 @@ mod tests {
             create_mixed_versioning_error("revision_history"),
         ]);
 
-        TESTS_2_0.test_6_1_30.expect(
-            case_inconsistent_history_and_mismatch_to_document.clone(),
-            case_consistent_history_mismatch_to_document.clone(),
-            case_consistent_history_mismatch_to_document.clone(),
-            Ok(()), // only semver versioning
-            Ok(()), // only intver versioning
-        );
-        TESTS_2_1.test_6_1_30.expect(
-            case_inconsistent_history_and_mismatch_to_document,
-            case_consistent_history_mismatch_to_document.clone(),
-            case_consistent_history_mismatch_to_document,
-            Ok(()), // only semver versioning
-            Ok(()), // only intver versioning
-        );
+        TESTS_2_0.test_6_1_30.expect(ExpectedResults_2_0 {
+            case_01: case_inconsistent_history_and_mismatch_to_document.clone(),
+            case_s01: case_consistent_history_mismatch_to_document.clone(),
+            case_s02: case_consistent_history_mismatch_to_document.clone(),
+            case_11: Ok(()),  // only semver versioning
+            case_s11: Ok(()), // only intver versioning
+        });
+        TESTS_2_1.test_6_1_30.expect(ExpectedResults_2_1 {
+            case_01: case_inconsistent_history_and_mismatch_to_document,
+            case_s01: case_consistent_history_mismatch_to_document.clone(),
+            case_s02: case_consistent_history_mismatch_to_document,
+            case_11: Ok(()),  // only semver versioning
+            case_s11: Ok(()), // only intver versioning
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_30.rs
+++ b/csaf-rs/src/validations/test_6_1_30.rs
@@ -1,22 +1,22 @@
 use crate::csaf::types::version_number::CsafVersionNumber;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_mixed_versioning_error(part: &str) -> ValidationError {
-    ValidationError {
+fn create_mixed_versioning_error(part: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "mixed integer and semantic versioning used".to_string(),
         instance_path: format!("/document/tracking/{part}"),
-    }
+    })
 }
 
 /// 6.1.30 Mixed Integer and Semantic Versioning
 ///
 /// `/document/tracking/version` and `document/tracking/revision_history[]/number` need to use
 /// the same versioning scheme (either integer versioning or semantic versioning) across the document.
-pub fn test_6_1_30_mixed_integer_and_semantic_versioning(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_30_mixed_integer_and_semantic_versioning(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let tracking = doc.get_document().get_tracking();
     // make sure revision history is consistent in itself
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     let rev_history_tuples = tracking.aggregate_revision_history();
     let mut semver_count = 0;

--- a/csaf-rs/src/validations/test_6_1_31.rs
+++ b/csaf-rs/src/validations/test_6_1_31.rs
@@ -114,7 +114,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_31 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_31 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -192,45 +194,45 @@ mod tests {
         // Case S11: Keyword "all" as part of word "overall" (backport for CSAF 2.0, CSAF 2.1 has this as Case 13)
         // Case S12: Just a valid branch name "2.0"
 
-        TESTS_2_0.test_6_1_31.expect(
-            case_01_prior.clone(),
-            case_02_less_than.clone(),
-            case_03_less_equal.clone(),
-            case_04_less_equal_space.clone(),
-            case_05_earlier.clone(),
-            case_06_all.clone(),
-            case_07_before.clone(),
-            case_08_later.clone(),
-            case_09_versions.clone(),
-            case_s01_all_uppercase.clone(),
-            case_s02_greater_than.clone(),
-            case_s03_greater_equal.clone(),
-            case_s04_multiple.clone(),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_1_31.expect(ExpectedResults_2_0 {
+            case_01: case_01_prior.clone(),
+            case_02: case_02_less_than.clone(),
+            case_03: case_03_less_equal.clone(),
+            case_04: case_04_less_equal_space.clone(),
+            case_05: case_05_earlier.clone(),
+            case_06: case_06_all.clone(),
+            case_07: case_07_before.clone(),
+            case_08: case_08_later.clone(),
+            case_09: case_09_versions.clone(),
+            case_s01: case_s01_all_uppercase.clone(),
+            case_s02: case_s02_greater_than.clone(),
+            case_s03: case_s03_greater_equal.clone(),
+            case_s04: case_s04_multiple.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
 
-        TESTS_2_1.test_6_1_31.expect(
-            case_01_prior,
-            case_02_less_than,
-            case_03_less_equal,
-            case_04_less_equal_space,
-            case_05_earlier,
-            case_06_all,
-            case_07_before,
-            case_08_later,
-            case_09_versions,
-            case_s01_all_uppercase,
-            case_s02_greater_than,
-            case_s03_greater_equal,
-            case_s04_multiple,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_31.expect(ExpectedResults_2_1 {
+            case_01: case_01_prior,
+            case_02: case_02_less_than,
+            case_03: case_03_less_equal,
+            case_04: case_04_less_equal_space,
+            case_05: case_05_earlier,
+            case_06: case_06_all,
+            case_07: case_07_before,
+            case_08: case_08_later,
+            case_09: case_09_versions,
+            case_s01: case_s01_all_uppercase,
+            case_s02: case_s02_greater_than,
+            case_s03: case_s03_greater_equal,
+            case_s04: case_s04_multiple,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 
     // Additional tests for the helper function `check_branch_name_for_forbidden_substrings`.

--- a/csaf-rs/src/validations/test_6_1_31.rs
+++ b/csaf-rs/src/validations/test_6_1_31.rs
@@ -1,12 +1,12 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
 fn create_forbidden_strings_in_version_error(
     product_name: &str,
     forbidden_substrings: Vec<&str>,
     product_path: &str,
-) -> ValidationError {
+) -> TestFinding {
     let forbidden_substrings_str: String = {
         if forbidden_substrings.len() > 1 {
             format!("substrings '{}'", forbidden_substrings.join("', '"))
@@ -14,10 +14,10 @@ fn create_forbidden_strings_in_version_error(
             format!("substring '{}'", forbidden_substrings[0])
         }
     };
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!("Product version '{product_name}' contains forbidden {forbidden_substrings_str}"),
         instance_path: format!("{product_path}/name"),
-    }
+    })
 }
 const FORBIDDEN_LESS_EQUAL: &str = "<=";
 const FORBIDDEN_GREATER_EQUAL: &str = ">=";
@@ -79,14 +79,12 @@ fn check_branch_name_for_forbidden_substrings(branch_name: &str) -> Option<Vec<&
 /// tokenized by whitespace in their branch `name`.
 /// `<=` and `>=` are prioritized before `<` and `>` respectively.
 /// The error contains all unique offending operators and keywords.
-pub fn test_6_1_31_version_range_in_product_version_branch_name(
-    doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_31_version_range_in_product_version_branch_name(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(());
     };
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     product_tree.visit_all_branches(&mut |branch, path| {
         if branch.get_category() == CategoryOfTheBranch::ProductVersion {

--- a/csaf-rs/src/validations/test_6_1_32.rs
+++ b/csaf-rs/src/validations/test_6_1_32.rs
@@ -44,7 +44,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_1_32, test_6_1_32_flag
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_32 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_32 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -63,11 +65,21 @@ mod tests {
         // Case S12: A flag with both product_ids and group_ids
         // Case S13: A vulnerability without a flag
 
-        TESTS_2_0
-            .test_6_1_32
-            .expect(case_01.clone(), case_s01.clone(), Ok(()), Ok(()), Ok(()), Ok(()));
-        TESTS_2_1
-            .test_6_1_32
-            .expect(case_01, case_s01, Ok(()), Ok(()), Ok(()), Ok(()));
+        TESTS_2_0.test_6_1_32.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_s01: case_s01.clone(),
+            case_11: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
+        TESTS_2_1.test_6_1_32.expect(ExpectedResults_2_1 {
+            case_01,
+            case_s01,
+            case_11: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+            case_s13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_32.rs
+++ b/csaf-rs/src/validations/test_6_1_32.rs
@@ -1,17 +1,17 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait, WithOptionalGroupIds, WithOptionalProductIds};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_flag_without_product_reference_error(vulnerability_index: usize, flag_index: usize) -> ValidationError {
-    ValidationError {
+fn create_flag_without_product_reference_error(vulnerability_index: usize, flag_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "A flag must have at least one of the elements group_ids or product_ids".to_string(),
         instance_path: format!("/vulnerabilities/{vulnerability_index}/flags/{flag_index}"),
-    }
+    })
 }
 
 /// 6.1.32 Flag without Product Reference
 ///
 /// Each `/vulnerabilities[]/flags[]` must have at least one of the elements group_ids or product_ids.
-pub fn test_6_1_32_flag_without_product_reference(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_32_flag_without_product_reference(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
 
     // Check if there are any vulnerabilities, if there aren't, this test can be skipped
@@ -20,7 +20,7 @@ pub fn test_6_1_32_flag_without_product_reference(doc: &impl CsafTrait) -> Resul
         return Ok(());
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // Check each flag in each vulnerability
     for (vuln_i, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(flags) = vulnerability.get_flags() {

--- a/csaf-rs/src/validations/test_6_1_33.rs
+++ b/csaf-rs/src/validations/test_6_1_33.rs
@@ -1,13 +1,13 @@
 use crate::csaf_traits::resolve_product_groups;
 use crate::csaf_traits::{CsafTrait, FlagTrait, VulnerabilityTrait, WithOptionalGroupIds, WithOptionalProductIds};
 use crate::schema::csaf2_1::schema::LabelOfTheFlag;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
 type VexJustificationInfo = (LabelOfTheFlag, usize, Option<String>);
 /// 6.1.33 Multiple Flags with VEX Justification Codes per Product
-pub fn test_6_1_33_multiple_flags_with_vex_codes_per_product(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_33_multiple_flags_with_vex_codes_per_product(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // Check each flag in each vulnerability
     for (vuln_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
@@ -78,7 +78,7 @@ fn test_6_1_33_err_generator(
     group_id: Option<String>,
     vuln_i: usize,
     flag_i: usize,
-) -> ValidationError {
+) -> TestFinding {
     // sort labels and join them with ', ' for error message
     let labels_joined = {
         let mut labels_str: Vec<_> = labels.iter().map(|l| l.to_string()).collect();
@@ -93,12 +93,12 @@ fn test_6_1_33_err_generator(
             "".to_string()
         }
     };
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Product '{product_id}' is associated with multiple flag labels: [{labels_joined}] {group_id_str}, it has flag label {label} on this path"
         ),
         instance_path: format!("/vulnerabilities/{vuln_i}/flags/{flag_i}"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(

--- a/csaf-rs/src/validations/test_6_1_33.rs
+++ b/csaf-rs/src/validations/test_6_1_33.rs
@@ -109,7 +109,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_1_33 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_33 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -138,7 +140,13 @@ mod tests {
                 1,
             ),
         ]);
-        TESTS_2_0.test_6_1_33.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_1_33.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_1_33.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_1_33.expect(ExpectedResults_2_1 {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_34.rs
+++ b/csaf-rs/src/validations/test_6_1_34.rs
@@ -32,6 +32,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_34, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_34 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -59,11 +60,11 @@ mod tests {
                 /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0/branches/0\
                 /branches/0/branches/0/branches/0/branches/0/branches/0/branches/0",
         )]);
-        TESTS_2_1.test_6_1_34.expect(
-            one_too_long_branch_error,
-            more_complex_too_long_branch_error,
-            two_too_long_branches_error,
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_34.expect(ExpectedResults {
+            case_01: one_too_long_branch_error,
+            case_02: more_complex_too_long_branch_error,
+            case_s01: two_too_long_branches_error,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_34.rs
+++ b/csaf-rs/src/validations/test_6_1_34.rs
@@ -1,22 +1,22 @@
 use crate::csaf_traits::{BranchTrait, CsafTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 static MAX_DEPTH: u32 = 30;
 
-fn create_excessive_branch_depth_error(branch_index: usize, path: &str) -> ValidationError {
-    ValidationError {
+fn create_excessive_branch_depth_error(branch_index: usize, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Branches recursion depth too big (> {MAX_DEPTH})"),
         instance_path: format!("/product_tree/branches/{branch_index}{path}"),
-    }
+    })
 }
 
-pub fn test_6_1_34_branches_recursion_depth(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_34_branches_recursion_depth(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     // TODO This can be wasSkipped in the future
     let Some(branches) = doc.get_product_tree().and_then(|t| t.get_branches()) else {
         return Ok(());
     };
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (i, branch) in branches.iter().enumerate() {
         if let Some(path) = branch.find_excessive_branch_depth(MAX_DEPTH) {
             errors

--- a/csaf-rs/src/validations/test_6_1_35.rs
+++ b/csaf-rs/src/validations/test_6_1_35.rs
@@ -1,6 +1,6 @@
 use crate::csaf_traits::{CsafTrait, RemediationTrait, VulnerabilityTrait};
 use crate::schema::csaf2_1::schema::CategoryOfTheRemediation;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::BTreeMap;
 use strum::{AsRefStr, Display};
 
@@ -19,13 +19,13 @@ fn generate_category_contradiction_error(
     contradiction_categories: String,
     vulnerability_index: usize,
     remediation_index: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Product {product_id} has {exclusivity_kind} remediation category '{exclusive_category}', but also '{contradiction_categories}'",
         ),
         instance_path: format!("/vulnerabilities/{vulnerability_index}/remediations/{remediation_index}"),
-    }
+    })
 }
 
 /// Aggregation mapping:
@@ -83,7 +83,7 @@ impl ProductIdRemediationCategoriesMap {
     ///
     /// For each exclusive category, if there are any other categories, for each remediation with
     /// this category an error is added to `errors`.
-    fn check_exclusive_categories_contradiction(&self, vuln_index: usize, errors: &mut Option<Vec<ValidationError>>) {
+    fn check_exclusive_categories_contradiction(&self, vuln_index: usize, errors: &mut Option<Vec<TestFinding>>) {
         // for each product and the associated categories map
         for (product_id, category_map) in &self.0 {
             // check if the map contains an exclusive category and any other category
@@ -118,7 +118,7 @@ impl ProductIdRemediationCategoriesMap {
     fn check_mutually_exclusive_category_contradiction(
         &self,
         vuln_index: usize,
-        errors: &mut Option<Vec<ValidationError>>,
+        errors: &mut Option<Vec<TestFinding>>,
     ) {
         // for each product and the associated categories map
         for (product_id, category_map) in &self.0 {
@@ -152,7 +152,7 @@ impl ProductIdRemediationCategoriesMap {
     }
 
     /// Calls [`Self::check_mutually_exclusive_category_contradiction`] and [`Self::check_exclusive_categories_contradiction].
-    pub fn check_category_contradiction(&self, vuln_index: usize, errors: &mut Option<Vec<ValidationError>>) {
+    pub fn check_category_contradiction(&self, vuln_index: usize, errors: &mut Option<Vec<TestFinding>>) {
         self.check_exclusive_categories_contradiction(vuln_index, errors);
         self.check_mutually_exclusive_category_contradiction(vuln_index, errors);
     }
@@ -165,12 +165,12 @@ impl ProductIdRemediationCategoriesMap {
 /// This takes indirect relations through product groups into account.
 ///
 /// For more details on how the checks work, see `ProductIdRemediationCategoriesMap`.
-pub fn test_6_1_35_contradicting_remediations(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_35_contradicting_remediations(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
     if vulnerabilities.is_empty() {
         return Ok(()); // TODO #409 this will be noData after refactor
     }
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (v_i, v) in vulnerabilities.iter().enumerate() {
         ProductIdRemediationCategoriesMap::aggregate(doc, v).check_category_contradiction(v_i, &mut errors);
     }

--- a/csaf-rs/src/validations/test_6_1_35.rs
+++ b/csaf-rs/src/validations/test_6_1_35.rs
@@ -182,6 +182,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_35, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_35 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     fn join_categories(categories: Vec<CategoryOfTheRemediation>) -> String {
@@ -266,17 +267,17 @@ mod tests {
         // Case s11: Duplicate optional_patch (same exclusive category, no contradiction)
         // Case s12: Duplicate vendor_fix (same mut_ex category, no contradiction)
 
-        TESTS_2_1.test_6_1_35.expect(
-            case_01_mutually_exclusive_via_product,
-            case_02_exclusive_none_available_via_group,
-            case_03_exclusive_optional_patch_via_group,
-            case_04_exclusive_optional_patch_via_groups_multiple_products,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_35.expect(ExpectedResults {
+            case_01: case_01_mutually_exclusive_via_product,
+            case_02: case_02_exclusive_none_available_via_group,
+            case_03: case_03_exclusive_optional_patch_via_group,
+            case_04: case_04_exclusive_optional_patch_via_groups_multiple_products,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_36.rs
+++ b/csaf-rs/src/validations/test_6_1_36.rs
@@ -1,6 +1,6 @@
 use crate::csaf_traits::{CsafTrait, ProductStatusGroup, ProductStatusGroupMap, RemediationTrait, VulnerabilityTrait};
 use crate::schema::csaf2_1::schema::CategoryOfTheRemediation;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// Remediation categories that conflict with the product status "not affected".
 const NOT_AFFECTED_CONFLICTS: &[CategoryOfTheRemediation] = &[
@@ -25,13 +25,13 @@ fn create_affected_conflict_error(
     category: &CategoryOfTheRemediation,
     v_i: usize,
     r_i: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Product {product_id} is listed as affected but has conflicting remediation category {category}"
         ),
         instance_path: format!("/vulnerabilities/{v_i}/remediations/{r_i}"),
-    }
+    })
 }
 
 fn create_not_affected_conflict_error(
@@ -39,13 +39,13 @@ fn create_not_affected_conflict_error(
     category: &CategoryOfTheRemediation,
     v_i: usize,
     r_i: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Product {product_id} is listed as not affected but has conflicting remediation category {category}"
         ),
         instance_path: format!("/vulnerabilities/{v_i}/remediations/{r_i}"),
-    }
+    })
 }
 
 fn create_fixed_conflict_error(
@@ -53,16 +53,16 @@ fn create_fixed_conflict_error(
     category: &CategoryOfTheRemediation,
     v_i: usize,
     r_i: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Product {product_id} is listed as fixed but has conflicting remediation category {category}"),
         instance_path: format!("/vulnerabilities/{v_i}/remediations/{r_i}"),
-    }
+    })
 }
 
 pub fn test_6_1_36_status_group_contradicting_remediation_categories(
     doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     for (v_i, v) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(product_status) = v.get_product_status() {
             let status_map = ProductStatusGroupMap::from(product_status);

--- a/csaf-rs/src/validations/test_6_1_36.rs
+++ b/csaf-rs/src/validations/test_6_1_36.rs
@@ -104,40 +104,41 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_36 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_36() {
         // Only CSAF 2.1 has this test with 8 test cases (4 error cases, 4 success cases)
-        TESTS_2_1.test_6_1_36.expect(
-            Err(vec![create_not_affected_conflict_error(
+        TESTS_2_1.test_6_1_36.expect(ExpectedResults {
+            case_01: Err(vec![create_not_affected_conflict_error(
                 "CSAFPID-9080700",
                 &CategoryOfTheRemediation::VendorFix,
                 0,
                 0,
             )]),
-            Err(vec![create_fixed_conflict_error(
+            case_02: Err(vec![create_fixed_conflict_error(
                 "CSAFPID-9080703",
                 &CategoryOfTheRemediation::NoneAvailable,
                 0,
                 0,
             )]),
-            Err(vec![create_affected_conflict_error(
+            case_03: Err(vec![create_affected_conflict_error(
                 "CSAFPID-9080700",
                 &CategoryOfTheRemediation::OptionalPatch,
                 0,
                 0,
             )]),
-            Err(vec![create_fixed_conflict_error(
+            case_04: Err(vec![create_fixed_conflict_error(
                 "CSAFPID-9080700",
                 &CategoryOfTheRemediation::NoFixPlanned,
                 0,
                 0,
             )]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_37.rs
+++ b/csaf-rs/src/validations/test_6_1_37.rs
@@ -4,7 +4,7 @@ use crate::csaf_traits::{
     CsafTrait, DocumentTrait, FirstKnownExploitationDatesTrait, TrackingTrait, VulnerabilityTrait, WithDate,
     WithOptionalDate,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -17,7 +17,7 @@ static CSAF_RFC3339_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 ///
 /// This function checks all date/time fields in the document, including tracking dates,
 /// vulnerability disclosure/discovery dates, remediation dates, threat dates, etc.
-pub fn test_6_1_37_date_and_time(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_37_date_and_time(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let tracking = doc.get_document().get_tracking();
 
     // Check the initial release date
@@ -108,23 +108,23 @@ pub fn test_6_1_37_date_and_time(doc: &impl CsafTrait) -> Result<(), Vec<Validat
     Ok(())
 }
 
-fn create_invalid_format_error(date_time: &str, instance_path: &str) -> ValidationError {
-    ValidationError {
+fn create_invalid_format_error(date_time: &str, instance_path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Invalid date-time string {date_time}, expected RFC3339-compliant format with non-empty timezone and no leap seconds"
         ),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
-fn create_parsing_error(date_time: &str, error: impl std::fmt::Display, instance_path: &str) -> ValidationError {
-    ValidationError {
+fn create_parsing_error(date_time: &str, error: impl std::fmt::Display, instance_path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Date-time string {date_time} matched RFC3339 regex but failed chrono parsing: {error}"),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
-fn check_datetime(date_time: &CsafDateTime, instance_path: &str) -> Result<(), Vec<ValidationError>> {
+fn check_datetime(date_time: &CsafDateTime, instance_path: &str) -> Result<(), Vec<TestFinding>> {
     let date = match date_time {
         Valid(date) => date.get_raw_string(),
         Invalid(err) => err.get_raw_string(),

--- a/csaf-rs/src/validations/test_6_1_37.rs
+++ b/csaf-rs/src/validations/test_6_1_37.rs
@@ -145,60 +145,61 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_37, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_37 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_37() {
         // Only CSAF 2.1 has this test with 16 test cases (10 error cases, 6 success cases)
-        TESTS_2_1.test_6_1_37.expect(
-            Err(vec![create_invalid_format_error(
+        TESTS_2_1.test_6_1_37.expect(ExpectedResults {
+            case_01: Err(vec![create_invalid_format_error(
                 "2024-01-24 10:00:00.000Z",
                 "/document/tracking/initial_release_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_02: Err(vec![create_invalid_format_error(
                 "2024-01-24T10:00:00.000z",
                 "/document/tracking/initial_release_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_03: Err(vec![create_invalid_format_error(
                 "2017-01-01T02:59:60+04:00",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_parsing_error(
+            case_04: Err(vec![create_parsing_error(
                 "2023-04-31T00:00:00+01:00",
                 "Failed to parse '2023-04-31T00:00:00+01:00' as RFC3339 with reason 'input is out of range'",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_parsing_error(
+            case_05: Err(vec![create_parsing_error(
                 "2023-02-29T00:00:00+01:00",
                 "Failed to parse '2023-02-29T00:00:00+01:00' as RFC3339 with reason 'input is out of range'",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_06: Err(vec![create_invalid_format_error(
                 "2016-12-31T00:00:60+23:59",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_07: Err(vec![create_invalid_format_error(
                 "2015-06-30T10:29:60-13:30",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_08: Err(vec![create_invalid_format_error(
                 "2015-06-30T10:29:60-13:30",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_09: Err(vec![create_invalid_format_error(
                 "2016-12-31T23:59:60.0123+00:00",
                 "/vulnerabilities/0/disclosure_date",
             )]),
-            Err(vec![create_invalid_format_error(
+            case_20: Err(vec![create_invalid_format_error(
                 "2024-01-24t10:00:00.000Z",
                 "/vulnerabilities/0/first_known_exploitation_dates/0/date",
             )]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_38.rs
+++ b/csaf-rs/src/validations/test_6_1_38.rs
@@ -2,11 +2,13 @@ use std::sync::LazyLock;
 
 use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait, SharingGroupTrait, TlpTrait};
 use crate::schema::csaf2_1::schema::LabelOfTlp;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static NON_PUBLIC_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "Document must be public (TLP:CLEAR) when using max UUID as sharing group ID.".to_string(),
-    instance_path: "/document/distribution/sharing_group/tlp/label".to_string(),
+static NON_PUBLIC_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: "Document must be public (TLP:CLEAR) when using max UUID as sharing group ID.".to_string(),
+        instance_path: "/document/distribution/sharing_group/tlp/label".to_string(),
+    })
 });
 
 /// Validates that a CSAF document using the maximum UUID as the sharing group ID
@@ -23,9 +25,9 @@ static NON_PUBLIC_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new
 /// # Returns
 ///
 /// * `Ok(())` if the validation passes.
-/// * `Err(vec![ValidationError])` if the validation fails, with a message explaining the reason
+/// * `Err(vec![TestFinding])` if the validation fails, with a message explaining the reason
 ///   and the JSON path to the invalid element.
-pub fn test_6_1_38_non_public_sharing_group_max_uuid(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_38_non_public_sharing_group_max_uuid(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group()

--- a/csaf-rs/src/validations/test_6_1_38.rs
+++ b/csaf-rs/src/validations/test_6_1_38.rs
@@ -47,31 +47,32 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_38 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_38() {
         let err = Err(vec![NON_PUBLIC_SHARING_GROUP_ERROR.clone()]);
         // Only CSAF 2.1 has this test with 9 test cases (4 error cases, 5 success cases)
-        TESTS_2_1.test_6_1_38.expect(
-            // Case 01: Max UUID with TLP:RED
+        TESTS_2_1.test_6_1_38.expect(ExpectedResults {
+            case_01: // Case 01: Max UUID with TLP:RED
             err.clone(),
-            // Case 02: Max UUID with TLP:AMBER+STRICT
+            case_02: // Case 02: Max UUID with TLP:AMBER+STRICT
             err.clone(),
-            // Case 03: Max UUID with TLP:AMBER
+            case_03: // Case 03: Max UUID with TLP:AMBER
             err.clone(),
-            // Case 04: Max UUID with TLP:GREEN
+            case_04: // Case 04: Max UUID with TLP:GREEN
             err,
-            // Case 11: Regular UUID with TLP:RED
+            case_11: // Case 11: Regular UUID with TLP:RED
             Ok(()),
-            // Case 12: Regular UUID with TLP:AMBER+STRICT, no name
+            case_12: // Case 12: Regular UUID with TLP:AMBER+STRICT, no name
             Ok(()),
-            // Case 13: Regular UUID with TLP:AMBER
+            case_13: // Case 13: Regular UUID with TLP:AMBER
             Ok(()),
-            // Case 14: No sharing group with TLP:GREEN
+            case_14: // Case 14: No sharing group with TLP:GREEN
             Ok(()),
-            // Case 15: Max UUID with TLP:CLEAR
+            case_15: // Case 15: Max UUID with TLP:CLEAR
             Ok(()),
-        );
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_39.rs
+++ b/csaf-rs/src/validations/test_6_1_39.rs
@@ -53,21 +53,22 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_39 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_39() {
         let err = Err(vec![PUBLIC_SHARING_GROUP_ERROR.clone()]);
         // Only CSAF 2.1 has this test with 4 test cases (2 error cases, 2 success cases)
-        TESTS_2_1.test_6_1_39.expect(
-            // Case 01: TLP:CLEAR with regular UUID, status final
+        TESTS_2_1.test_6_1_39.expect(ExpectedResults {
+            case_01: // Case 01: TLP:CLEAR with regular UUID, status final
             err.clone(),
-            // Case 02: TLP:CLEAR with Nil UUID, status final
+            case_02: // Case 02: TLP:CLEAR with Nil UUID, status final
             err,
-            // Case 11: TLP:CLEAR with Max UUID, status final
+            case_11: // Case 11: TLP:CLEAR with Max UUID, status final
             Ok(()),
-            // Case 12: TLP:CLEAR with Nil UUID, status draft
+            case_12: // Case 12: TLP:CLEAR with Nil UUID, status draft
             Ok(()),
-        );
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_39.rs
+++ b/csaf-rs/src/validations/test_6_1_39.rs
@@ -2,11 +2,14 @@ use std::sync::LazyLock;
 
 use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait, SharingGroupTrait, TlpTrait, TrackingTrait};
 use crate::schema::csaf2_1::schema::{DocumentStatus, LabelOfTlp};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static PUBLIC_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "Document with TLP CLEAR and sharing group must use max UUID or nil UUID plus draft status.".to_string(),
-    instance_path: "/document/distribution/sharing_group/id".to_string(),
+static PUBLIC_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: "Document with TLP CLEAR and sharing group must use max UUID or nil UUID plus draft status."
+            .to_string(),
+        instance_path: "/document/distribution/sharing_group/id".to_string(),
+    })
 });
 
 /// Validates that when a document is marked with TLP CLEAR, any associated sharing group
@@ -15,7 +18,7 @@ static PUBLIC_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| 
 /// This function checks the following (if TLP CLEAR):
 /// - If the sharing group ID is `MAX_UUID`, the validation passes.
 /// - If the sharing group ID is `NIL_UUID` and the document status is "Draft", the validation passes.
-/// - Otherwise, the function returns a `ValidationError` with a relevant error message.
+/// - Otherwise, the function returns a `TestFinding` with a relevant error message.
 ///
 /// # Arguments
 ///
@@ -24,8 +27,8 @@ static PUBLIC_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| 
 /// # Returns
 ///
 /// - `Ok(())` if the validation passes.
-/// - `Err(vec![ValidationError])` if the requirements are not met.
-pub fn test_6_1_39_public_sharing_group_with_no_max_uuid(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+/// - `Err(vec![TestFinding])` if the requirements are not met.
+pub fn test_6_1_39_public_sharing_group_with_no_max_uuid(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if distribution.get_tlp_21().map_err(|e| vec![e])?.get_label() == LabelOfTlp::Clear

--- a/csaf-rs/src/validations/test_6_1_40.rs
+++ b/csaf-rs/src/validations/test_6_1_40.rs
@@ -3,16 +3,20 @@ use std::sync::LazyLock;
 use crate::csaf_traits::{
     CsafTrait, DistributionTrait, DocumentTrait, SG_NAME_PRIVATE, SG_NAME_PUBLIC, SharingGroupTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static PUBLIC_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: format!("Sharing group name \"{SG_NAME_PUBLIC}\" is prohibited without max UUID."),
-    instance_path: "/document/distribution/sharing_group/name".to_string(),
+static PUBLIC_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: format!("Sharing group name \"{SG_NAME_PUBLIC}\" is prohibited without max UUID."),
+        instance_path: "/document/distribution/sharing_group/name".to_string(),
+    })
 });
 
-static PRIVATE_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: format!("Sharing group name \"{SG_NAME_PRIVATE}\" is prohibited without nil UUID."),
-    instance_path: "/document/distribution/sharing_group/name".to_string(),
+static PRIVATE_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: format!("Sharing group name \"{SG_NAME_PRIVATE}\" is prohibited without nil UUID."),
+        instance_path: "/document/distribution/sharing_group/name".to_string(),
+    })
 });
 
 /// Validates the sharing group name and ID combinations in a CSAF document.
@@ -32,9 +36,9 @@ static PRIVATE_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(||
 /// # Returns
 ///
 /// * `Ok(())` if the validation passes.
-/// * `Err(vec![ValidationError])` if the validation fails, with a message explaining the reason
+/// * `Err(vec![TestFinding])` if the validation fails, with a message explaining the reason
 ///   and the JSON path to the invalid element.
-pub fn test_6_1_40_invalid_sharing_group_name(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_40_invalid_sharing_group_name(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group() {

--- a/csaf-rs/src/validations/test_6_1_40.rs
+++ b/csaf-rs/src/validations/test_6_1_40.rs
@@ -56,24 +56,25 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_40, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_40 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_40() {
         // Only CSAF 2.1 has this test with 6 test cases (2 error cases, 4 success cases)
-        TESTS_2_1.test_6_1_40.expect(
-            // Case 01: Name "Public" with regular UUID
+        TESTS_2_1.test_6_1_40.expect(ExpectedResults {
+            case_01: // Case 01: Name "Public" with regular UUID
             Err(vec![PUBLIC_SHARING_GROUP_ERROR.clone()]),
-            // Case 02: Name "No sharing allowed" with regular UUID
+            case_02: // Case 02: Name "No sharing allowed" with regular UUID
             Err(vec![PRIVATE_SHARING_GROUP_ERROR.clone()]),
-            // Case 11: Name "Public" with Max UUID
+            case_11: // Case 11: Name "Public" with Max UUID
             Ok(()),
-            // Case 12: Name "No sharing allowed" with Nil UUID
+            case_12: // Case 12: Name "No sharing allowed" with Nil UUID
             Ok(()),
-            // Case 13: Regular UUID without name
+            case_13: // Case 13: Regular UUID without name
             Ok(()),
-            // Case 14: Regular UUID with arbitrary name
+            case_14: // Case 14: Regular UUID with arbitrary name
             Ok(()),
-        );
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_41.rs
+++ b/csaf-rs/src/validations/test_6_1_41.rs
@@ -54,6 +54,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_41, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_41 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -62,19 +63,19 @@ mod tests {
         let nil_uuid_err = Err(vec![NIL_UUID_SHARING_GROUP_ERROR.clone()]);
 
         // Only CSAF 2.1 has this test with 6 test cases (4 error cases, 2 success cases)
-        TESTS_2_1.test_6_1_41.expect(
-            // Case 01: Max UUID without name
+        TESTS_2_1.test_6_1_41.expect(ExpectedResults {
+            case_01: // Case 01: Max UUID without name
             max_uuid_err.clone(),
-            // Case 02: NIL UUID without name
+            case_02: // Case 02: NIL UUID without name
             nil_uuid_err.clone(),
-            // Case 03: Max UUID with wrong name
+            case_03: // Case 03: Max UUID with wrong name
             max_uuid_err,
-            // Case 04: Nil UUID with wrong name
+            case_04: // Case 04: Nil UUID with wrong name
             nil_uuid_err,
-            // Case 11: Max UUID with correct name "Public"
+            case_11: // Case 11: Max UUID with correct name "Public"
             Ok(()),
-            // Case 12: Nil UUID with correct name "No sharing allowed"
+            case_12: // Case 12: Nil UUID with correct name "No sharing allowed"
             Ok(()),
-        );
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_41.rs
+++ b/csaf-rs/src/validations/test_6_1_41.rs
@@ -3,16 +3,20 @@ use std::sync::LazyLock;
 use crate::csaf_traits::{
     CsafTrait, DistributionTrait, DocumentTrait, SG_NAME_PRIVATE, SG_NAME_PUBLIC, SharingGroupTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static MAX_UUID_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: format!("Max UUID requires sharing group name to be \"{SG_NAME_PUBLIC}\"."),
-    instance_path: "/document/distribution/sharing_group/name".to_string(),
+static MAX_UUID_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: format!("Max UUID requires sharing group name to be \"{SG_NAME_PUBLIC}\"."),
+        instance_path: "/document/distribution/sharing_group/name".to_string(),
+    })
 });
 
-static NIL_UUID_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: format!("Nil UUID requires sharing group name to be \"{SG_NAME_PRIVATE}\"."),
-    instance_path: "/document/distribution/sharing_group/name".to_string(),
+static NIL_UUID_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: format!("Nil UUID requires sharing group name to be \"{SG_NAME_PRIVATE}\"."),
+        instance_path: "/document/distribution/sharing_group/name".to_string(),
+    })
 });
 
 /// Validates that a CSAF document with specific sharing group IDs has the correct corresponding name.
@@ -30,9 +34,9 @@ static NIL_UUID_SHARING_GROUP_ERROR: LazyLock<ValidationError> = LazyLock::new(|
 /// # Returns
 ///
 /// * `Ok(())` if the validation passes.
-/// * `Err(vec![ValidationError])` if the validation fails, with a message explaining the reason
+/// * `Err(vec![TestFinding])` if the validation fails, with a message explaining the reason
 ///   and the JSON path to the invalid element.
-pub fn test_6_1_41_missing_sharing_group_name(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_41_missing_sharing_group_name(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group() {

--- a/csaf-rs/src/validations/test_6_1_42.rs
+++ b/csaf-rs/src/validations/test_6_1_42.rs
@@ -1,19 +1,19 @@
 use crate::csaf::types::purl::csaf_purl::CsafPurl::{Invalid, Valid};
 use crate::csaf_traits::{CsafTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
-fn create_purl_consistency_error(path: &str, index: usize) -> ValidationError {
-    ValidationError {
+fn create_purl_consistency_error(path: &str, index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: String::from("PURLs within the same product_identification_helper must only differ in qualifiers"),
         instance_path: format!("{path}/product_identification_helper/purls/{index}"),
-    }
+    })
 }
 
 /// 6.1.42 PURL Consistency
 /// Checks the consistency of PURLs within the same product_identification_helper. PURLs must only differ in qualifiers.
-pub fn test_6_1_42_purl_consistency(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_42_purl_consistency(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {

--- a/csaf-rs/src/validations/test_6_1_42.rs
+++ b/csaf-rs/src/validations/test_6_1_42.rs
@@ -77,25 +77,26 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_42, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_42 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_42() {
-        TESTS_2_1.test_6_1_42.expect(
-            Err(vec![create_purl_consistency_error(
+        TESTS_2_1.test_6_1_42.expect(ExpectedResults {
+            case_01: Err(vec![create_purl_consistency_error(
                 "/product_tree/full_product_names/0",
                 1,
             )]),
-            Err(vec![create_purl_consistency_error(
+            case_02: Err(vec![create_purl_consistency_error(
                 "/product_tree/branches/0/branches/0/branches/0/product",
                 2,
             )]),
-            Err(vec![create_purl_consistency_error(
+            case_s01: Err(vec![create_purl_consistency_error(
                 "/product_tree/full_product_names/0",
                 1,
             )]),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_43.rs
+++ b/csaf-rs/src/validations/test_6_1_43.rs
@@ -1,16 +1,16 @@
 use crate::csaf::types::csaf_product_id_helper_number::CsafModelNumber;
 use crate::csaf_traits::{CsafTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_multiple_stars_model_number_error(number: &CsafModelNumber, path: &str, index: usize) -> ValidationError {
-    ValidationError {
+fn create_multiple_stars_model_number_error(number: &CsafModelNumber, path: &str, index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Model number '{number}' must not contain multiple unescaped asterisks (stars)"),
         instance_path: format!("{path}/product_identification_helper/model_numbers/{index}"),
-    }
+    })
 }
 
-pub fn test_6_1_43_multiple_stars_in_model_number(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_43_multiple_stars_in_model_number(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {

--- a/csaf-rs/src/validations/test_6_1_43.rs
+++ b/csaf-rs/src/validations/test_6_1_43.rs
@@ -40,6 +40,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_43 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -48,25 +49,25 @@ mod tests {
         // S01: 1 model number, no stars
 
         // Only CSAF 2.1 has this test with 5 test cases (2 error cases, 3 success cases)
-        TESTS_2_1.test_6_1_43.expect(
-            // Case 01: One model number with two unescaped stars
+        TESTS_2_1.test_6_1_43.expect(ExpectedResults {
+            case_01: // Case 01: One model number with two unescaped stars
             Err(vec![create_multiple_stars_model_number_error(
                 &CsafModelNumber::from("P*A*"),
                 "/product_tree/full_product_names/0",
                 0,
             )]),
-            // Case 02: One model number with one escaped and two unescaped stars
+            case_02: // Case 02: One model number with one escaped and two unescaped stars
             Err(vec![create_multiple_stars_model_number_error(
                 &CsafModelNumber::from("*P*\\*?*"),
                 "/product_tree/full_product_names/0",
                 0,
             )]),
-            // Case 03: 5 model numbers, all end with one unescaped star (and some '?' in between)
+            case_11: // Case 03: 5 model numbers, all end with one unescaped star (and some '?' in between)
             Ok(()),
-            // Case 04: 1 model number, starts with unescaped star, 3 escaped stars
+            case_12: // Case 04: 1 model number, starts with unescaped star, 3 escaped stars
             Ok(()),
-            // Case 05: 1 model number, 2 escaped stars, one escaped backslash
+            case_13: // Case 05: 1 model number, 2 escaped stars, one escaped backslash
             Ok(()),
-        );
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_44.rs
+++ b/csaf-rs/src/validations/test_6_1_44.rs
@@ -1,16 +1,16 @@
 use crate::csaf::types::csaf_product_id_helper_number::CsafSerialNumber;
 use crate::csaf_traits::{CsafTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_multiple_stars_serial_number_error(number: &CsafSerialNumber, path: &str, index: usize) -> ValidationError {
-    ValidationError {
+fn create_multiple_stars_serial_number_error(number: &CsafSerialNumber, path: &str, index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Serial number '{number}' must not contain multiple unescaped asterisks (stars)"),
         instance_path: format!("{path}/product_identification_helper/serial_numbers/{index}"),
-    }
+    })
 }
 
-pub fn test_6_1_44_multiple_stars_in_serial_number(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_44_multiple_stars_in_serial_number(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {

--- a/csaf-rs/src/validations/test_6_1_44.rs
+++ b/csaf-rs/src/validations/test_6_1_44.rs
@@ -40,6 +40,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_44 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -48,25 +49,25 @@ mod tests {
         // S01: 1 serial number, no stars
 
         // Only CSAF 2.1 has this test with 5 test cases (2 error cases, 3 success cases)
-        TESTS_2_1.test_6_1_44.expect(
-            // Case 01: One serial number with two unescaped stars
+        TESTS_2_1.test_6_1_44.expect(ExpectedResults {
+            case_01: // Case 01: One serial number with two unescaped stars
             Err(vec![create_multiple_stars_serial_number_error(
                 &CsafSerialNumber::from("P*A*"),
                 "/product_tree/full_product_names/0",
                 0,
             )]),
-            // Case 02: One serial number with one escaped and two unescaped stars
+            case_02: // Case 02: One serial number with one escaped and two unescaped stars
             Err(vec![create_multiple_stars_serial_number_error(
                 &CsafSerialNumber::from("*P*\\*?*"),
                 "/product_tree/full_product_names/0",
                 0,
             )]),
-            // Case 03: 5 serial numbers, all end with one unescaped star (and some '?' in between)
+            case_11: // Case 03: 5 serial numbers, all end with one unescaped star (and some '?' in between)
             Ok(()),
-            // Case 04: 1 serial number, starts with unescaped star, 3 escaped stars
+            case_12: // Case 04: 1 serial number, starts with unescaped star, 3 escaped stars
             Ok(()),
-            // Case 05: 1 serial number, 2 escaped stars, one escaped backslash
+            case_13: // Case 05: 1 serial number, 2 escaped stars, one escaped backslash
             Ok(()),
-        );
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_45.rs
+++ b/csaf-rs/src/validations/test_6_1_45.rs
@@ -2,20 +2,20 @@ use crate::csaf::macros::skip_if_document_status_is_not::skip_if_document_status
 use crate::csaf::types::csaf_datetime::{CsafDateTime, ValidCsafDateTime};
 use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait, TlpTrait, TrackingTrait, VulnerabilityTrait};
 use crate::schema::csaf2_1::schema::{DocumentStatus, LabelOfTlp};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn create_disclosure_date_too_late_error(
     doc_status: &DocumentStatus,
     disclosure_date: &ValidCsafDateTime,
     i_v: usize,
     newest_revision_date: &ValidCsafDateTime,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Disclosure date ({disclosure_date}) for vulnerability at index {i_v} is newer than the newest revision date ({newest_revision_date}) on a document with TLP:CLEAR and document status {doc_status}"
         ),
         instance_path: format!("/vulnerabilities/{i_v}/disclosure_date"),
-    }
+    })
 }
 
 /// 6.1.45 Inconsistent Disclosure Date
@@ -23,7 +23,7 @@ fn create_disclosure_date_too_late_error(
 /// For each vulnerability, it is tested that the `disclosure_date` is earlier or equal to the `date`
 /// of the newest item in the `revision_history` (taking timezones into consideration)
 /// if the document is TLP:CLEAR and the document status is `final` or `interim`.
-pub fn test_6_1_45_inconsistent_disclosure_date(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_45_inconsistent_disclosure_date(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
     let tracking = document.get_tracking();
     let status = tracking.get_status();
@@ -57,7 +57,7 @@ pub fn test_6_1_45_inconsistent_disclosure_date(doc: &impl CsafTrait) -> Result<
     };
 
     // Check each vulnerability's disclosure date
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(disclosure_date) = vulnerability.get_disclosure_date() {
             match disclosure_date {

--- a/csaf-rs/src/validations/test_6_1_45.rs
+++ b/csaf-rs/src/validations/test_6_1_45.rs
@@ -92,6 +92,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_45 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -121,14 +122,14 @@ mod tests {
         // Case 13: Not TLP:CLEAR, so test doesn't apply
         // Case 14: disclosure_date before newest revision date, with timezone
 
-        TESTS_2_1.test_6_1_45.expect(
-            case_01_disclosure_date_too_late,
-            case_02_disclosure_date_too_late,
-            case_03_disclosure_date_too_late_with_timezone,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_45.expect(ExpectedResults {
+            case_01: case_01_disclosure_date_too_late,
+            case_02: case_02_disclosure_date_too_late,
+            case_03: case_03_disclosure_date_too_late_with_timezone,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_46.rs
+++ b/csaf-rs/src/validations/test_6_1_46.rs
@@ -63,6 +63,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_46, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_46 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -72,19 +73,19 @@ mod tests {
         // Case 11: minimal valid ssvc
         // Case 12: valid ssvc
 
-        TESTS_2_1.test_6_1_46.expect(
-            Err(vec![create_invalid_ssvc_error(
+        TESTS_2_1.test_6_1_46.expect(ExpectedResults {
+            case_01: Err(vec![create_invalid_ssvc_error(
                 "\"selections\" is a required property",
                 "",
                 0,
                 0,
             )]),
-            Err(vec![
+            case_02: Err(vec![
                 create_invalid_ssvc_error("\"key\" is a required property", "/selections/0", 0, 0),
                 create_invalid_ssvc_error("\"key\" is a required property", "/selections/0/values/0", 0, 0),
             ]),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_46.rs
+++ b/csaf-rs/src/validations/test_6_1_46.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use jsonschema::Validator;
 
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::validation_schemas::SSVC_2_SCHEMA;
 
 static SSVC_VALIDATOR: LazyLock<Validator> = LazyLock::new(|| jsonschema::draft202012::new(&SSVC_2_SCHEMA).unwrap());
@@ -13,25 +13,25 @@ fn create_invalid_ssvc_error(
     error_path: &str,
     vulnerability_index: usize,
     metric_index: usize,
-) -> ValidationError {
+) -> TestFinding {
     let path_info = if error_path.is_empty() {
         String::new()
     } else {
         format!(" at {error_path}")
     };
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid SSVC object{path_info}: {error_message}"),
         instance_path: format!(
             "/vulnerabilities/{vulnerability_index}/metrics/{metric_index}/content/ssvc_v2{error_path}"
         ),
-    }
+    })
 }
 
 /// 6.1.46 Invalid SSVC
 ///
 /// It MUST be tested that the given SSVC object is valid according to the referenced schema.
-pub fn test_6_1_46_invalid_ssvc(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_46_invalid_ssvc(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
     // look for ssvc_v2 metrics in all vulnerabilities and metrics
     for (i_v, v) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = v.get_metrics() {

--- a/csaf-rs/src/validations/test_6_1_47.rs
+++ b/csaf-rs/src/validations/test_6_1_47.rs
@@ -119,6 +119,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_47, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_47 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -157,18 +158,18 @@ mod tests {
         // Case 14: 2 vulns, target ID equals vuln ID, there is also a CVE in the second vuln
         // Case 15: target ID matches both document ID and vuln ID
 
-        TESTS_2_1.test_6_1_47.expect(
-            case_01_target_id_cve_mismatch,
-            case_02_target_id_vuln_id_mismatch,
-            case_03_target_id_vuln_id_partial_mismatch,
-            case_04_target_id_vuln_id_swapped_mismatch,
-            case_05_target_id_document_id_mismatch,
-            case_06_target_id_document_id_match_multi_vuln,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_47.expect(ExpectedResults {
+            case_01: case_01_target_id_cve_mismatch,
+            case_02: case_02_target_id_vuln_id_mismatch,
+            case_03: case_03_target_id_vuln_id_partial_mismatch,
+            case_04: case_04_target_id_vuln_id_swapped_mismatch,
+            case_05: case_05_target_id_document_id_mismatch,
+            case_06: case_06_target_id_document_id_match_multi_vuln,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_47.rs
+++ b/csaf-rs/src/validations/test_6_1_47.rs
@@ -1,36 +1,36 @@
 use crate::csaf_traits::{
     ContentTrait, CsafTrait, DocumentTrait, MetricTrait, TrackingTrait, VulnerabilityIdTrait, VulnerabilityTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn create_document_id_multiple_vulnerabilities_error(
     document_id: &str,
     i_v: usize,
     i_m: usize,
     i_t: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The SSVC target ID equals the document ID '{document_id}' and the document contains multiple vulnerabilities"
         ),
         instance_path: format!("/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2/target_ids/{i_t}"),
-    }
+    })
 }
 
-fn create_target_id_mismatch_error(target_id: &str, i_v: usize, i_m: usize, i_t: usize) -> ValidationError {
-    ValidationError {
+fn create_target_id_mismatch_error(target_id: &str, i_v: usize, i_m: usize, i_t: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The SSVC target ID '{target_id}' does not match the document ID, the CVE ID or any ID in the IDs array of the vulnerability"
         ),
         instance_path: format!("/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2/target_ids/{i_t}"),
-    }
+    })
 }
 
-fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usize) -> ValidationError {
-    ValidationError {
+fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid SSVC object: {error}"),
         instance_path: format!("/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2"),
-    }
+    })
 }
 
 /// 6.1.47 Inconsistent SSVC Target IDs
@@ -39,8 +39,8 @@ fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usi
 /// the CVE of the vulnerability given in cve or the text of an item in the ids array of the vulnerability.
 /// The test MUST fail, if the target ID equals the /document/tracking/id and the CSAF document
 /// contains more than one vulnerability.
-pub fn test_6_1_47_inconsistent_ssvc_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_47_inconsistent_ssvc_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     let vulnerabilities = doc.get_vulnerabilities();
 

--- a/csaf-rs/src/validations/test_6_1_48.rs
+++ b/csaf-rs/src/validations/test_6_1_48.rs
@@ -72,6 +72,7 @@ impl crate::test_validation::TestValidator<crate::schema::csaf2_1::schema::Commo
 
 #[cfg(test)]
 mod tests {
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_48 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use crate::validation::ValidationError;
 
@@ -143,7 +144,7 @@ mod tests {
         }]);
 
         // Only CSAF 2.1 has this test, with 20 test cases (6 error cases, 14 success cases)
-        TESTS_2_1.test_6_1_48.expect(
+        TESTS_2_1.test_6_1_48.expect(ExpectedResults {
             case_01,
             case_02,
             case_03,
@@ -154,16 +155,16 @@ mod tests {
             case_08,
             case_09,
             case_21,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
             case_16, // no Exploit Maturity E v3.0.1
-            Ok(()),
-            Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
             case_19, // wrong order of translated keys "R" and "C"
-            Ok(()),
-        );
+            case_31: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_48.rs
+++ b/csaf-rs/src/validations/test_6_1_48.rs
@@ -1,15 +1,15 @@
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usize) -> ValidationError {
-    ValidationError {
+fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid SSVC object: {error}"),
         instance_path: format!("/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2"),
-    }
+    })
 }
 
 /// Test function for invocation by users, does not permit usage of the "test" namespace.
-pub fn test_6_1_48_ssvc_decision_points(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_48_ssvc_decision_points(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     test_6_1_48_ssvc_decision_points_internal(doc, false)
 }
 
@@ -18,7 +18,7 @@ pub fn test_6_1_48_ssvc_decision_points(doc: &impl CsafTrait) -> Result<(), Vec<
 fn test_6_1_48_ssvc_decision_points_internal(
     doc: &impl CsafTrait,
     allow_test_namespaces: bool,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
 
     for (i_v, v) in vulnerabilities.iter().enumerate() {
@@ -30,17 +30,17 @@ fn test_6_1_48_ssvc_decision_points_internal(
                         Ok(ssvc) => {
                             let result = ssvc::validation::validate_selection_list(&ssvc, allow_test_namespaces);
                             if !result.success {
-                                let validation_errors: Vec<ValidationError> = result
+                                let validation_errors: Vec<TestFinding> = result
                                     .errors
                                     .into_iter()
                                     .map(|ssvc_error| {
                                         let path_suffix = ssvc_error.instance_path.join("/");
-                                        ValidationError {
+                                        TestFinding::Error(TestFindingData {
                                             message: ssvc_error.message,
                                             instance_path: format!(
                                                 "/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2/{path_suffix}"
                                             ),
-                                        }
+                                        })
                                     })
                                     .collect();
                                 return Err(validation_errors);
@@ -64,7 +64,7 @@ impl crate::test_validation::TestValidator<crate::schema::csaf2_1::schema::Commo
     fn validate(
         &self,
         doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
-    ) -> Result<(), Vec<ValidationError>> {
+    ) -> Result<(), Vec<TestFinding>> {
         // Use the internal validation function allowing usage of the "test" namespace.
         test_6_1_48_ssvc_decision_points_internal(doc, true)
     }
@@ -74,74 +74,74 @@ impl crate::test_validation::TestValidator<crate::schema::csaf2_1::schema::Commo
 mod tests {
     use crate::csaf2_1::testcases::ExpectedResults_6_1_48 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
-    use crate::validation::ValidationError;
+    use crate::validation::{TestFinding, TestFindingData};
 
     #[test]
     fn test_test_6_1_48() {
-        let case_01 = Err(vec![ValidationError {
+        let case_01 = Err(vec![TestFinding::Error(TestFindingData {
             message: "The SSVC decision point 'ssvc::Mission Impact' (version 1.0.0) doesn't have a value with key 'D'"
                 .to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/1".to_string(),
-        }]);
-        let case_02 = Err(vec![ValidationError {
+        })]);
+        let case_02 = Err(vec![TestFinding::Error(TestFindingData {
             message: "Unknown SSVC decision point 'ssvc::SIs' with version '2.0.0'".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0".to_string(),
-        }]);
+        })]);
         let case_03 = Err(vec![
-            ValidationError {
+            TestFinding::Error(TestFindingData {
                 message:
                     "The values for SSVC decision point 'ssvc::Safety Impact' (version 2.0.0) are not in correct order"
                         .to_string(),
                 instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/1".to_string(),
-            },
-            ValidationError {
+            }),
+            TestFinding::Error(TestFindingData {
                 message:
                     "The values for SSVC decision point 'ssvc::Safety Impact' (version 2.0.0) are not in correct order"
                         .to_string(),
                 instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/2".to_string(),
-            },
-            ValidationError {
+            }),
+            TestFinding::Error(TestFindingData {
                 message:
                     "The values for SSVC decision point 'ssvc::Safety Impact' (version 2.0.0) are not in correct order"
                         .to_string(),
                 instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/3".to_string(),
-            },
+            }),
         ]);
-        let case_04 = Err(vec![ValidationError {
+        let case_04 = Err(vec![TestFinding::Error(TestFindingData {
             message: "Unknown SSVC decision point 'ssvc::SI' with version '1.9.7'".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0".to_string(),
-        }]);
-        let case_05 = Err(vec![ValidationError {
+        })]);
+        let case_05 = Err(vec![TestFinding::Error(TestFindingData {
             message:
                 "The SSVC decision point 'cvss::Attack Complexity' (version 3.0.1) doesn't have a value with key 'E'"
                     .to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/0".to_string(),
-        }]);
-        let case_06 = Err(vec![ValidationError {
+        })]);
+        let case_06 = Err(vec![TestFinding::Error(TestFindingData {
             message: "Unknown SSVC decision point 'cvss::E' with version '3.0.1'".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0".to_string(),
-        }]);
-        let case_07 = Err(vec![ValidationError {
+        })]);
+        let case_07 = Err(vec![TestFinding::Error ( TestFindingData {
             message: "The SSVC decision point 'ssvc//.example.test#some-private-decision-point-collection::Safety Impact' (version 2.0.0) doesn't have a value with key 'S'".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/0".to_string(),
-        }]);
-        let case_08 = Err(vec![ValidationError {
+        })]);
+        let case_08 = Err(vec![TestFinding::Error ( TestFindingData {
             message: "The values for SSVC decision point 'ssvc//.example.test$en-GB::Safety Impact' (version 2.0.0) are not in correct order".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/2".to_string(),
-        }]);
-        let case_09 = Err(vec![ValidationError {
+        })]);
+        let case_09 = Err(vec![TestFinding::Error ( TestFindingData {
             message: "The values for SSVC decision point 'ssvc//.example.test$en-CA::Safety Impact' (version 2.0.0) are not in correct order".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/2".to_string(),
-        }]);
-        let case_21 = Err(vec![ValidationError {
+        })]);
+        let case_21 = Err(vec![TestFinding::Error(TestFindingData {
             message: "Invalid SSVC namespace: Reserved namespace 'invalid' must not be used".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/namespace".to_string(),
-        }]);
+        })]);
         let case_16 = case_06.clone();
-        let case_19 = Err(vec![ValidationError {
+        let case_19 = Err(vec![TestFinding::Error ( TestFindingData {
             message: "The values for SSVC decision point 'ssvc//.example.test$de-DE::Safety Impact' (version 2.0.0) are not in correct order".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/2".to_string(),
-        }]);
+        })]);
 
         // Only CSAF 2.1 has this test, with 20 test cases (6 error cases, 14 success cases)
         TESTS_2_1.test_6_1_48.expect(ExpectedResults {

--- a/csaf-rs/src/validations/test_6_1_49.rs
+++ b/csaf-rs/src/validations/test_6_1_49.rs
@@ -5,19 +5,21 @@ use crate::csaf::types::csaf_datetime::CsafDateTime::{Invalid, Valid};
 use crate::csaf_traits::{
     ContentTrait, CsafTrait, DocumentTrait, MetricTrait, TrackingTrait, VulnerabilityTrait, WithDate,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use chrono::{DateTime, FixedOffset};
 
-fn create_invalid_revision_date_error(date_str: &str, i_r: usize) -> ValidationError {
-    ValidationError {
+fn create_invalid_revision_date_error(date_str: &str, i_r: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid date format in revision history: {date_str}"),
         instance_path: format!("/document/tracking/revision_history/{i_r}/date"),
-    }
+    })
 }
 
-static EMPTY_REVISION_HISTORY_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "Revision history must not be empty for status final or interim".to_string(),
-    instance_path: "/document/tracking/revision_history".to_string(),
+static EMPTY_REVISION_HISTORY_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: "Revision history must not be empty for status final or interim".to_string(),
+        instance_path: "/document/tracking/revision_history".to_string(),
+    })
 });
 
 fn create_ssvc_timestamp_too_late_error(
@@ -25,27 +27,27 @@ fn create_ssvc_timestamp_too_late_error(
     i_v: usize,
     newest_revision_date: &str,
     i_m: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "SSVC timestamp ({ssvc_timestamp}) for vulnerability at index {i_v} is later than the newest revision date ({newest_revision_date})"
         ),
         instance_path: format!("/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2/timestamp"),
-    }
+    })
 }
 
-fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usize) -> ValidationError {
-    ValidationError {
+fn create_invalid_ssvc_error(error: impl std::fmt::Display, i_v: usize, i_m: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid SSVC object: {error}"),
         instance_path: format!("/vulnerabilities/{i_v}/metrics/{i_m}/content/ssvc_v2"),
-    }
+    })
 }
 
 /// 6.1.49 Inconsistent SSVC Timestamp
 ///
 /// For each vulnerability, it is tested that the SSVC `timestamp` is earlier or equal to the `date`
 /// of the newest item in the `revision_history` if the document status is `final` or `interim`.
-pub fn test_6_1_49_inconsistent_ssvc_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_49_inconsistent_ssvc_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
     let tracking = document.get_tracking();
 

--- a/csaf-rs/src/validations/test_6_1_49.rs
+++ b/csaf-rs/src/validations/test_6_1_49.rs
@@ -114,33 +114,34 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_49, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_49 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_49() {
         // Only CSAF 2.1 has this test with 6 test cases (3 error cases, 3 success cases)
-        TESTS_2_1.test_6_1_49.expect(
-            Err(vec![create_ssvc_timestamp_too_late_error(
+        TESTS_2_1.test_6_1_49.expect(ExpectedResults {
+            case_01: Err(vec![create_ssvc_timestamp_too_late_error(
                 "2024-07-13T10:00:00+00:00",
                 0,
                 "2024-01-24T10:00:00+00:00",
                 0,
             )]),
-            Err(vec![create_ssvc_timestamp_too_late_error(
+            case_02: Err(vec![create_ssvc_timestamp_too_late_error(
                 "2024-02-29T10:30:00+00:00",
                 0,
                 "2024-02-29T10:00:00+00:00",
                 0,
             )]),
-            Err(vec![create_ssvc_timestamp_too_late_error(
+            case_03: Err(vec![create_ssvc_timestamp_too_late_error(
                 "2024-02-29T10:30:00+00:00",
                 0,
                 "2024-02-29T10:00:00+00:00",
                 0,
             )]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_51.rs
+++ b/csaf-rs/src/validations/test_6_1_51.rs
@@ -4,20 +4,20 @@ use crate::csaf_traits::{
     ContentTrait, CsafTrait, DocumentTrait, EpssTrait, MetricTrait, TrackingTrait, VulnerabilityTrait,
 };
 use crate::schema::csaf2_1::schema::DocumentStatus;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn create_epss_timestamp_too_new_error(
     doc_status: &DocumentStatus,
     epss_timestamp: &ValidCsafDateTime,
     newest_revision_date: &ValidCsafDateTime,
     content_json_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "EPSS timestamp ({epss_timestamp}) is newer than the newest revision date ({newest_revision_date}) on a document with status {doc_status}.",
         ),
         instance_path: format!("{content_json_path}/epss/timestamp"),
-    }
+    })
 }
 
 /// 6.1.51 Inconsistent EPSS Timestamp
@@ -25,7 +25,7 @@ fn create_epss_timestamp_too_new_error(
 /// For each vulnerability, it is tested that the EPSS `timestamp` is earlier or equal to the `date`
 /// of the newest item in the `revision_history` (taking timezones into consideration)
 /// if the document status is `final` or `interim`.
-pub fn test_6_1_51_inconsistent_epss_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_51_inconsistent_epss_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
     let tracking = document.get_tracking();
     let status = tracking.get_status();
@@ -46,7 +46,7 @@ pub fn test_6_1_51_inconsistent_epss_timestamp(doc: &impl CsafTrait) -> Result<(
     };
 
     // Check each vulnerability's EPSS timestamp
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {
             for (i_m, metric) in metrics.iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_51.rs
+++ b/csaf-rs/src/validations/test_6_1_51.rs
@@ -82,6 +82,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_51, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_51 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -110,13 +111,13 @@ mod tests {
         // Case 12: EPSS timestamp before newest rev history, with negative timezone offset
         // Case 13: EPSS timestamp before newest rev history, with positive timezone offset
 
-        TESTS_2_1.test_6_1_51.expect(
-            case_01_too_late_new_timezone,
-            case_02_too_new_neg_timezone_offset,
-            case_03_too_new_pos_timezone_offset,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_51.expect(ExpectedResults {
+            case_01: case_01_too_late_new_timezone,
+            case_02: case_02_too_new_neg_timezone_offset,
+            case_03: case_03_too_new_pos_timezone_offset,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_52.rs
+++ b/csaf-rs/src/validations/test_6_1_52.rs
@@ -110,6 +110,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_52 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -174,11 +175,11 @@ mod tests {
         // Case 11: dates are before or equal to newest revision date
         // Case 12: dates with timezones are to before or equal to newest revision date
 
-        TESTS_2_1.test_6_1_52.expect(
-            case_01_date_and_exploit_date_after_newest_rev_date,
-            case_02_multiple_vulns_multiple_first_exploit_dates_also_timezones,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_52.expect(ExpectedResults {
+            case_01: case_01_date_and_exploit_date_after_newest_rev_date,
+            case_02: case_02_multiple_vulns_multiple_first_exploit_dates_also_timezones,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_52.rs
+++ b/csaf-rs/src/validations/test_6_1_52.rs
@@ -5,7 +5,7 @@ use crate::csaf_traits::{
     CsafTrait, DocumentTrait, FirstKnownExploitationDatesTrait, TrackingTrait, VulnerabilityTrait, WithDate,
 };
 use crate::schema::csaf2_1::schema::DocumentStatus;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use strum::{AsRefStr, Display};
 
 #[derive(Display, AsRefStr)]
@@ -23,13 +23,13 @@ fn create_date_too_new_error(
     v_i: usize,
     f_i: usize,
     property: DateProperty,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The {property} '{date}' of the first known exploitation date is newer than the newest revision date ({newest_revision_date}) on a document with status {doc_status}"
         ),
         instance_path: format!("/vulnerabilities/{v_i}/first_known_exploitation_dates/{f_i}/{property}"),
-    }
+    })
 }
 
 /// 6.1.52 Inconsistent First Known Exploitation Dates
@@ -38,9 +38,7 @@ fn create_date_too_new_error(
 /// `exploitation_date` properties are both earlier than or equal to the `date` of the newest item
 /// of the `revision_history` (taking timezones into consideration) if the document
 /// status is `final` or `interim`.
-pub fn test_6_1_52_inconsistent_first_known_exploitation_dates(
-    doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_52_inconsistent_first_known_exploitation_dates(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
     let tracking = document.get_tracking();
     let status = tracking.get_status();
@@ -60,7 +58,7 @@ pub fn test_6_1_52_inconsistent_first_known_exploitation_dates(
     };
 
     // Check each vulnerability's first known exploitation dates
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     // TODO: #409 no data
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(first_known_exploitation_dates) = vulnerability.get_first_known_exploitation_dates() {

--- a/csaf-rs/src/validations/test_6_1_53.rs
+++ b/csaf-rs/src/validations/test_6_1_53.rs
@@ -57,6 +57,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_53 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -88,11 +89,11 @@ mod tests {
         // Case 11: exploitation_date is before date
         // Case 12: exploitation_date after, but with timezones
 
-        TESTS_2_1.test_6_1_53.expect(
-            case_01_exp_date_after_date,
-            case_02_exp_date_after_date_timezones,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_53.expect(ExpectedResults {
+            case_01: case_01_exp_date_after_date,
+            case_02: case_02_exp_date_after_date_timezones,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_53.rs
+++ b/csaf-rs/src/validations/test_6_1_53.rs
@@ -1,27 +1,27 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime::Valid;
 use crate::csaf_traits::{CsafTrait, FirstKnownExploitationDatesTrait, VulnerabilityTrait, WithDate};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn create_inconsistent_exploitation_date_error(
     exploitation_date: &str,
     date: &str,
     v_i: usize,
     f_i: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "The exploitation date '{exploitation_date}' must not be later than the date '{date}' of a first known exploitation date"
         ),
         instance_path: format!("/vulnerabilities/{v_i}/first_known_exploitation_dates/{f_i}/exploitation_date"),
-    }
+    })
 }
 
 /// 6.1.53 Inconsistent Exploitation Date
 ///
 /// For each `/vulnerabilities[]/first_known_exploitation_dates[]`, it is tested that `exploitation_date`
 /// is earlier or equal to the `date`.
-pub fn test_6_1_53_inconsistent_exploitation_date(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_53_inconsistent_exploitation_date(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(first_known_exploitation_dates) = vulnerability.get_first_known_exploitation_dates() {
             for (f_i, first_known_exploitation_date) in first_known_exploitation_dates.iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_54.rs
+++ b/csaf-rs/src/validations/test_6_1_54.rs
@@ -81,43 +81,44 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_54, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_54 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_1_54() {
         // Only CSAF 2.1 has this test with 6 test cases (3 error cases, 3 success case)
-        TESTS_2_1.test_6_1_54.expect(
-            Err(vec![create_invalid_license_expression_error(
+        TESTS_2_1.test_6_1_54.expect(ExpectedResults {
+            case_01: Err(vec![create_invalid_license_expression_error(
                 "This is a license text that should not be here.",
                 r#"Error at position 5: expected one of `AND`, `OR`, `WITH`, `)`, `+` here"#,
             )]),
-            // Ok(()),
+            case_02: // Ok(()),
             Err(vec![create_invalid_license_expression_error(
                 "DocumentRef-some-document-reference:LicenseRef-www.example.org-Example-CSAF-License-2.0",
                 r#"Error at position 0: expected a `LicenseRef` here"#,
             )]),
-            Err(vec![create_invalid_license_expression_error(
+            case_03: Err(vec![create_invalid_license_expression_error(
                 "LicenseRef-www.example.org-Example-CSAF-License-3.0+",
                 r#"Error at position 51: expected one of `AND`, `OR`, `WITH`, `)` here"#,
             )]),
-            Err(vec![create_invalid_license_expression_error(
+            case_04: Err(vec![create_invalid_license_expression_error(
                 "LicenseRef-www.example.org/Example-CSAF-License-3.0",
                 "Error at position 26: invalid character(s)",
             )]),
-            Err(vec![create_invalid_license_expression_error(
+            case_05: Err(vec![create_invalid_license_expression_error(
                 "LicenseRef-www.example.org%20Example-CSAF-License-3.0",
                 "Error at position 26: invalid character(s)",
             )]),
-            Err(vec![create_invalid_license_expression_error(
+            case_06: Err(vec![create_invalid_license_expression_error(
                 "LicenseRef-www.example.org#Example-CSAF-License-3.0",
                 "Error at position 26: invalid character(s)",
             )]),
-            Ok(()), // TODO: clarify if licenseref-... should be allowed, #672
-            Ok(()), // TODO: clarify if licenseREF-... should be allowed, #672
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_07: Ok(()), // TODO: clarify if licenseref-... should be allowed, #672
+            case_08: Ok(()), // TODO: clarify if licenseREF-... should be allowed, #672
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_54.rs
+++ b/csaf-rs/src/validations/test_6_1_54.rs
@@ -2,13 +2,13 @@ use spdx::Expression;
 
 use crate::csaf_traits::CsafTrait;
 use crate::schema::csaf2_1::schema::LicenseExpression;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_invalid_license_expression_error(license_expression: &str, error: &str) -> ValidationError {
-    ValidationError {
+fn create_invalid_license_expression_error(license_expression: &str, error: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid license expression '{license_expression}': {error}."),
         instance_path: "/document/license_expression".to_string(),
-    }
+    })
 }
 
 /// Parses the given license expression using the SPDX parser with specific options that align with the requirements of CSAF.
@@ -60,7 +60,7 @@ fn parse_license_as_allowed_in_csaf(license: &LicenseExpression) -> Result<Expre
 /// on the DocumentRef part given in 3.2.2.7.
 pub fn test_6_1_54_invalid_license_expression(
     doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     document

--- a/csaf-rs/src/validations/test_6_1_55.rs
+++ b/csaf-rs/src/validations/test_6_1_55.rs
@@ -111,6 +111,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_55, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_55 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -126,14 +127,14 @@ mod tests {
         )]);
         let case_s01_multiple = Err(vec![MULTIPLE_LICENSE_TEXT_ERROR.clone()]);
 
-        TESTS_2_1.test_6_1_55.expect(
-            case_01_category_other,
-            case_02_category_general,
-            case_s01_multiple,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_55.expect(ExpectedResults {
+            case_01: case_01_category_other,
+            case_02: case_02_category_general,
+            case_s01: case_s01_multiple,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_55.rs
+++ b/csaf-rs/src/validations/test_6_1_55.rs
@@ -6,26 +6,27 @@ use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
 use crate::helpers::SCANCODE_LICENSEDB_LICENSES;
 use crate::schema::csaf2_1::schema::LicenseExpression;
 use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static MISSING_LICENSE_TEXT_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "Missing license text (document note with title 'License') for non-standard license.".to_string(),
-    instance_path: "/document/license_expression".to_string(),
+static MISSING_LICENSE_TEXT_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: "Missing license text (document note with title 'License') for non-standard license.".to_string(),
+        instance_path: "/document/license_expression".to_string(),
+    })
 });
 
-static MULTIPLE_LICENSE_TEXT_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "Multiple license texts (document notes with title 'License') for non-standard license.".to_string(),
-    instance_path: "/document/license_expression".to_string(),
+static MULTIPLE_LICENSE_TEXT_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Error(TestFindingData {
+        message: "Multiple license texts (document notes with title 'License') for non-standard license.".to_string(),
+        instance_path: "/document/license_expression".to_string(),
+    })
 });
 
-fn create_incorrect_license_text_category_error(
-    license_expression_path: &str,
-    category: &NoteCategory,
-) -> ValidationError {
-    ValidationError {
+fn create_incorrect_license_text_category_error(license_expression_path: &str, category: &NoteCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Invalid category for license text: '{category}' instead of 'legal_disclaimer'."),
         instance_path: license_expression_path.to_string(),
-    }
+    })
 }
 
 fn license_listed_in_spdx_licensedb(license: &LicenseExpression) -> bool {
@@ -49,9 +50,9 @@ fn is_english_or_default(doc: &impl CsafTrait) -> bool {
     }
 }
 
-fn expect_exactly_one_license_text(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+fn expect_exactly_one_license_text(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     if let Some(notes) = doc.get_document().get_notes() {
-        let mut errors: Option<Vec<ValidationError>> = None;
+        let mut errors: Option<Vec<TestFinding>> = None;
         let license_notes = notes
             .iter()
             .enumerate()
@@ -91,7 +92,7 @@ fn expect_exactly_one_license_text(doc: &impl CsafTrait) -> Result<(), Vec<Valid
 /// MUST be legal_disclaimer.
 pub fn test_6_1_55_license_text(
     doc: &crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     if document

--- a/csaf-rs/src/validations/test_6_1_56.rs
+++ b/csaf-rs/src/validations/test_6_1_56.rs
@@ -1,20 +1,20 @@
 use std::collections::HashMap;
 
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn generate_cvss_and_qualitative_error(
     product_id: &str,
     source: &Option<String>,
     v_i: usize,
     m_i: usize,
-) -> ValidationError {
+) -> TestFinding {
     let source_str = match source {
         Some(s) => format!("and source '{s}'"),
         None => "by author".to_string(),
     };
 
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!(
             "Vulnerability has both a CVSS score and qualitative severity rating for product_id '{product_id}' {source_str}"
         ),
@@ -23,17 +23,17 @@ fn generate_cvss_and_qualitative_error(
         // So even if we implement running CSAF 2.1 tests for CSAF 2.0 docs, this test will always pass,
         // as the offending metric type does not exist on CSAF 2.0, and this will never print the wrong path.
         instance_path: format!("/vulnerabilities/{v_i}/metrics/{m_i}/content/qualitative_severity_rating",),
-    }
+    })
 }
 
 /// 6.1.56 Use of CVSS and Qualitative Severity Rating
 ///
 /// In each vulnerability, for each tuple of Product ID and source, there cannot be both a CVSS score
 /// and a qualitative severity rating present.
-pub fn test_6_1_56_cvss_and_qualitative_severity_rating(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_1_56_cvss_and_qualitative_severity_rating(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     type ProductIdSourceTuple = (String, Option<String>);
     type HasRatingsTuple = (usize, bool, bool);
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // for each vulnerability
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_1_56.rs
+++ b/csaf-rs/src/validations/test_6_1_56.rs
@@ -81,6 +81,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_56 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -149,20 +150,20 @@ mod tests {
         // Case 18: complex case, 4 vulnerabilities, all of them with 2 metrics, overlapping product,
         // different sources, one with CVSS and the other with qualitative, but differently ordered
 
-        TESTS_2_1.test_6_1_56.expect(
-            qualitative_in_second_metric_no_source.clone(),
-            case_02_qualitative_in_first_metric_no_source,
-            qualitative_in_second_metric_no_source.clone(),
-            qualitative_in_second_metric_no_source,
-            case_05_err,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_56.expect(ExpectedResults {
+            case_01: qualitative_in_second_metric_no_source.clone(),
+            case_02: case_02_qualitative_in_first_metric_no_source,
+            case_03: qualitative_in_second_metric_no_source.clone(),
+            case_04: qualitative_in_second_metric_no_source,
+            case_05: case_05_err,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+            case_17: Ok(()),
+            case_18: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_1_57.rs
+++ b/csaf-rs/src/validations/test_6_1_57.rs
@@ -78,6 +78,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_57, test_6_
 #[cfg(test)]
 mod tests {
     use crate::csaf_traits::CategoryOfTheBranch;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_57 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use crate::validations::test_6_1_57::create_stacked_categories_error;
 
@@ -135,8 +136,13 @@ mod tests {
         // Case 12: 30 branches deep, but the only stacked category is product_family
         // Case 13: breadth with no stacked categories
 
-        TESTS_2_1
-            .test_6_1_57
-            .expect(case_01_simple, case_02_depth, case_03_breadth, Ok(()), Ok(()), Ok(()))
+        TESTS_2_1.test_6_1_57.expect(ExpectedResults {
+            case_01: case_01_simple,
+            case_02: case_02_depth,
+            case_03: case_03_breadth,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        })
     }
 }

--- a/csaf-rs/src/validations/test_6_1_57.rs
+++ b/csaf-rs/src/validations/test_6_1_57.rs
@@ -1,11 +1,11 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait, build_leaf_instance_path};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
 fn create_stacked_categories_error(
     stacked_categories: &[(CategoryOfTheBranch, &u64)],
     instance_path: String,
-) -> ValidationError {
+) -> TestFinding {
     // singular / plural of category
     let category_word = if stacked_categories.len() == 1 {
         "category"
@@ -18,18 +18,18 @@ fn create_stacked_categories_error(
         .map(|(cat, count)| format!("{cat} ({count})"))
         .collect();
     let stacked_list_str = stacked_list.join(", ");
-    ValidationError {
+    TestFinding::Error(TestFindingData {
         message: format!("Stacked branch {category_word} found in path: {stacked_list_str}"),
         instance_path,
-    }
+    })
 }
 
 /// 6.1.57 Stacked Branch Categories
 ///
 /// In the product tree, the path from root to any FPN, all branch categories (except 'product_family')
 /// are only allowed to occur once.
-pub fn test_6_1_57_stacked_branch_categories(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_57_stacked_branch_categories(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(()); // this will be a Passed::NoData later (#409)

--- a/csaf-rs/src/validations/test_6_1_58.rs
+++ b/csaf-rs/src/validations/test_6_1_58.rs
@@ -56,6 +56,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::create_both_product_version_version_range_error;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_58 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -71,6 +72,9 @@ mod tests {
         ]);
         // Case 11: Only version range
 
-        TESTS_2_1.test_6_1_58.expect(case_01, Ok(()))
+        TESTS_2_1.test_6_1_58.expect(ExpectedResults {
+            case_01,
+            case_11: Ok(()),
+        })
     }
 }

--- a/csaf-rs/src/validations/test_6_1_58.rs
+++ b/csaf-rs/src/validations/test_6_1_58.rs
@@ -1,11 +1,11 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait, build_leaf_instance_path};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_both_product_version_version_range_error(instance_path: String) -> ValidationError {
-    ValidationError {
+fn create_both_product_version_version_range_error(instance_path: String) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: "Path contains both branches with category 'product_version' and 'product_version_range'".to_string(),
         instance_path,
-    }
+    })
 }
 
 /// 6.1.58 Use of product_version in one Path with product_version_range
@@ -14,12 +14,12 @@ fn create_both_product_version_version_range_error(instance_path: String) -> Val
 /// and 'product_version_range' are not allowed to occur together.
 pub fn test_6_1_58_product_version_and_product_version_range_in_one_path(
     doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(()); // this will be a Passed::NoData later (#409)
     };
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // get all paths from root to leaves in the product tree
     let leaf_paths = product_tree.collect_leaf_paths();

--- a/csaf-rs/src/validations/test_6_1_61.rs
+++ b/csaf-rs/src/validations/test_6_1_61.rs
@@ -1,16 +1,16 @@
 use crate::csaf::types::csaf_product_id_helper_number::CsafStockKeepingUnit;
 use crate::csaf_traits::{CsafTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_multiple_stars_sku_error(sku: &CsafStockKeepingUnit, path: &str, index: usize) -> ValidationError {
-    ValidationError {
+fn create_multiple_stars_sku_error(sku: &CsafStockKeepingUnit, path: &str, index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: format!("Stock keeping unit '{sku}' must not contain multiple unescaped asterisks (stars)"),
         instance_path: format!("{path}/product_identification_helper/skus/{index}"),
-    }
+    })
 }
 
-pub fn test_6_1_61_multiple_stars_in_sku(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_1_61_multiple_stars_in_sku(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_products(&mut |product, path| {

--- a/csaf-rs/src/validations/test_6_1_61.rs
+++ b/csaf-rs/src/validations/test_6_1_61.rs
@@ -36,6 +36,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_1_61, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_1_61 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -54,12 +55,12 @@ mod tests {
         // Case 12: One unescaped star, multiple escaped stars
         // Case 13: Escaped stars, also escaped question mark
 
-        TESTS_2_1.test_6_1_61.expect(
-            case01_two_unescaped,
-            case02_escaped_unescaped_mixed,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_1_61.expect(ExpectedResults {
+            case_01: case01_two_unescaped,
+            case_02: case02_escaped_unescaped_mixed,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_01.rs
+++ b/csaf-rs/src/validations/test_6_2_01.rs
@@ -1,13 +1,13 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
 
-fn create_unused_product_id_error(product_id: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn create_unused_product_id_error(product_id: &str, path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("Product ID '{product_id}' is defined but not referenced in the document"),
         instance_path: format!("{path}/product_id"),
-    }
+    })
 }
 
 const SKIP_TEST_CONFIG: DocumentCategoryTestConfig =
@@ -16,8 +16,8 @@ const SKIP_TEST_CONFIG: DocumentCategoryTestConfig =
 /// 6.2.1 Unused Definition of Product ID
 ///
 /// All defined product IDs need to be referenced at least once in the document.
-pub fn test_6_2_01_unused_definition_of_product_id(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_01_unused_definition_of_product_id(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // Skips the test for profile "Informational Advisory"
     if SKIP_TEST_CONFIG.matches_category(&doc.get_document().get_category()) {

--- a/csaf-rs/src/validations/test_6_2_01.rs
+++ b/csaf-rs/src/validations/test_6_2_01.rs
@@ -46,7 +46,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_1, test_6_2_01_unuse
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_1 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_1 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -57,7 +59,13 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_1.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_2_1.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_2_1.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_1.expect(ExpectedResults_2_1 {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_02.rs
+++ b/csaf-rs/src/validations/test_6_2_02.rs
@@ -121,7 +121,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_2, test_6_2_02_missi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_2 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_2 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -134,7 +136,9 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_2.expect(case_01.clone());
-        TESTS_2_1.test_6_2_2.expect(case_01);
+        TESTS_2_0.test_6_2_2.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+        });
+        TESTS_2_1.test_6_2_2.expect(ExpectedResults_2_1 { case_01 });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_02.rs
+++ b/csaf-rs/src/validations/test_6_2_02.rs
@@ -1,6 +1,6 @@
 use crate::csaf_traits::{CsafTrait, ProductStatusTrait, RemediationTrait, VulnerabilityTrait, WithOptionalProductIds};
 use crate::schema::csaf2_1::schema::CategoryOfTheRemediation;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
 fn create_missing_remediation_error(
@@ -8,19 +8,19 @@ fn create_missing_remediation_error(
     status_group_name: &str,
     status_group_product_index: usize,
     product_id: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Missing at least a remediation of category 'none_available' or 'no_fix_planned' for product ID '{product_id}' in product status group '{status_group_name}'",
         ),
         instance_path: format!(
             "/vulnerabilities/{vulnerability_index}/product_status/{status_group_name}/{status_group_product_index}"
         ),
-    }
+    })
 }
 
 fn check_product_status_group_for_missing_remediations<'a>(
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
     status_group_product_ids: impl Iterator<Item = &'a str>,
     remediation_product_ids: &HashSet<String>,
     vulnerability_index: usize,
@@ -44,8 +44,8 @@ fn check_product_status_group_for_missing_remediations<'a>(
 ///
 /// For each product in status groups "affected" or "under investigation", a remediation of category
 /// `none_available` or `no_fix_planned` must exist.
-pub fn test_6_2_02_missing_remediations(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_02_missing_remediations(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // for each vulnerability
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_2_03.rs
+++ b/csaf-rs/src/validations/test_6_2_03.rs
@@ -1,5 +1,5 @@
 use crate::csaf_traits::{CsafTrait, MetricTrait, ProductStatusTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
 fn create_missing_metric_error(
@@ -7,19 +7,19 @@ fn create_missing_metric_error(
     status_group_name: &str,
     status_group_product_index: usize,
     product_id: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Missing at least one metric for product ID '{product_id}' in product status group '{status_group_name}'",
         ),
         instance_path: format!(
             "/vulnerabilities/{vulnerability_index}/product_status/{status_group_name}/{status_group_product_index}"
         ),
-    }
+    })
 }
 
 fn check_product_status_group_for_missing_metrics<'a>(
-    errors: &mut Option<Vec<ValidationError>>,
+    errors: &mut Option<Vec<TestFinding>>,
     status_group_product_ids: impl Iterator<Item = &'a str>,
     remediation_product_ids: &HashSet<String>,
     vulnerability_index: usize,
@@ -42,8 +42,8 @@ fn check_product_status_group_for_missing_metrics<'a>(
 /// 6.2.3 Missing Metric
 ///
 /// For each product in status groups "affected", a metric must exist.
-pub fn test_6_2_03_missing_metric(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_03_missing_metric(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // for each vulnerability
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_2_03.rs
+++ b/csaf-rs/src/validations/test_6_2_03.rs
@@ -106,7 +106,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_3, test_6_2_03_missi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_3 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_3 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -119,7 +121,9 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_3.expect(case_01.clone());
-        TESTS_2_1.test_6_2_3.expect(case_01);
+        TESTS_2_0.test_6_2_3.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+        });
+        TESTS_2_1.test_6_2_3.expect(ExpectedResults_2_1 { case_01 });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_04.rs
+++ b/csaf-rs/src/validations/test_6_2_04.rs
@@ -43,7 +43,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_4, test_6_2_04_build
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_4 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_4 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use semver::Version;
     use std::str::FromStr;
@@ -56,7 +58,9 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_4.expect(case_01.clone());
-        TESTS_2_1.test_6_2_4.expect(case_01);
+        TESTS_2_0.test_6_2_4.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+        });
+        TESTS_2_1.test_6_2_4.expect(ExpectedResults_2_1 { case_01 });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_04.rs
+++ b/csaf-rs/src/validations/test_6_2_04.rs
@@ -1,12 +1,12 @@
 use crate::csaf::types::version_number::{CsafVersionNumber, SemVerVersion};
 use crate::csaf_traits::{CsafTrait, DocumentTrait, RevisionTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.4 Build Metadata in Revision History
 ///
 /// The revision history must not contain build metadata in their `number` field
-pub fn test_6_2_04_build_metadata_in_rev_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_04_build_metadata_in_rev_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (revision_index, revision) in doc
         .get_document()
@@ -31,11 +31,11 @@ pub fn test_6_2_04_build_metadata_in_rev_history(doc: &impl CsafTrait) -> Result
     errors.map_or(Ok(()), Err)
 }
 
-fn create_build_metadata_in_rev_history_error(number: &SemVerVersion, revision_index: &usize) -> ValidationError {
-    ValidationError {
+fn create_build_metadata_in_rev_history_error(number: &SemVerVersion, revision_index: &usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("Revision history item with number '{number}' contains build metadata"),
         instance_path: format!("/document/tracking/revision_history/{revision_index}/number"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_4, test_6_2_04_build_metadata_in_rev_history);

--- a/csaf-rs/src/validations/test_6_2_05.rs
+++ b/csaf-rs/src/validations/test_6_2_05.rs
@@ -1,22 +1,22 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime::Valid;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn create_older_initial_release_date_error(
     initial_release_date: impl std::fmt::Display,
     earliest_rev_history_release_date: impl std::fmt::Display,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Initial release date '{initial_release_date}' is older than the earliest revision history date '{earliest_rev_history_release_date}'"
         ),
         instance_path: "/document/tracking/initial_release_date".to_string(),
-    }
+    })
 }
 
 /// 6.2.5 Older Initial Release Date than Revision History
 ///
-pub fn test_6_2_05_older_init_release_than_rev_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_05_older_init_release_than_rev_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let initial_release_date = doc.get_document().get_tracking().get_initial_release_date();
     // TODO: Check for invalid dates here, will be done after revision history refactor, which will introduce
     // generic parsing error handling

--- a/csaf-rs/src/validations/test_6_2_05.rs
+++ b/csaf-rs/src/validations/test_6_2_05.rs
@@ -48,29 +48,31 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_5, test_6_2_05_older
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_5 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_5 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_2_05() {
         // Both CSAF 2.0 and 2.1 have test cases
-        TESTS_2_0
-            .test_6_2_5
-            .expect(Err(vec![create_older_initial_release_date_error(
+        TESTS_2_0.test_6_2_5.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![create_older_initial_release_date_error(
                 "2021-04-22T10:00:00.000Z",
                 "2021-05-06T10:00:00.000Z",
-            )]));
-        TESTS_2_1.test_6_2_5.expect(
-            Err(vec![create_older_initial_release_date_error(
+            )]),
+        });
+        TESTS_2_1.test_6_2_5.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![create_older_initial_release_date_error(
                 "2023-08-22T10:00:00.000Z",
                 "2023-09-06T10:00:00.000Z",
             )]),
-            Err(vec![create_older_initial_release_date_error(
+            case_02: Err(vec![create_older_initial_release_date_error(
                 "2023-09-06T10:00:00.000+10:00",
                 "2023-09-06T10:00:00.000-01:00",
             )]),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_06.rs
+++ b/csaf-rs/src/validations/test_6_2_06.rs
@@ -1,22 +1,22 @@
 use crate::csaf::types::csaf_datetime::CsafDateTime::Valid;
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn create_older_current_release_date_error(
     current_release_date: impl std::fmt::Display,
     newest_rev_history_release_date: impl std::fmt::Display,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Current release date '{current_release_date}' is older than the newest revision history date '{newest_rev_history_release_date}'"
         ),
         instance_path: "/document/tracking/current_release_date".to_string(),
-    }
+    })
 }
 
 /// 6.2.6 Older Current Release Date than Revision History
 ///
-pub fn test_6_2_06_older_current_release_than_rev_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_06_older_current_release_than_rev_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let current_release_date = doc.get_document().get_tracking().get_current_release_date();
     // TODO: Check for invalid dates here, will be done after revision history refactor, which will introduce
     // generic parsing error handling

--- a/csaf-rs/src/validations/test_6_2_06.rs
+++ b/csaf-rs/src/validations/test_6_2_06.rs
@@ -51,34 +51,36 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_6 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_6 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_2_06() {
         // Both CSAF 2.0 and 2.1 have test cases
-        TESTS_2_0
-            .test_6_2_6
-            .expect(Err(vec![create_older_current_release_date_error(
+        TESTS_2_0.test_6_2_6.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![create_older_current_release_date_error(
                 "2021-05-06T10:00:00.000Z",
                 "2021-07-21T11:00:00.000Z",
-            )]));
-        TESTS_2_1.test_6_2_6.expect(
-            Err(vec![create_older_current_release_date_error(
+            )]),
+        });
+        TESTS_2_1.test_6_2_6.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![create_older_current_release_date_error(
                 "2023-09-06T10:00:00.000Z",
                 "2024-01-21T11:00:00.000Z",
             )]),
-            Err(vec![create_older_current_release_date_error(
+            case_02: Err(vec![create_older_current_release_date_error(
                 "2024-01-21T11:00:00.000+11:00",
                 "2024-01-21T11:00:00.000+10:00",
             )]),
-            Err(vec![create_older_current_release_date_error(
+            case_03: Err(vec![create_older_current_release_date_error(
                 "2024-01-22T11:00:00.000+11:30",
                 "2024-01-21T13:00:00.000-11:30",
             )]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_07.rs
+++ b/csaf-rs/src/validations/test_6_2_07.rs
@@ -36,7 +36,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_7, test_6_2_07_missi
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_7 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_7 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -44,7 +46,9 @@ mod tests {
         let case_01 = Err(vec![create_missing_date_in_involvements_error(0, 0)]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_7.expect(case_01.clone());
-        TESTS_2_1.test_6_2_7.expect(case_01);
+        TESTS_2_0.test_6_2_7.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+        });
+        TESTS_2_1.test_6_2_7.expect(ExpectedResults_2_1 { case_01 });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_07.rs
+++ b/csaf-rs/src/validations/test_6_2_07.rs
@@ -1,11 +1,11 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait, WithOptionalDate};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.7 Missing Date in Involvements
 ///
 /// Each involvement item must have the `date` field set.
-pub fn test_6_2_07_missing_date_in_involvements(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_07_missing_date_in_involvements(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // for each vuln and each of its involvements, check if date is set
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
@@ -24,11 +24,11 @@ pub fn test_6_2_07_missing_date_in_involvements(doc: &impl CsafTrait) -> Result<
     errors.map_or(Ok(()), Err)
 }
 
-fn create_missing_date_in_involvements_error(vulnerability_index: usize, involvement_index: usize) -> ValidationError {
-    ValidationError {
+fn create_missing_date_in_involvements_error(vulnerability_index: usize, involvement_index: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: "Involvement item is missing required 'date' field".to_string(),
         instance_path: format!("/vulnerabilities/{vulnerability_index}/involvements/{involvement_index}"),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_7, test_6_2_07_missing_date_in_involvements);

--- a/csaf-rs/src/validations/test_6_2_08.rs
+++ b/csaf-rs/src/validations/test_6_2_08.rs
@@ -41,7 +41,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_8, test_6_2_08_use_o
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_8 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_8 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -56,14 +58,16 @@ mod tests {
         // Case S01: (CSAF 2.0 only) two md5 hashes one with non-default casing
         // Case S11: two file hashes, one with md5
 
-        TESTS_2_0.test_6_2_8.expect(
-            case_01_and_02.clone(),
-            case_01_and_02.clone(),
-            case_01_and_02.clone(),
-            Ok(()),
-        );
-        TESTS_2_1
-            .test_6_2_8
-            .expect(case_01_and_02.clone(), case_01_and_02, Ok(()));
+        TESTS_2_0.test_6_2_8.expect(ExpectedResults_2_0 {
+            case_01: case_01_and_02.clone(),
+            case_02: case_01_and_02.clone(),
+            case_s01: case_01_and_02.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_8.expect(ExpectedResults_2_1 {
+            case_01: case_01_and_02.clone(),
+            case_02: case_01_and_02,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_08.rs
+++ b/csaf-rs/src/validations/test_6_2_08.rs
@@ -1,13 +1,13 @@
 use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
 use crate::csaf_traits::{CsafTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.8 Use of MD5 as the only Hash Algorithm
 ///
 /// When hashes are provided as product identification helpers for a product, another hash
 /// besides a MD5 hash must be provided.
-pub fn test_6_2_08_use_of_md5_as_only_hash_algo(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_08_use_of_md5_as_only_hash_algo(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // for each product in the product tree, check all product identification helper hashes for MD5 as the only hash algorithm
     if let Some(tree) = doc.get_product_tree() {
@@ -29,11 +29,11 @@ pub fn test_6_2_08_use_of_md5_as_only_hash_algo(doc: &impl CsafTrait) -> Result<
     errors.map_or(Ok(()), Err)
 }
 
-fn create_md5_only_hash_error(path: &str, hash_index: usize) -> ValidationError {
-    ValidationError {
+fn create_md5_only_hash_error(path: &str, hash_index: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: "Product identification helper uses hashes with `md5` as the only hash algorithm".to_string(),
         instance_path: format!("{path}/product_identification_helper/hashes/{hash_index}/file_hashes",),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_8, test_6_2_08_use_of_md5_as_only_hash_algo);

--- a/csaf-rs/src/validations/test_6_2_09.rs
+++ b/csaf-rs/src/validations/test_6_2_09.rs
@@ -41,7 +41,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_9, test_6_2_09_use_o
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_9 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_9 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -56,14 +58,16 @@ mod tests {
         // Case S01: (CSAF 2.0 only) two sha1 hashes with non-default casing
         // Case S11: two file hashes, one with sha1
 
-        TESTS_2_0.test_6_2_9.expect(
-            case_01_and_02.clone(),
-            case_01_and_02.clone(),
-            case_01_and_02.clone(),
-            Ok(()),
-        );
-        TESTS_2_1
-            .test_6_2_9
-            .expect(case_01_and_02.clone(), case_01_and_02, Ok(()));
+        TESTS_2_0.test_6_2_9.expect(ExpectedResults_2_0 {
+            case_01: case_01_and_02.clone(),
+            case_02: case_01_and_02.clone(),
+            case_s01: case_01_and_02.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_9.expect(ExpectedResults_2_1 {
+            case_01: case_01_and_02.clone(),
+            case_02: case_01_and_02,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_09.rs
+++ b/csaf-rs/src/validations/test_6_2_09.rs
@@ -1,13 +1,13 @@
 use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
 use crate::csaf_traits::{CsafTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.9 Use of SHA1 as the only Hash Algorithm
 ///
 /// When hashes are provided as product identification helpers for a product, another hash
 /// besides a SHA1 hash must be provided.
-pub fn test_6_2_09_use_of_sha1_as_only_hash_algo(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_09_use_of_sha1_as_only_hash_algo(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // For each product and its product identification helpers, check if any hash uses SHA-1 as the only hash algorithm.
     if let Some(tree) = doc.get_product_tree() {
@@ -29,11 +29,11 @@ pub fn test_6_2_09_use_of_sha1_as_only_hash_algo(doc: &impl CsafTrait) -> Result
     errors.map_or(Ok(()), Err)
 }
 
-fn create_sha1_only_hash_error(path: &str, hash_index: usize) -> ValidationError {
-    ValidationError {
+fn create_sha1_only_hash_error(path: &str, hash_index: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: "Product identification helper uses hashes with `sha1` as the only hash algorithm".to_string(),
         instance_path: format!("{path}/product_identification_helper/hashes/{hash_index}/file_hashes",),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_9, test_6_2_09_use_of_sha1_as_only_hash_algo);

--- a/csaf-rs/src/validations/test_6_2_10.rs
+++ b/csaf-rs/src/validations/test_6_2_10.rs
@@ -1,5 +1,5 @@
 use crate::csaf_traits::{CsafTrait, CsafVersion, DistributionTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::sync::LazyLock;
 
 /// 6.2.10 Missing TLP label
@@ -10,7 +10,7 @@ use std::sync::LazyLock;
 /// The test harness for CSAF 2.1 does not include the test.
 /// If the test function was to be called programmatically on a CSAF 2.1 doc, we are returning
 /// Ok(()). (later wasSkipped TODO)
-pub fn test_6_2_10_missing_tlp_label(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_10_missing_tlp_label(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     // In CSAF 2.1 this field is mandatory and validated via the schema, so we skip this test
     if doc.get_document().get_csaf_version() == CsafVersion::X21 {
         return Ok(()); // TODO #409 wasSkipped
@@ -28,9 +28,11 @@ pub fn test_6_2_10_missing_tlp_label(doc: &impl CsafTrait) -> Result<(), Vec<Val
     }
 }
 
-static MISSING_TLP_LABEL_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "The CSAF document has no TLP label".to_string(),
-    instance_path: "/document/distribution/tlp/label".to_string(),
+static MISSING_TLP_LABEL_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "The CSAF document has no TLP label".to_string(),
+        instance_path: "/document/distribution/tlp/label".to_string(),
+    })
 });
 
 crate::test_validation::impl_validator!(csaf2_0, ValidatorForTest6_2_10, test_6_2_10_missing_tlp_label);

--- a/csaf-rs/src/validations/test_6_2_10.rs
+++ b/csaf-rs/src/validations/test_6_2_10.rs
@@ -38,6 +38,7 @@ crate::test_validation::impl_validator!(csaf2_0, ValidatorForTest6_2_10, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_10 as ExpectedResults;
     use crate::csaf2_0::testcases::TESTS_2_0;
 
     #[test]
@@ -46,7 +47,10 @@ mod tests {
 
         // Case S11: A CSAF 2.0 document with a valid TLP label
 
-        TESTS_2_0.test_6_2_10.expect(err, Ok(()));
+        TESTS_2_0.test_6_2_10.expect(ExpectedResults {
+            case_01: err,
+            case_s11: Ok(()),
+        });
     }
 
     /// Check that the test is skipped (returns Ok) for CSAF 2.1 documents.

--- a/csaf-rs/src/validations/test_6_2_11.rs
+++ b/csaf-rs/src/validations/test_6_2_11.rs
@@ -25,7 +25,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_11, test_6_2_11_miss
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_11 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_11 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -34,11 +36,19 @@ mod tests {
         let ok = Ok(());
 
         // CSAF 2.0 has 2 test cases
-        TESTS_2_0.test_6_2_11.expect(err.clone(), ok.clone());
+        TESTS_2_0.test_6_2_11.expect(ExpectedResults_2_0 {
+            case_01: err.clone(),
+            case_11: ok.clone(),
+        });
 
         // CSAF 2.1 has 6 test cases
-        TESTS_2_1
-            .test_6_2_11
-            .expect(err.clone(), err.clone(), err, ok.clone(), ok.clone(), ok);
+        TESTS_2_1.test_6_2_11.expect(ExpectedResults_2_1 {
+            case_01: err.clone(),
+            case_02: err.clone(),
+            case_03: err,
+            case_11: ok.clone(),
+            case_12: ok.clone(),
+            case_13: ok,
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_11.rs
+++ b/csaf-rs/src/validations/test_6_2_11.rs
@@ -1,5 +1,5 @@
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::sync::LazyLock;
 
 /// 6.2.11 Missing Canonical URL
@@ -8,16 +8,18 @@ use std::sync::LazyLock;
 /// - category = "self"
 /// - url starts with "https://"
 /// - url ends with the valid filename according to section 5.1
-pub fn test_6_2_11_missing_canonical_url(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_11_missing_canonical_url(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     if !doc.get_document().has_canonical_url() {
         return Err(vec![MISSING_CANONICAL_URL.clone()]);
     }
     Ok(())
 }
 
-static MISSING_CANONICAL_URL: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "Document is missing a canonical URL".to_string(),
-    instance_path: "/document/references".to_string(),
+static MISSING_CANONICAL_URL: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "Document is missing a canonical URL".to_string(),
+        instance_path: "/document/references".to_string(),
+    })
 });
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_11, test_6_2_11_missing_canonical_url);

--- a/csaf-rs/src/validations/test_6_2_12.rs
+++ b/csaf-rs/src/validations/test_6_2_12.rs
@@ -1,20 +1,22 @@
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::sync::LazyLock;
 
 /// 6.2.12 Missing Document Language
 ///
 /// `/document/lang` must be set.
-pub fn test_6_2_12_missing_document_language(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_12_missing_document_language(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     if doc.get_document().get_lang().is_none() {
         return Err(vec![MISSING_DOCUMENT_LANGUAGE.clone()]);
     }
     Ok(())
 }
 
-static MISSING_DOCUMENT_LANGUAGE: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "The document language is not defined".to_string(),
-    instance_path: "/document/lang".to_string(),
+static MISSING_DOCUMENT_LANGUAGE: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "The document language is not defined".to_string(),
+        instance_path: "/document/lang".to_string(),
+    })
 });
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_12, test_6_2_12_missing_document_language);

--- a/csaf-rs/src/validations/test_6_2_12.rs
+++ b/csaf-rs/src/validations/test_6_2_12.rs
@@ -22,7 +22,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_12, test_6_2_12_miss
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_12 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_12 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -30,7 +32,9 @@ mod tests {
         let err = Err(vec![MISSING_DOCUMENT_LANGUAGE.clone()]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_12.expect(err.clone());
-        TESTS_2_1.test_6_2_12.expect(err);
+        TESTS_2_0
+            .test_6_2_12
+            .expect(ExpectedResults_2_0 { case_01: err.clone() });
+        TESTS_2_1.test_6_2_12.expect(ExpectedResults_2_1 { case_01: err });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_13.rs
+++ b/csaf-rs/src/validations/test_6_2_13.rs
@@ -1,16 +1,16 @@
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use serde_json::Value;
 
 /// 6.2.13 Sorting
 ///
 /// All keys in a CSAF document must be sorted alphabetically.
-pub fn test_6_2_13_sorting(json: &Value) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_13_sorting(json: &Value) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
     check_sorted_recursive(json, "", &mut errors);
     errors.map_or(Ok(()), Err)
 }
 
-fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<ValidationError>>) {
+fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<TestFinding>>) {
     match value {
         Value::Object(map) => {
             // object -> check if keys are sorted
@@ -38,11 +38,11 @@ fn check_sorted_recursive(value: &Value, path: &str, errors: &mut Option<Vec<Val
     }
 }
 
-fn create_unsorted_keys_error(path: &str) -> ValidationError {
-    ValidationError {
+fn create_unsorted_keys_error(path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: "The keys in the CSAF document are not sorted alphabetically".to_string(),
         instance_path: path.to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_raw_json_validator!(ValidatorForTest6_2_13, test_6_2_13_sorting);

--- a/csaf-rs/src/validations/test_6_2_13.rs
+++ b/csaf-rs/src/validations/test_6_2_13.rs
@@ -50,7 +50,9 @@ crate::test_validation::impl_raw_json_validator!(ValidatorForTest6_2_13, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_13 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_13 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -58,7 +60,9 @@ mod tests {
         let err = Err(vec![create_unsorted_keys_error("/document/csaf_version")]);
 
         // Both CSAF 2.0 and 2.1 have 1 test cases
-        TESTS_2_0.test_6_2_13.expect(err.clone());
-        TESTS_2_1.test_6_2_13.expect(err);
+        TESTS_2_0
+            .test_6_2_13
+            .expect(ExpectedResults_2_0 { case_01: err.clone() });
+        TESTS_2_1.test_6_2_13.expect(ExpectedResults_2_1 { case_01: err });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -1,20 +1,20 @@
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf::types::language::valid_language::PrivateUseReason;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.14 Use of Private Language
 ///
 /// For each element of type `/$defs/lang_t` it MUST be tested that the language code does not
 /// contain subtags reserved for private use.
-pub fn test_6_2_14_use_of_private_language(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_14_use_of_private_language(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     if document.get_lang().is_none() && document.get_source_lang().is_none() {
         return Ok(()); // This should be a wasSkipped later (see #409)
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     validate_private_language(document.get_lang(), "/document/lang", &mut errors);
     validate_private_language(document.get_source_lang(), "/document/source_lang", &mut errors);
@@ -31,7 +31,7 @@ pub fn test_6_2_14_use_of_private_language(doc: &impl CsafTrait) -> Result<(), V
 /// - `lang`: The (optional) language tag to validate
 /// - `json_path`: The JSON path to the language tag
 /// - `errors`: A mutable reference to the errors vector
-fn validate_private_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+fn validate_private_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     if let Some(CsafLanguage::Valid(valid_lang)) = lang
         && let Some(private_use_reasons) = valid_lang.get_private_use()
     {
@@ -47,28 +47,28 @@ fn validate_private_language(lang: Option<CsafLanguage>, json_path: &str, errors
 
 /// Keeping this in, if we ever want less "detailed" error messages.
 #[allow(dead_code)]
-fn create_private_language_error(lang_tag: String, instance_path: &str) -> ValidationError {
-    ValidationError {
+fn create_private_language_error(lang_tag: String, instance_path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("The language tag '{lang_tag}' contains subtags reserved for private use"),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 fn create_private_language_error_from_reasons(
     lang_tag: String,
     reasons: &[PrivateUseReason],
     instance_path: &str,
-) -> ValidationError {
+) -> TestFinding {
     // Reasons are constructed in the fixed order from ValidCsafLanguage::get_private_use, so no sorting is necessary here
     let reasons_str = reasons
         .iter()
         .map(|reason| reason.to_string())
         .collect::<Vec<String>>()
         .join(", ");
-    ValidationError {
+    TestFinding::Warning(TestFindingData {
         message: format!("The language tag '{lang_tag}' contains subtags reserved for private use: {reasons_str}"),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_14, test_6_2_14_use_of_private_language);

--- a/csaf-rs/src/validations/test_6_2_14.rs
+++ b/csaf-rs/src/validations/test_6_2_14.rs
@@ -76,7 +76,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_14, test_6_2_14_use_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_14 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_14 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -161,33 +163,33 @@ mod tests {
         // Case 11: /document/lang is set to a non-private language
         // Case 12: Both are set to non-private languages
 
-        TESTS_2_0.test_6_2_14.expect(
-            case_01_private_primary_lang.clone(),
-            case_02_private_primary_source_lang.clone(),
-            case_03_both_private_primary_lang.clone(),
-            case_04_private_region_qm.clone(),
-            case_05_private_region_xp.clone(),
-            case_06_private_script_qabc.clone(),
-            case_07_private_region_aa.clone(),
-            case_08_private_region_zz.clone(),
-            case_s01_private_use_tag.clone(),
-            case_s02_multiple_reasons.clone(),
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_2_14.expect(
-            case_01_private_primary_lang,
-            case_02_private_primary_source_lang,
-            case_03_both_private_primary_lang,
-            case_04_private_region_qm,
-            case_05_private_region_xp,
-            case_06_private_script_qabc,
-            case_07_private_region_aa,
-            case_08_private_region_zz,
-            case_s01_private_use_tag,
-            case_s02_multiple_reasons,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_2_14.expect(ExpectedResults_2_0 {
+            case_01: case_01_private_primary_lang.clone(),
+            case_02: case_02_private_primary_source_lang.clone(),
+            case_03: case_03_both_private_primary_lang.clone(),
+            case_04: case_04_private_region_qm.clone(),
+            case_05: case_05_private_region_xp.clone(),
+            case_06: case_06_private_script_qabc.clone(),
+            case_07: case_07_private_region_aa.clone(),
+            case_08: case_08_private_region_zz.clone(),
+            case_s01: case_s01_private_use_tag.clone(),
+            case_s02: case_s02_multiple_reasons.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_2_14.expect(ExpectedResults_2_1 {
+            case_01: case_01_private_primary_lang,
+            case_02: case_02_private_primary_source_lang,
+            case_03: case_03_both_private_primary_lang,
+            case_04: case_04_private_region_qm,
+            case_05: case_05_private_region_xp,
+            case_06: case_06_private_script_qabc,
+            case_07: case_07_private_region_aa,
+            case_08: case_08_private_region_zz,
+            case_s01: case_s01_private_use_tag,
+            case_s02: case_s02_multiple_reasons,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_15.rs
+++ b/csaf-rs/src/validations/test_6_2_15.rs
@@ -1,18 +1,18 @@
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.15 Use of Default Language
 ///
 /// The language tag in `/document/lang` and `/document/source_lang` must not contain the default language code `i-default`.
-pub fn test_6_2_15_use_of_default_language(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_15_use_of_default_language(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
 
     if document.get_lang().is_none() && document.get_source_lang().is_none() {
         return Ok(()); // This should be a wasSkipped later (see #409)
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     validate_default_language(document.get_lang(), "/document/lang", &mut errors);
     validate_default_language(document.get_source_lang(), "/document/source_lang", &mut errors);
@@ -29,7 +29,7 @@ pub fn test_6_2_15_use_of_default_language(doc: &impl CsafTrait) -> Result<(), V
 /// - `lang`: The (optional) language tag to validate
 /// - `json_path`: The JSON path to the language tag
 /// - `errors`: A mutable reference to the errors vector
-fn validate_default_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<ValidationError>>) {
+fn validate_default_language(lang: Option<CsafLanguage>, json_path: &str, errors: &mut Option<Vec<TestFinding>>) {
     if let Some(CsafLanguage::Valid(valid_lang)) = lang
         && valid_lang.is_default()
     {
@@ -40,11 +40,11 @@ fn validate_default_language(lang: Option<CsafLanguage>, json_path: &str, errors
     }
 }
 
-fn create_default_language_error(lang_tag: String, instance_path: &str) -> ValidationError {
-    ValidationError {
+fn create_default_language_error(lang_tag: String, instance_path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("The default language tag '{lang_tag}' may not be used"),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(ValidatorForTest6_2_15, test_6_2_15_use_of_default_language);

--- a/csaf-rs/src/validations/test_6_2_15.rs
+++ b/csaf-rs/src/validations/test_6_2_15.rs
@@ -52,7 +52,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_15, test_6_2_15_use_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_15 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_15 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -77,21 +79,21 @@ mod tests {
 
         // Case 11: /document/lang is not set to the default language
         // Case S11: Both /document/lang and /document/source_lang are missing (should be skipped? #409)
-        TESTS_2_0.test_6_2_15.expect(
-            case_01_default_lang.clone(),
-            case_02_default_source_lang.clone(),
-            case_s01_default_both_langs.clone(),
-            case_s02_default_lang_uppercase.clone(),
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_2_15.expect(
-            case_01_default_lang,
-            case_02_default_source_lang,
-            case_s01_default_both_langs,
-            case_s02_default_lang_uppercase,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_2_15.expect(ExpectedResults_2_0 {
+            case_01: case_01_default_lang.clone(),
+            case_02: case_02_default_source_lang.clone(),
+            case_s01: case_s01_default_both_langs.clone(),
+            case_s02: case_s02_default_lang_uppercase.clone(),
+            case_11: Ok(()),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_15.expect(ExpectedResults_2_1 {
+            case_01: case_01_default_lang,
+            case_02: case_02_default_source_lang,
+            case_s01: case_s01_default_both_langs,
+            case_s02: case_s02_default_lang_uppercase,
+            case_11: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_16.rs
+++ b/csaf-rs/src/validations/test_6_2_16.rs
@@ -1,5 +1,5 @@
 use crate::csaf_traits::{CsafTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.16 Missing Product Identification Helper
 ///
@@ -7,8 +7,8 @@ use crate::validation::ValidationError;
 ///
 /// As this property is not allowed to be empty in the schema, this ensures that at least
 /// one product identification helper is provided for each product.
-pub fn test_6_2_16_missing_product_identification_helper(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_16_missing_product_identification_helper(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(tree) = doc.get_product_tree() {
         tree.visit_all_products(&mut |fpn, path| {
@@ -23,11 +23,11 @@ pub fn test_6_2_16_missing_product_identification_helper(doc: &impl CsafTrait) -
     errors.map_or(Ok(()), Err)
 }
 
-fn create_missing_product_identification_helper_error(instance_path: &str) -> ValidationError {
-    ValidationError {
+fn create_missing_product_identification_helper_error(instance_path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: "Product is missing 'product_identification_helper' property".to_string(),
         instance_path: instance_path.to_string(),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(

--- a/csaf-rs/src/validations/test_6_2_16.rs
+++ b/csaf-rs/src/validations/test_6_2_16.rs
@@ -38,7 +38,9 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_16 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_16 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -51,7 +53,15 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_16.expect(case_01.clone(), case_02.clone(), Ok(()));
-        TESTS_2_1.test_6_2_16.expect(case_01, case_02, Ok(()));
+        TESTS_2_0.test_6_2_16.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_02: case_02.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_16.expect(ExpectedResults_2_1 {
+            case_01,
+            case_02,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_17.rs
+++ b/csaf-rs/src/validations/test_6_2_17.rs
@@ -1,22 +1,22 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityIdTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use regex::Regex;
 use std::sync::LazyLock;
 
 static CVE_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^CVE-[0-9]{4}-[0-9]{4,}$").unwrap());
 
-fn create_cve_in_ids_error(id: &str, vuln_index: usize, id_index: usize) -> ValidationError {
-    ValidationError {
+fn create_cve_in_ids_error(id: &str, vuln_index: usize, id_index: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("Vulnerability ID text '{id}' matches CVE format"),
         instance_path: format!("/vulnerabilities/{vuln_index}/ids/{id_index}/text"),
-    }
+    })
 }
 
 /// 6.2.17 CVE in field IDs
 ///
 /// All `/vulnerabilities[]/ids[]` items must not match the CVE ID format in their `text` field.
-pub fn test_6_2_17_cve_in_field_ids(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_17_cve_in_field_ids(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(ids) = vuln.get_ids() {

--- a/csaf-rs/src/validations/test_6_2_17.rs
+++ b/csaf-rs/src/validations/test_6_2_17.rs
@@ -38,7 +38,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_17, test_6_2_17_cve_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_17 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_17 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -46,7 +48,13 @@ mod tests {
         let case_01 = Err(vec![create_cve_in_ids_error("CVE-2021-44228", 0, 0)]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_17.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_2_17.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_2_17.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_17.expect(ExpectedResults_2_1 {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_18.rs
+++ b/csaf-rs/src/validations/test_6_2_18.rs
@@ -1,13 +1,13 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use regex::Regex;
 use std::sync::LazyLock;
 
-fn create_product_version_range_without_vers_error(version_range: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn create_product_version_range_without_vers_error(version_range: &str, path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("Product version range {version_range} does not match vers syntax"),
         instance_path: format!("{path}/name"),
-    }
+    })
 }
 
 static VERS_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^vers:[a-z.\-+][a-z0-9.\-+]*/.+").unwrap());
@@ -16,8 +16,8 @@ static VERS_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^vers:[a-z.\-
 ///
 /// Tests that in the product tree, all branches with the category `product_version_range` use vers
 /// in their `name` property.
-pub fn test_6_2_18_product_version_range_without_vers(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_18_product_version_range_without_vers(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_branches(&mut |branch, path| {

--- a/csaf-rs/src/validations/test_6_2_18.rs
+++ b/csaf-rs/src/validations/test_6_2_18.rs
@@ -39,7 +39,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_2_18, test_6_2_18_prod
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_18 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_18 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -50,7 +52,13 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_2_18.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_2_18.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_2_18.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_18.expect(ExpectedResults_2_1 {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_20.rs
+++ b/csaf-rs/src/validations/test_6_2_20.rs
@@ -141,29 +141,28 @@ crate::test_validation::impl_raw_json_validator!(csaf2_1, ValidatorForTest6_2_20
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_2_20 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_20 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_2_20() {
         // Both CSAF 2.0 and 2.1 have 1 test cases
-        TESTS_2_0
-            .test_6_2_20
-            .expect(Err(vec![create_additional_properties_error(
-                "custom_property",
-                "/document",
-            )]));
-        TESTS_2_1.test_6_2_20.expect(
-            Err(vec![create_additional_properties_error(
+        TESTS_2_0.test_6_2_20.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![create_additional_properties_error("custom_property", "/document")]),
+        });
+        TESTS_2_1.test_6_2_20.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![create_additional_properties_error(
                 "custom_property",
                 "/vulnerabilities/0/metrics/0/content/cvss_v3",
             )]),
-            Err(vec![create_additional_properties_error(
+            case_02: Err(vec![create_additional_properties_error(
                 "custom_property",
                 "/vulnerabilities/0/metrics/0/content/cvss_v4",
             )]),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_20.rs
+++ b/csaf-rs/src/validations/test_6_2_20.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use crate::{
-    validation::ValidationError,
+    validation::{TestFinding, TestFindingData},
     validations::utils::{
         validation_schema_urls::{
             CVSS_V2_SCHEMA_URL, CVSS_V3_0_SCHEMA_URL, CVSS_V3_1_SCHEMA_URL, CVSS_V4_0_SCHEMA_URL,
@@ -104,8 +104,8 @@ static STRICT_VALIDATOR_2_1: LazyLock<jsonschema::Validator> = LazyLock::new(|| 
 pub fn test_6_2_20_additional_properties(
     json: &Value,
     validator: &jsonschema::Validator,
-) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
     for error in validator.iter_errors(json) {
         if let ValidationErrorKind::UnevaluatedProperties { unexpected } = error.kind() {
             for property in unexpected {
@@ -120,18 +120,18 @@ pub fn test_6_2_20_additional_properties(
     errors.map_or(Ok(()), Err)
 }
 
-fn create_additional_properties_error(key: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn create_additional_properties_error(key: &str, path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("The key '{key}' is not defined in the JSON schema."),
         instance_path: path.to_string(),
-    }
+    })
 }
 
-fn test_6_2_20_validate_2_0(json: &Value) -> Result<(), Vec<ValidationError>> {
+fn test_6_2_20_validate_2_0(json: &Value) -> Result<(), Vec<TestFinding>> {
     test_6_2_20_additional_properties(json, &STRICT_VALIDATOR_2_0)
 }
 
-fn test_6_2_20_validate_2_1(json: &Value) -> Result<(), Vec<ValidationError>> {
+fn test_6_2_20_validate_2_1(json: &Value) -> Result<(), Vec<TestFinding>> {
     test_6_2_20_additional_properties(json, &STRICT_VALIDATOR_2_1)
 }
 

--- a/csaf-rs/src/validations/test_6_2_21.rs
+++ b/csaf-rs/src/validations/test_6_2_21.rs
@@ -80,6 +80,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_21 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -177,15 +178,15 @@ mod tests {
         ]);
 
         // Cases 11-13: Valid (all timestamps are distinct, with subsecond precision and timezones)
-        TESTS_2_1.test_6_2_21.expect(
-            case_01_two_items_with_same_date,
-            case_02_two_groups_with_same_date,
+        TESTS_2_1.test_6_2_21.expect(ExpectedResults {
+            case_01: case_01_two_items_with_same_date,
+            case_02: case_02_two_groups_with_same_date,
             case_03,
-            case_04_subsecond_precision,
-            case_05_empty_timezone_expr,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_04: case_04_subsecond_precision,
+            case_05: case_05_empty_timezone_expr,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_21.rs
+++ b/csaf-rs/src/validations/test_6_2_21.rs
@@ -1,13 +1,9 @@
 use crate::csaf::types::csaf_datetime::{CsafDateTime, ValidCsafDateTime};
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashMap;
 
-fn create_same_timestamp_error(
-    index: usize,
-    date: &ValidCsafDateTime,
-    conflicting_indices: &[usize],
-) -> ValidationError {
+fn create_same_timestamp_error(index: usize, date: &ValidCsafDateTime, conflicting_indices: &[usize]) -> TestFinding {
     // join the duplicate revision history date indices excluding the current one
     let conflicting_indices_not_current = conflicting_indices
         .iter()
@@ -16,26 +12,26 @@ fn create_same_timestamp_error(
         .collect::<Vec<String>>()
         .join(", ");
 
-    ValidationError {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "The timestamp '{date}' of this revision history item is also used by item at the position(s) {conflicting_indices_not_current}."
         ),
         instance_path: format!("/document/tracking/revision_history/{index}/date"),
-    }
+    })
 }
 
 /// 6.2.21 Same Timestamps in Revision History
 ///
 /// It MUST be tested that the timestamps of all items in the revision history are pairwise disjoint,
 /// taking timezones into account.
-pub fn test_6_2_21_same_timestamps_in_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_21_same_timestamps_in_revision_history(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let revision_history = doc.get_document().get_tracking().aggregate_revision_history();
 
     // lookup of ValidCsafDateTime (hash function uses normalized utc)
     // to a vec containing each occurrence of that normalized utc
     // with its path index and "original" ValidCsafDateTime to preserve timezones etc.
     let mut datetime_path_lookup: HashMap<&ValidCsafDateTime, Vec<(usize, &ValidCsafDateTime)>> = HashMap::new();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // does the lookup already contain the datetime
     for item in &revision_history {

--- a/csaf-rs/src/validations/test_6_2_22.rs
+++ b/csaf-rs/src/validations/test_6_2_22.rs
@@ -1,17 +1,17 @@
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_tracking_id_in_title_error(title: &str, tracking_id: &str) -> ValidationError {
-    ValidationError {
+fn create_tracking_id_in_title_error(title: &str, tracking_id: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("The document title '{title}' contains the document tracking id '{tracking_id}'."),
         instance_path: "/document/title".to_string(),
-    }
+    })
 }
 
 /// 6.2.22 Document Tracking ID in Title
 ///
 /// It MUST be tested that the /document/title does not contain the /document/tracking/id.
-pub fn test_6_2_22_document_tracking_id_in_title(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_22_document_tracking_id_in_title(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
     let title = document.get_title();
     let tracking_id = document.get_tracking().get_id();

--- a/csaf-rs/src/validations/test_6_2_22.rs
+++ b/csaf-rs/src/validations/test_6_2_22.rs
@@ -32,6 +32,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_22 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -56,13 +57,13 @@ mod tests {
         // Case 11: title does not contain its own tracking ID
         // Case 12: title contains a different tracking ID (not its own)
 
-        TESTS_2_1.test_6_2_22.expect(
-            case_01_starts_with_id_colon_as_sep,
-            case_02_ends_with_id_in_parenthesis,
-            case_03_ends_with_id_colon_sep,
-            case_04_starts_with_id_dash_sep,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_2_22.expect(ExpectedResults {
+            case_01: case_01_starts_with_id_colon_as_sep,
+            case_02: case_02_ends_with_id_in_parenthesis,
+            case_03: case_03_ends_with_id_colon_sep,
+            case_04: case_04_starts_with_id_dash_sep,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_23.rs
+++ b/csaf-rs/src/validations/test_6_2_23.rs
@@ -1,20 +1,20 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
 use crate::helpers::CWE_ENTRIES;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_deprecated_cwe_error(cwe: &str, version: &str, i_r: usize, i_cwe: usize) -> ValidationError {
-    ValidationError {
+fn create_deprecated_cwe_error(cwe: &str, version: &str, i_r: usize, i_cwe: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("Weakness '{cwe}' is deprecated in version {version}."),
         instance_path: format!("/vulnerabilities/{i_r}/cwes/{i_cwe}"),
-    }
+    })
 }
 
 /// 6.2.23 Usage of Deprecated CWE
 ///
 /// For each item in the CWE array it MUST be tested that the CWE is not deprecated in the given version.
-pub fn test_6_2_23_usage_of_deprecated_cwe(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_23_usage_of_deprecated_cwe(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_r, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(cwes) = vulnerability.get_cwes() {

--- a/csaf-rs/src/validations/test_6_2_23.rs
+++ b/csaf-rs/src/validations/test_6_2_23.rs
@@ -50,6 +50,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_23, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_23 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -65,13 +66,13 @@ mod tests {
         let case_03_third_multi_vuln_with_deprecated_cwe =
             Err(vec![create_deprecated_cwe_error("CWE-365", "4.13", 2, 0)]);
 
-        TESTS_2_1.test_6_2_23.expect(
-            case_01_single_vuln_with_deprecated_cwe,
-            case_02_single_vuln_containing_deprecated_cwe,
-            case_03_third_multi_vuln_with_deprecated_cwe,
-            Ok(()), // case 11: valid version of 01, one vulnerability containing one cwe that is not deprecated
-            Ok(()), // case 12: valid version of 02, one vulnerability containing several cwes, non deprecated
-            Ok(()), // case 13: valid version of 03, multiple vulnerabilities with one cwe each, non deprecated
-        );
+        TESTS_2_1.test_6_2_23.expect(ExpectedResults {
+            case_01: case_01_single_vuln_with_deprecated_cwe,
+            case_02: case_02_single_vuln_containing_deprecated_cwe,
+            case_03: case_03_third_multi_vuln_with_deprecated_cwe,
+            case_11: Ok(()), // case 11: valid version of 01, one vulnerability containing one cwe that is not deprecated
+            case_12: Ok(()), // case 12: valid version of 02, one vulnerability containing several cwes, non deprecated
+            case_13: Ok(()), // case 13: valid version of 03, multiple vulnerabilities with one cwe each, non deprecated
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_24.rs
+++ b/csaf-rs/src/validations/test_6_2_24.rs
@@ -154,6 +154,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_24 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use rstest::rstest;
 
@@ -189,16 +190,16 @@ mod tests {
             create_non_latest_cwe_error(VersionMissmatch::Future, "CWE-61", "4.15", "4.13", 2, 0),
         ]);
 
-        TESTS_2_1.test_6_2_24.expect(
-            case_01_cwe_version_before_latest,
-            case_02_cwe_version_after_latest,
-            case_03_cwe_version_mismatch,
-            case_04_cwe_version_mismatch_multi_vulnerabilities,
-            Ok(()), // Case 11: 1 vuln, 1 correct cwe version, correction of case 01 with version 4.12 -> 4.13
-            Ok(()), // Case 12: 1 vuln, 1 correct cwe version, correction of case 02 where version 4.15 was newer than latest 4.13
-            Ok(()), // Case 13: 1 vuln, 3 correct cwe versions, correction of case 03 with versions 1.8.1 -> 4.13, 1.0 -> 4.13
-            Ok(()), // Case 14: 3 vulns, 4 correct cwe versions, correction of case 04 with versions 1.3 -> 4.13, 2.1 -> 4.13, 4.14 -> 4.13, 4.15 -> 4.13
-        );
+        TESTS_2_1.test_6_2_24.expect(ExpectedResults {
+            case_01: case_01_cwe_version_before_latest,
+            case_02: case_02_cwe_version_after_latest,
+            case_03: case_03_cwe_version_mismatch,
+            case_04: case_04_cwe_version_mismatch_multi_vulnerabilities,
+            case_11: Ok(()), // Case 11: 1 vuln, 1 correct cwe version, correction of case 01 with version 4.12 -> 4.13
+            case_12: Ok(()), // Case 12: 1 vuln, 1 correct cwe version, correction of case 02 where version 4.15 was newer than latest 4.13
+            case_13: Ok(()), // Case 13: 1 vuln, 3 correct cwe versions, correction of case 03 with versions 1.8.1 -> 4.13, 1.0 -> 4.13
+            case_14: Ok(()), // Case 14: 3 vulns, 4 correct cwe versions, correction of case 04 with versions 1.3 -> 4.13, 2.1 -> 4.13, 4.14 -> 4.13, 4.15 -> 4.13
+        });
     }
 
     #[rstest]

--- a/csaf-rs/src/validations/test_6_2_24.rs
+++ b/csaf-rs/src/validations/test_6_2_24.rs
@@ -1,6 +1,6 @@
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait, VulnerabilityTrait};
 use crate::helpers::get_latest_cwe_version_for_date;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use semver::Version;
 use std::sync::LazyLock;
 
@@ -9,9 +9,11 @@ enum VersionMissmatch {
     Future,
 }
 
-static CWE_VERSION_UNAVAILABLE_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "CWE version information is not available for the current release date.".to_string(),
-    instance_path: "/document/tracking/current_release_date".to_string(),
+static CWE_VERSION_UNAVAILABLE_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "CWE version information is not available for the current release date.".to_string(),
+        instance_path: "/document/tracking/current_release_date".to_string(),
+    })
 });
 
 fn check_for_non_latest_cwe_version(
@@ -20,7 +22,7 @@ fn check_for_non_latest_cwe_version(
     latest: &str,
     i_r: usize,
     i_cwe: usize,
-) -> Option<ValidationError> {
+) -> Option<TestFinding> {
     // If the both version strings are already equal, we can return early
     if version == latest {
         return None;
@@ -64,7 +66,7 @@ fn create_non_latest_cwe_error(
     latest: &str,
     i_r: usize,
     i_cwe: usize,
-) -> ValidationError {
+) -> TestFinding {
     let error_message = match e_type {
         VersionMissmatch::NonLatest => {
             format!("Weakness '{cwe}' uses non-latest CWE version '{version}' (latest: '{latest}').")
@@ -74,10 +76,10 @@ fn create_non_latest_cwe_error(
         },
     };
 
-    ValidationError {
+    TestFinding::Warning(TestFindingData {
         message: error_message,
         instance_path: format!("/vulnerabilities/{i_r}/cwes/{i_cwe}/version"),
-    }
+    })
 }
 
 ///CWE assets use two-part versions like "4.13". `semver::Version::parse` expects three parts
@@ -108,9 +110,9 @@ fn normalize_to_semver_str(s: &str) -> String {
 /// available at the time of the last revision was used. The test SHALL fail if
 /// a later CWE version was available (i.e. the CWE item does not reference the
 /// most recent CWE version as of the document's current_release_date).
-pub fn test_6_2_24_usage_of_non_latest_cwe_version(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_24_usage_of_non_latest_cwe_version(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     let tracking = doc.get_document().get_tracking();
     let current_release_date = tracking.get_current_release_date();

--- a/csaf-rs/src/validations/test_6_2_25.rs
+++ b/csaf-rs/src/validations/test_6_2_25.rs
@@ -1,20 +1,14 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
 use crate::helpers::CWE_ENTRIES;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_disallowed_cwe_usage_error(
-    cwe: &str,
-    usage: &str,
-    version: &str,
-    i_r: usize,
-    i_cwe: usize,
-) -> ValidationError {
-    ValidationError {
+fn create_disallowed_cwe_usage_error(cwe: &str, usage: &str, version: &str, i_r: usize, i_cwe: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Weakness '{cwe}' has usage '{usage}' in version '{version}', which is not allowed for vulnerability mapping."
         ),
         instance_path: format!("/vulnerabilities/{i_r}/cwes/{i_cwe}"),
-    }
+    })
 }
 
 /// 6.2.25 Usage of CWE Not Allowed for Vulnerability Mapping
@@ -27,9 +21,9 @@ fn create_disallowed_cwe_usage_error(
 /// CWE version 4.12.
 pub fn test_6_2_25_usage_of_cwe_not_allowed_for_vulnerability_mapping(
     doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_r, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(cwes) = vulnerability.get_cwes() {

--- a/csaf-rs/src/validations/test_6_2_25.rs
+++ b/csaf-rs/src/validations/test_6_2_25.rs
@@ -80,6 +80,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_25 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -121,15 +122,15 @@ mod tests {
         // Case 13: CWE-1287 (Allowed)
         // Case 14: multiple vulns, multiple cwes, all allowed
 
-        TESTS_2_1.test_6_2_25.expect(
-            case_01_discouraged,
-            case_02_prohibited,
-            case_03_multiple_cwes_with_discouraged,
-            case_04_multiple_vulns_cwe_with_discouraged,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_2_25.expect(ExpectedResults {
+            case_01: case_01_discouraged,
+            case_02: case_02_prohibited,
+            case_03: case_03_multiple_cwes_with_discouraged,
+            case_04: case_04_multiple_vulns_cwe_with_discouraged,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_26.rs
+++ b/csaf-rs/src/validations/test_6_2_26.rs
@@ -72,6 +72,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_26 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -82,13 +83,13 @@ mod tests {
 
         let case_03_multiple_vulns = Err(vec![create_allowed_with_review_error("CWE-1039", "4.13", 3, 0)]);
 
-        TESTS_2_1.test_6_2_26.expect(
-            case_01_allowed_with_review,
-            case_02_multiple_cwes,
-            case_03_multiple_vulns,
-            Ok(()), // case_11: CWE-184 (Allowed)
-            Ok(()), // case_12: CWE-14 + CWE-733 (both Allowed)
-            Ok(()), // case_13: all Allowed
-        );
+        TESTS_2_1.test_6_2_26.expect(ExpectedResults {
+            case_01: case_01_allowed_with_review,
+            case_02: case_02_multiple_cwes,
+            case_03: case_03_multiple_vulns,
+            case_11: Ok(()), // CWE-184 (Allowed)
+            case_12: Ok(()), // CWE-14 + CWE-733 (both Allowed)
+            case_13: Ok(()), // all Allowed
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_26.rs
+++ b/csaf-rs/src/validations/test_6_2_26.rs
@@ -1,14 +1,14 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
 use crate::helpers::CWE_ENTRIES;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_allowed_with_review_error(cwe: &str, version: &str, i_r: usize, i_cwe: usize) -> ValidationError {
-    ValidationError {
+fn create_allowed_with_review_error(cwe: &str, version: &str, i_r: usize, i_cwe: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Weakness '{cwe}' has usage 'Allowed-with-Review' in version {version}, which requires a thorough review."
         ),
         instance_path: format!("/vulnerabilities/{i_r}/cwes/{i_cwe}"),
-    }
+    })
 }
 
 /// 6.2.26 Usage of CWE Allowed with Review for Vulnerability Mapping
@@ -21,9 +21,9 @@ fn create_allowed_with_review_error(cwe: &str, version: &str, i_r: usize, i_cwe:
 /// CWE version 4.12.
 pub fn test_6_2_26_usage_of_cwe_allowed_with_review_for_vulnerability_mapping(
     doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_r, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(cwes) = vulnerability.get_cwes() {

--- a/csaf-rs/src/validations/test_6_2_28.rs
+++ b/csaf-rs/src/validations/test_6_2_28.rs
@@ -1,17 +1,19 @@
 use std::sync::LazyLock;
 
 use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait, SharingGroupTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static USAGE_OF_MAX_UUID_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "The sharing group id uses the Max UUID.".to_string(),
-    instance_path: "/document/distribution/sharing_group/id".to_string(),
+static USAGE_OF_MAX_UUID_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "The sharing group id uses the Max UUID.".to_string(),
+        instance_path: "/document/distribution/sharing_group/id".to_string(),
+    })
 });
 
 /// 6.2.28 Usage of Max UUID
 ///
 /// It MUST be tested that the Max UUID is not used as sharing group id.
-pub fn test_6_2_28_usage_of_max_uuid(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_28_usage_of_max_uuid(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group()

--- a/csaf-rs/src/validations/test_6_2_28.rs
+++ b/csaf-rs/src/validations/test_6_2_28.rs
@@ -28,6 +28,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_28, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_28 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -38,6 +39,10 @@ mod tests {
         // Case 11: no sharing group present
         // Case 12: sharing group with a regular UUID
 
-        TESTS_2_1.test_6_2_28.expect(err, Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_28.expect(ExpectedResults {
+            case_01: err,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_29.rs
+++ b/csaf-rs/src/validations/test_6_2_29.rs
@@ -1,17 +1,19 @@
 use std::sync::LazyLock;
 
 use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait, SharingGroupTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static USAGE_OF_NIL_UUID_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "The sharing group id uses the Nil UUID.".to_string(),
-    instance_path: "/document/distribution/sharing_group/id".to_string(),
+static USAGE_OF_NIL_UUID_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "The sharing group id uses the Nil UUID.".to_string(),
+        instance_path: "/document/distribution/sharing_group/id".to_string(),
+    })
 });
 
 /// 6.2.29 Usage of Nil UUID
 ///
 /// It MUST be tested that the Nil UUID is not used as sharing group id.
-pub fn test_6_2_29_usage_of_nil_uuid(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_29_usage_of_nil_uuid(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if let Some(sharing_group) = distribution.get_sharing_group()

--- a/csaf-rs/src/validations/test_6_2_29.rs
+++ b/csaf-rs/src/validations/test_6_2_29.rs
@@ -28,6 +28,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_29, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_29 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -38,6 +39,10 @@ mod tests {
         // Case 11: sharing group with a regular UUID
         // Case 12: no sharing group present
 
-        TESTS_2_1.test_6_2_29.expect(err, Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_29.expect(ExpectedResults {
+            case_01: err,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_30.rs
+++ b/csaf-rs/src/validations/test_6_2_30.rs
@@ -2,17 +2,19 @@ use std::sync::LazyLock;
 
 use crate::csaf_traits::{CsafTrait, DistributionTrait, DocumentTrait, TlpTrait};
 use crate::schema::csaf2_1::schema::LabelOfTlp;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-static USAGE_OF_SHARING_GROUP_ON_TLP_CLEAR_ERROR: LazyLock<ValidationError> = LazyLock::new(|| ValidationError {
-    message: "A sharing group must not be used when the document is TLP:CLEAR.".to_string(),
-    instance_path: "/document/distribution/sharing_group".to_string(),
+static USAGE_OF_SHARING_GROUP_ON_TLP_CLEAR_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
+    TestFinding::Warning(TestFindingData {
+        message: "A sharing group must not be used when the document is TLP:CLEAR.".to_string(),
+        instance_path: "/document/distribution/sharing_group".to_string(),
+    })
 });
 
 /// 6.2.30 Usage of Sharing Group on TLP:CLEAR
 ///
 /// It MUST be tested that no sharing group is used if the document is TLP:CLEAR.
-pub fn test_6_2_30_usage_of_sharing_group_on_tlp_clear(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_30_usage_of_sharing_group_on_tlp_clear(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let distribution = doc.get_document().get_distribution_21().map_err(|e| vec![e])?;
 
     if distribution.get_tlp_21().map_err(|e| vec![e])?.get_label() == LabelOfTlp::Clear

--- a/csaf-rs/src/validations/test_6_2_30.rs
+++ b/csaf-rs/src/validations/test_6_2_30.rs
@@ -33,6 +33,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_30 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -43,6 +44,10 @@ mod tests {
         // Case 11: TLP:CLEAR without sharing group
         // Case 12: sharing group present with TLP:RED
 
-        TESTS_2_1.test_6_2_30.expect(err, Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_30.expect(ExpectedResults {
+            case_01: err,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_31.rs
+++ b/csaf-rs/src/validations/test_6_2_31.rs
@@ -1,23 +1,23 @@
 use crate::csaf::traits::vulnerabilities::product_ident_helper_trait::ProductIdentificationHelperTrait;
 use crate::csaf_traits::{CsafTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
-fn generate_hardware_software_mix_error(product_id: &str, base_path: &str) -> ValidationError {
-    ValidationError {
+fn generate_hardware_software_mix_error(product_id: &str, base_path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Product '{product_id}' contains serial_numbers or model_numbers but lacks a valid product path. This indicates a potential hardware and software mix in the product tree."
         ),
         instance_path: base_path.to_string(),
-    }
+    })
 }
 
 /// Test 6.2.31: Hardware and Software Mix
-pub fn test_6_2_31_hardware_software_mix(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_31_hardware_software_mix(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(());
     };
-    let mut errors: Vec<ValidationError> = vec![];
+    let mut errors: Vec<TestFinding> = vec![];
 
     let mut valid_path_references: HashSet<String> = HashSet::new();
     for (id, _) in product_tree.get_relationships_product_references() {

--- a/csaf-rs/src/validations/test_6_2_31.rs
+++ b/csaf-rs/src/validations/test_6_2_31.rs
@@ -46,6 +46,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_31, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_31 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -74,8 +75,12 @@ mod tests {
         // Case 13: Valid - Pure software components without model or serial signatures
 
         // Sequence matches macro definition: 01, s01, 11, 12, 13
-        TESTS_2_1
-            .test_6_2_31
-            .expect(Err(case_01), Err(s01_errors), Ok(()), Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_31.expect(ExpectedResults {
+            case_01: Err(case_01),
+            case_s01: Err(s01_errors),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_32.rs
+++ b/csaf-rs/src/validations/test_6_2_32.rs
@@ -20,7 +20,7 @@ fn generate_duplicate_helper_error(category: &str, value: &str, product_id: &str
 fn process_violations(
     groups: HashMap<String, Vec<(String, String)>>,
     category: &str,
-    errors: &mut HashSet<TestFinding>, // ToDo TZ
+    errors: &mut HashSet<TestFinding>,
 ) {
     for (value, occurrences) in groups {
         // Count how many UNIQUE products share this helper value

--- a/csaf-rs/src/validations/test_6_2_32.rs
+++ b/csaf-rs/src/validations/test_6_2_32.rs
@@ -4,23 +4,23 @@ use crate::csaf::traits::vulnerabilities::{
 };
 use crate::csaf::types::purl::csaf_purl::CsafPurl;
 use crate::csaf_traits::{CsafTrait, ProductTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::{HashMap, HashSet};
 
-fn generate_duplicate_helper_error(category: &str, value: &str, product_id: &str, base_path: &str) -> ValidationError {
-    ValidationError {
+fn generate_duplicate_helper_error(category: &str, value: &str, product_id: &str, base_path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "The Product Identification Helper property '{category}' contains a duplicate value '{value}' for product '{product_id}'. Helper properties must be pairwise disjoint across all distinct products."
         ),
         instance_path: format!("{base_path}/product_identification_helper/{category}"),
-    }
+    })
 }
 
 // Private helper function instead of a capturing closure
 fn process_violations(
     groups: HashMap<String, Vec<(String, String)>>,
     category: &str,
-    errors: &mut HashSet<ValidationError>,
+    errors: &mut HashSet<TestFinding>, // ToDo TZ
 ) {
     for (value, occurrences) in groups {
         // Count how many UNIQUE products share this helper value
@@ -36,12 +36,12 @@ fn process_violations(
 }
 
 /// Test 6.2.32: Use of Same Product Identification Helper for Different Products
-pub fn test_6_2_32_duplicate_product_identification_helpers(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_32_duplicate_product_identification_helpers(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(());
     };
 
-    let mut errors: HashSet<ValidationError> = HashSet::new();
+    let mut errors: HashSet<TestFinding> = HashSet::new();
 
     // Grouping tracking maps: map a unique token to a list of (product_id, base_instance_path)
     let mut purl_groups: HashMap<String, Vec<(String, String)>> = HashMap::new();
@@ -160,7 +160,7 @@ pub fn test_6_2_32_duplicate_product_identification_helpers(doc: &impl CsafTrait
     process_violations(x_uri_groups, "x_generic_uris", &mut errors);
 
     // Convert error HashSet back to Vec at the very end
-    let error_vec: Vec<ValidationError> = errors.into_iter().collect();
+    let error_vec: Vec<TestFinding> = errors.into_iter().collect();
 
     if error_vec.is_empty() { Ok(()) } else { Err(error_vec) }
 }

--- a/csaf-rs/src/validations/test_6_2_32.rs
+++ b/csaf-rs/src/validations/test_6_2_32.rs
@@ -174,6 +174,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_32 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -359,14 +360,14 @@ mod tests {
         // Case 04: Disjoint product identification helpers (no collisions, expects pass)
         // Case 05: Products without identification helpers (no helpers to collide, expects pass)
         // Case S11: Verifies that duplicate helper values inside the *same* product are correctly ignored (expects pass)
-        TESTS_2_1.test_6_2_32.expect(
-            Err(case_01_errors),  // index 0: case_01
-            Err(case_02_errors),  // index 1: case_02
-            Err(case_03_errors),  // index 2: case_03
-            Err(case_s01_errors), // index 3: case_s01 (Yields 24 errors)
-            Ok(()),               // index 4: case_11
-            Ok(()),               // index 5: case_12
-            Ok(()),               // index 6: case_s11 (Yields Ok)
-        );
+        TESTS_2_1.test_6_2_32.expect(ExpectedResults {
+            case_01: Err(case_01_errors),   // index 0: case_01
+            case_02: Err(case_02_errors),   // index 1: case_02
+            case_03: Err(case_03_errors),   // index 2: case_03
+            case_s01: Err(case_s01_errors), // index 3: case_s01 (Yields 24 errors)
+            case_11: Ok(()),                // index 4: case_11
+            case_12: Ok(()),                // index 5: case_12
+            case_s11: Ok(()),               // index 6: case_s11 (Yields Ok)
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_33.rs
+++ b/csaf-rs/src/validations/test_6_2_33.rs
@@ -1,19 +1,19 @@
 use crate::csaf::types::csaf_datetime::{CsafDateTime, ValidCsafDateTime};
 use crate::csaf_traits::{CsafTrait, DocumentTrait, TrackingTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use chrono::Utc;
 
 fn create_disclosure_date_newer_than_revision_error(
     disclosure_date: &ValidCsafDateTime,
     newest_revision_date: &ValidCsafDateTime,
     i_v: usize,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "Disclosure date ({disclosure_date}) is in the past and newer than the newest revision date ({newest_revision_date})"
         ),
         instance_path: format!("/vulnerabilities/{i_v}/disclosure_date"),
-    }
+    })
 }
 
 /// 6.2.33 Disclosure Date Newer than Revision History
@@ -29,7 +29,7 @@ fn create_disclosure_date_newer_than_revision_error(
 ///
 /// Unlike test 6.1.45, this test applies regardless of TLP/status, and additionally takes the datetime of test
 /// execution into consideration.
-pub fn test_6_2_33_disclosure_date_newer_than_revision(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_33_disclosure_date_newer_than_revision(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     // Get sorted revision history and find the newest entry
     let mut revision_history = doc.get_document().get_tracking().aggregate_revision_history();
     revision_history.inplace_sort_by_date_then_number();
@@ -45,7 +45,7 @@ pub fn test_6_2_33_disclosure_date_newer_than_revision(doc: &impl CsafTrait) -> 
     let now = Utc::now();
 
     // Check each vulnerability's disclosure date
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     for (i_v, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         // If there is a disclosure date
         if let Some(disclosure_date) = vulnerability.get_disclosure_date() {

--- a/csaf-rs/src/validations/test_6_2_33.rs
+++ b/csaf-rs/src/validations/test_6_2_33.rs
@@ -84,6 +84,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_33 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -114,13 +115,13 @@ mod tests {
         // Case 12: disclosure_date is definitely not in the past (9999-12-31)
         // Case 13: disclosure_date is earlier than newest revision, with timezones
 
-        TESTS_2_1.test_6_2_33.expect(
-            case_01_disclosure_date_newer_than_newest_rev,
-            case_02_disclosure_date_newer_than_newest_rev_with_timezone,
-            case_03_disclosure_date_newer_than_newest_rev_with_timezone,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_2_33.expect(ExpectedResults {
+            case_01: case_01_disclosure_date_newer_than_newest_rev,
+            case_02: case_02_disclosure_date_newer_than_newest_rev_with_timezone,
+            case_03: case_03_disclosure_date_newer_than_newest_rev_with_timezone,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_38.rs
+++ b/csaf-rs/src/validations/test_6_2_38.rs
@@ -29,6 +29,7 @@ impl_validator!(csaf2_1, ValidatorForTest6_2_38, test_6_2_38_usage_of_deprecated
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_38 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -43,8 +44,13 @@ mod tests {
         // Case 12: with prefix ("Example Company csaf_deprecated_security_advisory")´
         // Case 13: casing ("CSAF_deprecated_security_advisory")
         // Case S11: leading whitespace (" csaf_deprecated_some_other_type")
-        TESTS_2_1
-            .test_6_2_38
-            .expect(case_01, case_02, Ok(()), Ok(()), Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_38.expect(ExpectedResults {
+            case_01,
+            case_02,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_38.rs
+++ b/csaf-rs/src/validations/test_6_2_38.rs
@@ -1,20 +1,20 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
 use crate::test_validation::impl_validator;
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_usage_of_deprecated_profile_error(category: &CsafDocumentCategory) -> ValidationError {
-    ValidationError {
+fn create_usage_of_deprecated_profile_error(category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("Document category '{category}' starts with 'csaf_deprecated_' (or similar)"),
         instance_path: "/document/category".to_string(),
-    }
+    })
 }
 
 /// 6.2.38 Usage of Deprecated Profile
 ///
 /// It MUST be tested that the `/document/category` does not start with `csaf_deprecated_`.
 /// To implement this test it is deemed sufficient to do a "starts with" check.
-pub fn test_6_2_38_usage_of_deprecated_profile(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_38_usage_of_deprecated_profile(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let category = doc.get_document().get_category();
 
     if category.to_string().starts_with("csaf_deprecated_") {

--- a/csaf-rs/src/validations/test_6_2_41.rs
+++ b/csaf-rs/src/validations/test_6_2_41.rs
@@ -100,6 +100,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_41, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_41 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use std::str::FromStr;
 
@@ -119,8 +120,11 @@ mod tests {
         // Case 11: EPSS timestamp is same as newest revision history date
         // Case 12: Newest EPSS timestamp (with timezone) is within 15 days of newest revision
 
-        TESTS_2_1
-            .test_6_2_41
-            .expect(case_01_old_epss, case_02_old_epss_with_timezone, Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_41.expect(ExpectedResults {
+            case_01: case_01_old_epss,
+            case_02: case_02_old_epss_with_timezone,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_41.rs
+++ b/csaf-rs/src/validations/test_6_2_41.rs
@@ -3,20 +3,20 @@ use crate::csaf::types::csaf_datetime::{CsafDateTime, ValidCsafDateTime};
 use crate::csaf_traits::{
     ContentTrait, CsafTrait, DocumentTrait, EpssTrait, MetricTrait, TrackingTrait, VulnerabilityTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use chrono::TimeDelta;
 
 fn create_old_epss_timestamp_error(
     epss_timestamp: &ValidCsafDateTime,
     newest_revision_date: &ValidCsafDateTime,
     content_json_path: &str,
-) -> ValidationError {
-    ValidationError {
+) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!(
             "EPSS timestamp ({epss_timestamp}) is more than 15 days older than the newest revision date ({newest_revision_date}).",
         ),
         instance_path: format!("{content_json_path}/epss/timestamp"),
-    }
+    })
 }
 
 /// 6.2.41 Old EPSS Timestamp
@@ -24,7 +24,7 @@ fn create_old_epss_timestamp_error(
 /// For each vulnerability, it MUST be tested that the youngest EPSS timestamp is not more than
 /// 15 days older than the date of the newest item of the revision_history (taking timezones into account),
 /// if the document status is `final` or `interim`.
-pub fn test_6_2_41_old_epss_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_41_old_epss_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let document = doc.get_document();
     let tracking = document.get_tracking();
 
@@ -46,7 +46,7 @@ pub fn test_6_2_41_old_epss_timestamp(doc: &impl CsafTrait) -> Result<(), Vec<Va
         return Ok(());
     }
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
     let fifteen_days = TimeDelta::days(15);
 
     for (i_v, vulnerability) in vulnerabilities.iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_2_47.rs
+++ b/csaf-rs/src/validations/test_6_2_47.rs
@@ -68,6 +68,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_47 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -82,8 +83,11 @@ mod tests {
         // Case 11: metric without source and without qualitative severity
         // Case 12: metric with third-party URL as source and qualitative severity rating
 
-        TESTS_2_1
-            .test_6_2_47
-            .expect(case_01_no_source, case_02_source_is_canonical, Ok(()), Ok(()));
+        TESTS_2_1.test_6_2_47.expect(ExpectedResults {
+            case_01: case_01_no_source,
+            case_02: case_02_source_is_canonical,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_47.rs
+++ b/csaf-rs/src/validations/test_6_2_47.rs
@@ -1,12 +1,12 @@
 use crate::csaf_traits::{ContentTrait, CsafTrait, DocumentTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
-fn create_qualitative_severity_rating_error(content_path: &str) -> ValidationError {
-    ValidationError {
+fn create_qualitative_severity_rating_error(content_path: &str) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: "A metric provided by the issuing party must not use `qualitative_severity_rating`.".to_string(),
         instance_path: format!("{content_path}/qualitative_severity_rating"),
-    }
+    })
 }
 
 /// 6.2.47 Use of Qualitative Severity Rating by Issuing Party
@@ -18,7 +18,7 @@ fn create_qualitative_severity_rating_error(content_path: &str) -> ValidationErr
 /// is equal to the canonical URL. It does not cover assessments made by third parties.
 pub fn test_6_2_47_use_of_qualitative_severity_rating_by_issuing_party(
     doc: &impl CsafTrait,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     let vulnerabilities = doc.get_vulnerabilities();
     if vulnerabilities.is_empty() {
         // wasSkipped later (#407)
@@ -28,7 +28,7 @@ pub fn test_6_2_47_use_of_qualitative_severity_rating_by_issuing_party(
     // collect canonical URLs into a HashSet for O(1) lookups
     let canonical_urls: HashSet<&str> = doc.get_document().get_canonical_urls().into_iter().collect();
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (i_v, vulnerability) in vulnerabilities.iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {

--- a/csaf-rs/src/validations/test_6_2_48.rs
+++ b/csaf-rs/src/validations/test_6_2_48.rs
@@ -1,16 +1,16 @@
 use crate::csaf::consts::chars::is_invisible_char;
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_misuse_at_vendor_name_error(vendor_name: &str, path: &str) -> ValidationError {
+fn create_misuse_at_vendor_name_error(vendor_name: &str, path: &str) -> TestFinding {
     let message: String  = match vendor_name == "Open Source" {
         true => "For vendor branches, the branch name 'Open Source' is banned due to misuse. Please use a more appropriate vendor name for the open source project.".to_string(),
         false => format!("For vendor branches, the branch name 'Open Source' (and similar, provided: '{vendor_name}') is banned due to misuse. Please use a more appropriate vendor name for the open source project."),
     };
-    ValidationError {
+    TestFinding::Warning(TestFindingData {
         message,
         instance_path: format!("{path}/name"),
-    }
+    })
 }
 
 /// Checks if a name is `Open Source` (case-insensitive, white space insensitive).
@@ -29,12 +29,12 @@ fn is_open_source(name: &str) -> bool {
 ///
 /// For each item in branches with category `vendor` it MUST be tested that the name is not
 /// `Open Source` (case-insensitive, white space insensitive).
-pub fn test_6_2_48_misuse_at_vendor_name(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
+pub fn test_6_2_48_misuse_at_vendor_name(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(()); // TODO #409
     };
 
-    let mut errors: Option<Vec<ValidationError>> = None;
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     product_tree.visit_all_branches(&mut |branch, path| {
         if branch.get_category() == CategoryOfTheBranch::Vendor && is_open_source(branch.get_name()) {

--- a/csaf-rs/src/validations/test_6_2_48.rs
+++ b/csaf-rs/src/validations/test_6_2_48.rs
@@ -52,6 +52,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_48, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_48 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
     use rstest::rstest;
 
@@ -73,15 +74,15 @@ mod tests {
         // Case 11-13: Same as 01-03, but with appropriate values for the vendor branch name (ISDuBA Dev, curl, ...)
         // Case S11: product family branch with name "Open Source"
 
-        TESTS_2_1.test_6_2_48.expect(
-            case_01_open_source_isduba,
-            case_02_open_source_curl,
-            case_03_open_source_case_whitespace,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_2_48.expect(ExpectedResults {
+            case_01: case_01_open_source_isduba,
+            case_02: case_02_open_source_curl,
+            case_03: case_03_open_source_case_whitespace,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 
     #[rstest]

--- a/csaf-rs/src/validations/test_6_2_52.rs
+++ b/csaf-rs/src/validations/test_6_2_52.rs
@@ -2,7 +2,7 @@ use crate::csaf::types::csaf_hash_algo::CsafHashAlgorithm;
 use crate::csaf_traits::{
     CsafTrait, FileHashTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 /// 6.2.52 Unknown Hash Algorithm
 ///
@@ -13,8 +13,8 @@ use crate::validation::ValidationError;
 ///
 /// TODO: For now, we do not distinguish between algorithms that are supported and mentioned in the spec,
 /// but the methods are already there.
-pub fn test_6_2_52_unknown_hash_algorithm(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_52_unknown_hash_algorithm(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(tree) = doc.get_product_tree() {
         tree.visit_all_products(&mut |fpn, path| {
@@ -43,7 +43,7 @@ fn create_unknown_hash_algorithm_error(
     path: &str,
     hash_index: usize,
     file_hash_index: usize,
-) -> ValidationError {
+) -> TestFinding {
     let message = match algorithm.is_mentioned_in_spec() {
         // TODO Right now, is_supported == is_mentioned_in_spec, and this only gets called when
         // !is_supported, so this can't be reached.
@@ -55,12 +55,12 @@ fn create_unknown_hash_algorithm_error(
         ),
     };
 
-    ValidationError {
+    TestFinding::Warning(TestFindingData {
         message,
         instance_path: format!(
             "{path}/product_identification_helper/hashes/{hash_index}/file_hashes/{file_hash_index}/algorithm"
         ),
-    }
+    })
 }
 
 crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_52, test_6_2_52_unknown_hash_algorithm);

--- a/csaf-rs/src/validations/test_6_2_52.rs
+++ b/csaf-rs/src/validations/test_6_2_52.rs
@@ -68,6 +68,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_2_52, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_52 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -81,6 +82,9 @@ mod tests {
 
         // Case 11: "blake2s256" is mentioned in the spec and should be supported
 
-        TESTS_2_1.test_6_2_52.expect(case_01, Ok(()));
+        TESTS_2_1.test_6_2_52.expect(ExpectedResults {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_53.rs
+++ b/csaf-rs/src/validations/test_6_2_53.rs
@@ -1,12 +1,12 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityIdTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::rvisc;
 
-fn create_matching_text_error(system_name: &str, text: &str, vuln_index: usize, id_index: usize) -> ValidationError {
-    ValidationError {
+fn create_matching_text_error(system_name: &str, text: &str, vuln_index: usize, id_index: usize) -> TestFinding {
+    TestFinding::Warning(TestFindingData {
         message: format!("The text '{text}' does not match the pattern for registered ID system '{system_name}'"),
         instance_path: format!("/vulnerabilities/{vuln_index}/ids/{id_index}/text"),
-    }
+    })
 }
 
 /// 6.2.53 Matching Text for Registered ID System
@@ -14,8 +14,8 @@ fn create_matching_text_error(system_name: &str, text: &str, vuln_index: usize, 
 /// For each item in `/vulnerabilities[]/ids` that has the value of a registered vulnerability ID system
 /// as `system_name`, it MUST be tested that the `text` in the CSAF document matches the `text_pattern`
 /// given by the "Registry for Vulnerability ID Systems for CSAF" (RVISC).
-pub fn test_6_2_53_matching_text_for_registered_id_system(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_2_53_matching_text_for_registered_id_system(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(ids) = vuln.get_ids() {

--- a/csaf-rs/src/validations/test_6_2_53.rs
+++ b/csaf-rs/src/validations/test_6_2_53.rs
@@ -45,6 +45,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_2_53 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -58,6 +59,9 @@ mod tests {
 
         // Case 11: Valid OASIS CSAF TC Issues text
 
-        TESTS_2_1.test_6_2_53.expect(case_01, Ok(()));
+        TESTS_2_1.test_6_2_53.expect(ExpectedResults {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_01.rs
+++ b/csaf-rs/src/validations/test_6_3_01.rs
@@ -1,20 +1,20 @@
 use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::{HashMap, HashSet};
 
-fn create_cvss_v2_only_error(instance_path: String) -> ValidationError {
-    ValidationError {
+fn create_cvss_v2_only_error(instance_path: String) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: "Vulnerability uses CVSS v2 as the only scoring system".to_string(),
         instance_path,
-    }
+    })
 }
 
 /// 6.3.1 Use of CVSS v2 as the only Scoring System
 ///
 /// For each vulnerability, tests if in the scores / metrics, CVSS v2 is not the only scoring system used.
-pub fn test_6_3_1_use_of_cvss_v2_as_only_scoring_system(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_1_use_of_cvss_v2_as_only_scoring_system(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     // for each vuln
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {

--- a/csaf-rs/src/validations/test_6_3_01.rs
+++ b/csaf-rs/src/validations/test_6_3_01.rs
@@ -66,42 +66,44 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_1, test_6_3_1_use_of
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_1 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_1 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
     fn test_test_6_3_1() {
         // CSAF 2.0 has 4 test cases and CSAF 2.1 has 8 test cases
-        TESTS_2_0.test_6_3_1.expect(
-            Err(vec![create_cvss_v2_only_error(
+        TESTS_2_0.test_6_3_1.expect(ExpectedResults_2_0 {
+            case_01: Err(vec![create_cvss_v2_only_error(
                 "/vulnerabilities/0/scores/0".to_string(),
             )]),
-            Err(vec![
+            case_02: Err(vec![
                 create_cvss_v2_only_error("/vulnerabilities/0/scores/0".to_string()),
                 create_cvss_v2_only_error("/vulnerabilities/2/scores/0".to_string()),
             ]),
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_3_1.expect(
-            Err(vec![create_cvss_v2_only_error(
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_3_1.expect(ExpectedResults_2_1 {
+            case_01: Err(vec![create_cvss_v2_only_error(
                 "/vulnerabilities/0/metrics/0/content".to_string(),
             )]),
-            Err(vec![
+            case_02: Err(vec![
                 create_cvss_v2_only_error("/vulnerabilities/0/metrics/0/content".to_string()),
                 create_cvss_v2_only_error("/vulnerabilities/2/metrics/0/content".to_string()),
             ]),
-            Err(vec![
+            case_03: Err(vec![
                 create_cvss_v2_only_error("/vulnerabilities/0/metrics/0/content".to_string()),
                 create_cvss_v2_only_error("/vulnerabilities/3/metrics/0/content".to_string()),
             ]),
-            Err(vec![create_cvss_v2_only_error(
+            case_04: Err(vec![create_cvss_v2_only_error(
                 "/vulnerabilities/2/metrics/0/content".to_string(),
             )]),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_02.rs
+++ b/csaf-rs/src/validations/test_6_3_02.rs
@@ -69,7 +69,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_2, test_6_3_2_use_of
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_2 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_2 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -99,17 +101,17 @@ mod tests {
         // Case 11: 1 vuln with v3.1
         // Case 12: 3 vulns with v3.1
 
-        TESTS_2_0.test_6_3_2.expect(
-            case_01_v3_0_used_csaf_20,
-            case_02_mixed_some_with_v3_0_csaf_20,
-            Ok(()),
-            Ok(()),
-        );
-        TESTS_2_1.test_6_3_2.expect(
-            case_01_v3_0_used_csaf_21,
-            case_02_mixed_some_with_v3_0_csaf_21,
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_3_2.expect(ExpectedResults_2_0 {
+            case_01: case_01_v3_0_used_csaf_20,
+            case_02: case_02_mixed_some_with_v3_0_csaf_20,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_3_2.expect(ExpectedResults_2_1 {
+            case_01: case_01_v3_0_used_csaf_21,
+            case_02: case_02_mixed_some_with_v3_0_csaf_21,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_02.rs
+++ b/csaf-rs/src/validations/test_6_3_02.rs
@@ -1,18 +1,18 @@
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_cvss_v3_0_used_error(content_path: &str) -> ValidationError {
-    ValidationError {
+fn create_cvss_v3_0_used_error(content_path: &str) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: "CVSS v3.0 is used (version is '3.0').".to_string(),
         instance_path: format!("{content_path}/cvss_v3/version"),
-    }
+    })
 }
 
-fn create_cvss_v3_0_vector_string_error(content_path: &str) -> ValidationError {
-    ValidationError {
+fn create_cvss_v3_0_vector_string_error(content_path: &str) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: "CVSS v3.0 is used (vectorString prefix is 'CVSS:3.0/').".to_string(),
         instance_path: format!("{content_path}/cvss_v3/vectorString"),
-    }
+    })
 }
 
 /// 6.3.2 Use of CVSS v3.0
@@ -25,8 +25,8 @@ fn create_cvss_v3_0_vector_string_error(content_path: &str) -> ValidationError {
 /// indicate CVSS v3.0, which can be done with simple string comparisons.
 ///
 /// Returns up to two errors, if `version` is `3.0` and / or `vectorString` starts with `CVSS:3.0/`.
-pub fn test_6_3_2_use_of_cvss_v3_0(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_2_use_of_cvss_v3_0(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vuln.get_metrics() {

--- a/csaf-rs/src/validations/test_6_3_03.rs
+++ b/csaf-rs/src/validations/test_6_3_03.rs
@@ -28,7 +28,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_3, test_6_3_3_missin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_3 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_3 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -37,9 +39,17 @@ mod tests {
         let case_02 = Err(vec![create_missing_cve_error(0), create_missing_cve_error(2)]);
 
         // Both CSAF 2.0 and 2.1 have 4 test cases
-        TESTS_2_0
-            .test_6_3_3
-            .expect(case_01.clone(), case_02.clone(), Ok(()), Ok(()));
-        TESTS_2_1.test_6_3_3.expect(case_01, case_02, Ok(()), Ok(()));
+        TESTS_2_0.test_6_3_3.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_02: case_02.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_3_3.expect(ExpectedResults_2_1 {
+            case_01,
+            case_02,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_03.rs
+++ b/csaf-rs/src/validations/test_6_3_03.rs
@@ -1,18 +1,18 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_missing_cve_error(vulnerability_index: usize) -> ValidationError {
-    ValidationError {
+fn create_missing_cve_error(vulnerability_index: usize) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: "Vulnerability is missing 'cve' property".to_string(),
         instance_path: format!("/vulnerabilities/{vulnerability_index}"),
-    }
+    })
 }
 
 /// 6.3.3 Missing CVE
 ///
 /// Tests if all vulnerabilities have their `/vulnerabilities[]/cve` field filled.
-pub fn test_6_3_3_missing_cve(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_3_missing_cve(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if vuln.get_cve().is_none() {

--- a/csaf-rs/src/validations/test_6_3_04.rs
+++ b/csaf-rs/src/validations/test_6_3_04.rs
@@ -1,19 +1,19 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_missing_cwe_error(vulnerability_index: usize, field_name: &str) -> ValidationError {
-    ValidationError {
+fn create_missing_cwe_error(vulnerability_index: usize, field_name: &str) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: format!("Vulnerability is missing '{field_name}' property"),
         instance_path: format!("/vulnerabilities/{vulnerability_index}"),
-    }
+    })
 }
 
 /// 6.3.4 Missing CWE
 ///
 /// Tests if all vulnerabilities have a `/vulnerabilities[]/cwe` (CSAF 2.0) /
 /// `/vulnerabilities[]/cwes` (CSAF 2.1) field present.
-pub fn test_6_3_4_missing_cwe(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_4_missing_cwe(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if vuln.get_cwes().is_none() {

--- a/csaf-rs/src/validations/test_6_3_04.rs
+++ b/csaf-rs/src/validations/test_6_3_04.rs
@@ -31,7 +31,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_4, test_6_3_4_missin
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_4 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_4 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -48,7 +50,17 @@ mod tests {
         ]);
 
         // Both CSAF 2.0 and 2.1 have 4 test cases
-        TESTS_2_0.test_6_3_4.expect(case_01_20, case_02_20, Ok(()), Ok(()));
-        TESTS_2_1.test_6_3_4.expect(case_01_21, case_02_21, Ok(()), Ok(()));
+        TESTS_2_0.test_6_3_4.expect(ExpectedResults_2_0 {
+            case_01: case_01_20,
+            case_02: case_02_20,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
+        TESTS_2_1.test_6_3_4.expect(ExpectedResults_2_1 {
+            case_01: case_01_21,
+            case_02: case_02_21,
+            case_11: Ok(()),
+            case_12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_05.rs
+++ b/csaf-rs/src/validations/test_6_3_05.rs
@@ -57,7 +57,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_5, test_6_3_5_use_of
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_5 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_5 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -70,7 +72,9 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 1 test case
-        TESTS_2_0.test_6_3_5.expect(case_01.clone());
-        TESTS_2_1.test_6_3_5.expect(case_01);
+        TESTS_2_0.test_6_3_5.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+        });
+        TESTS_2_1.test_6_3_5.expect(ExpectedResults_2_1 { case_01 });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_05.rs
+++ b/csaf-rs/src/validations/test_6_3_05.rs
@@ -1,20 +1,15 @@
 use crate::csaf_traits::{
     CsafTrait, FileHashTrait, HashTrait, ProductIdentificationHelperTrait, ProductTrait, ProductTreeTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_short_hash_error(
-    path: &str,
-    hash_index: usize,
-    file_hash_index: usize,
-    hash_length: usize,
-) -> ValidationError {
-    ValidationError {
+fn create_short_hash_error(path: &str, hash_index: usize, file_hash_index: usize, hash_length: usize) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: format!("Too short hash found (length: {hash_length}), expected to be >= 64 chars"),
         instance_path: format!(
             "{path}/product_identification_helper/hashes/{hash_index}/file_hashes/{file_hash_index}/value"
         ),
-    }
+    })
 }
 
 /// 6.3.5 Use of Short Hash
@@ -24,8 +19,8 @@ fn create_short_hash_error(
 ///
 /// Hint: This will fail for algorithms like SHA-1 (40 characters) or MD5 (32 characters), which are also
 /// discouraged by 6.2.8 and 6.2.9.
-pub fn test_6_3_5_use_of_short_hash(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_5_use_of_short_hash(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(tree) = doc.get_product_tree() {
         tree.visit_all_products(&mut |fpn, path| {

--- a/csaf-rs/src/validations/test_6_3_09.rs
+++ b/csaf-rs/src/validations/test_6_3_09.rs
@@ -1,5 +1,5 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait, build_leaf_instance_path};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
 fn format_category_path(categories: &[CategoryOfTheBranch]) -> String {
     categories
@@ -13,19 +13,19 @@ fn create_branch_categories_error(
     full_path: &[CategoryOfTheBranch],
     relevant_categories: &[CategoryOfTheBranch],
     instance_path: String,
-) -> ValidationError {
+) -> TestFinding {
     let full_display = format_category_path(full_path);
     let found_display = if relevant_categories.is_empty() {
         "(none)".to_string()
     } else {
         format_category_path(relevant_categories)
     };
-    ValidationError {
+    TestFinding::Information(TestFindingData {
         message: format!(
             "Branch path to product does not follow the recommended sequence of the categories 'vendor' -> 'product_name' -> 'product_version'. Along the categories of this path '{full_display}', the following sequence was found: '{found_display}'"
         ),
         instance_path,
-    }
+    })
 }
 
 /// Required category sequence for branch paths.
@@ -43,8 +43,8 @@ const REQUIRED_CATEGORIES_ORDER: [CategoryOfTheBranch; 3] = [
 ///
 /// Other branch categories can be used before, after or between the aforementioned branch categories
 /// without making the test invalid.
-pub fn test_6_3_9_branch_categories(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_9_branch_categories(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     let Some(product_tree) = doc.get_product_tree() else {
         return Ok(()); // this will be a Passed::NoData later (#409)

--- a/csaf-rs/src/validations/test_6_3_09.rs
+++ b/csaf-rs/src/validations/test_6_3_09.rs
@@ -85,7 +85,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_9, test_6_3_9_branch
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_9 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_9 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -233,36 +235,36 @@ mod tests {
         // Case 15: Deep tree, split after 2x after name
         // Case S11: Stacked categories vendor x2, product_name x2, product_version x2
 
-        TESTS_2_0.test_6_3_9.expect(
-            case_01_missing_product_version.clone(),
-            case_02_missing_vendor.clone(),
-            case_03_missing_vendor_wrong_order.clone(),
-            case_04_wrong_order.clone(),
-            case_05_wrong_order_deep_tree.clone(),
-            case_06_missing_vendor_name_version.clone(),
-            case_s01_stacked_wrong_order.clone(),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_0.test_6_3_9.expect(ExpectedResults_2_0 {
+            case_01: case_01_missing_product_version.clone(),
+            case_02: case_02_missing_vendor.clone(),
+            case_03: case_03_missing_vendor_wrong_order.clone(),
+            case_04: case_04_wrong_order.clone(),
+            case_05: case_05_wrong_order_deep_tree.clone(),
+            case_06: case_06_missing_vendor_name_version.clone(),
+            case_s01: case_s01_stacked_wrong_order.clone(),
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_s11: Ok(()),
+        });
 
-        TESTS_2_1.test_6_3_9.expect(
-            case_01_missing_product_version,
-            case_02_missing_vendor,
-            case_03_missing_vendor_wrong_order,
-            case_04_wrong_order,
-            case_05_wrong_order_deep_tree,
-            case_06_missing_vendor_name_version,
-            case_s01_stacked_wrong_order,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_3_9.expect(ExpectedResults_2_1 {
+            case_01: case_01_missing_product_version,
+            case_02: case_02_missing_vendor,
+            case_03: case_03_missing_vendor_wrong_order,
+            case_04: case_04_wrong_order,
+            case_05: case_05_wrong_order_deep_tree,
+            case_06: case_06_missing_vendor_name_version,
+            case_s01: case_s01_stacked_wrong_order,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_s11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -32,7 +32,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_10, test_6_3_10_usag
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_10 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_10 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -42,7 +44,13 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_3_10.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_3_10.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_3_10.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_3_10.expect(ExpectedResults_2_1 {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -1,18 +1,18 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_product_version_range_error(path: &str) -> ValidationError {
-    ValidationError {
+fn create_product_version_range_error(path: &str) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: "Usage of 'product_version_range' branch category is not recommended".to_string(),
         instance_path: path.to_owned(),
-    }
+    })
 }
 
 /// 6.3.10 Usage of Product Version Range
 ///
 /// Tests that the `product_version_range` branch category is not used anywhere in the product tree.
-pub fn test_6_3_10_usage_of_product_version_range(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_10_usage_of_product_version_range(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree() {
         product_tree.visit_all_branches(&mut |branch, path| {

--- a/csaf-rs/src/validations/test_6_3_11.rs
+++ b/csaf-rs/src/validations/test_6_3_11.rs
@@ -41,7 +41,9 @@ crate::test_validation::impl_validator!(ValidatorForTest6_3_11, test_6_3_11_usag
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_0::testcases::ExpectedResults_6_3_11 as ExpectedResults_2_0;
     use crate::csaf2_0::testcases::TESTS_2_0;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_11 as ExpectedResults_2_1;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -52,7 +54,13 @@ mod tests {
         )]);
 
         // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0.test_6_3_11.expect(case_01.clone(), Ok(()));
-        TESTS_2_1.test_6_3_11.expect(case_01, Ok(()));
+        TESTS_2_0.test_6_3_11.expect(ExpectedResults_2_0 {
+            case_01: case_01.clone(),
+            case_11: Ok(()),
+        });
+        TESTS_2_1.test_6_3_11.expect(ExpectedResults_2_1 {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_11.rs
+++ b/csaf-rs/src/validations/test_6_3_11.rs
@@ -1,25 +1,25 @@
 use crate::csaf_traits::{BranchTrait, CategoryOfTheBranch, CsafTrait, ProductTreeTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use regex::Regex;
 use std::sync::LazyLock;
 
 static V_AS_VERSION_INDICATOR_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[vV][0-9].*$").unwrap());
 
-fn create_v_version_indicator_error(version: &str, path: &str) -> ValidationError {
-    ValidationError {
+fn create_v_version_indicator_error(version: &str, path: &str) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: format!(
             "Product version name {version} starting with 'v' or 'V' as version indicator is not recommended"
         ),
         instance_path: format!("{path}/name"),
-    }
+    })
 }
 
 /// 6.3.11 Usage of V as Version Indicator
 ///
 /// Tests that products in the product tree with the `product_version` branch category do not start
 /// with a `v` or `V` before their version.
-pub fn test_6_3_11_usage_of_v_as_version_indicator(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_11_usage_of_v_as_version_indicator(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     if let Some(product_tree) = doc.get_product_tree().as_ref() {
         product_tree.visit_all_branches(&mut |branch, path| {

--- a/csaf-rs/src/validations/test_6_3_12.rs
+++ b/csaf-rs/src/validations/test_6_3_12.rs
@@ -89,6 +89,7 @@ crate::test_validation::impl_validator!(csaf2_1, ValidatorForTest6_3_12, test_6_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_12 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -161,19 +162,19 @@ mod tests {
         // Vuln 1: with both products covered
         // Vuln 2: with 2 metrics, the second one covering both products
 
-        TESTS_2_1.test_6_3_12.expect(
-            case_01_cvss_v3_1_only,
-            case_02_cvss_v3_0_only,
-            case_03_cvss_v2_only,
-            case_04_multiple_vulns_two_without_cvss_v4,
-            case_05_uncovered_affected,
-            case_s01_last_affected_not_covered,
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-            Ok(()),
-        );
+        TESTS_2_1.test_6_3_12.expect(ExpectedResults {
+            case_01: case_01_cvss_v3_1_only,
+            case_02: case_02_cvss_v3_0_only,
+            case_03: case_03_cvss_v2_only,
+            case_04: case_04_multiple_vulns_two_without_cvss_v4,
+            case_05: case_05_uncovered_affected,
+            case_s01: case_s01_last_affected_not_covered,
+            case_11: Ok(()),
+            case_12: Ok(()),
+            case_13: Ok(()),
+            case_14: Ok(()),
+            case_15: Ok(()),
+            case_16: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_12.rs
+++ b/csaf-rs/src/validations/test_6_3_12.rs
@@ -2,26 +2,26 @@ use crate::csaf::types::csaf_vuln_metric::CsafVulnerabilityMetric;
 use crate::csaf_traits::{
     ContentTrait, CsafTrait, MetricTrait, ProductStatusGroup, ProductStatusGroupMap, VulnerabilityTrait,
 };
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use std::collections::HashSet;
 
-fn create_missing_cvss_v4_error(instance_path: String, cvss_versions: &[CsafVulnerabilityMetric]) -> ValidationError {
+fn create_missing_cvss_v4_error(instance_path: String, cvss_versions: &[CsafVulnerabilityMetric]) -> TestFinding {
     let versions_str = cvss_versions
         .iter()
         .map(|v| v.to_string())
         .collect::<Vec<String>>()
         .join(", ");
-    ValidationError {
+    TestFinding::Information(TestFindingData {
         message: format!("The metric contains {versions_str} but does not include a CVSS v4.0 score."),
         instance_path,
-    }
+    })
 }
 
-fn create_affected_product_not_covered_error(product_id: &str, instance_path: String) -> ValidationError {
-    ValidationError {
+fn create_affected_product_not_covered_error(product_id: &str, instance_path: String) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: format!("Affected product {product_id} is not covered by any CVSS score."),
         instance_path,
-    }
+    })
 }
 
 /// 6.3.12 Missing CVSS v4.0
@@ -33,8 +33,8 @@ fn create_affected_product_not_covered_error(product_id: &str, instance_path: St
 /// Affected is not covered by any CVSS object.
 ///
 /// This is essentially two tests at once for each vulnerability. We generate separate error messages for both.
-pub fn test_6_3_12_missing_cvss_v4(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_12_missing_cvss_v4(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         // collect product IDs covered by any CVSS object across all metrics of this vulnerability

--- a/csaf-rs/src/validations/test_6_3_18.rs
+++ b/csaf-rs/src/validations/test_6_3_18.rs
@@ -1,18 +1,18 @@
 use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 
-fn create_qualitative_severity_rating_error(instance_path: String) -> ValidationError {
-    ValidationError {
+fn create_qualitative_severity_rating_error(instance_path: String) -> TestFinding {
+    TestFinding::Error ( TestFindingData {
         message: "The metric uses a qualitative severity rating. The use of qualitative severity ratings is generally discouraged.".to_string(),
         instance_path,
-    }
+    })
 }
 
 /// 6.3.18 Use of Qualitative Severity Rating
 ///
 /// For each item in metrics it MUST be tested that it does not use the qualitative severity rating.
-pub fn test_6_3_18_use_of_qualitative_severity_rating(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_18_use_of_qualitative_severity_rating(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vulnerability) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(metrics) = vulnerability.get_metrics() {

--- a/csaf-rs/src/validations/test_6_3_18.rs
+++ b/csaf-rs/src/validations/test_6_3_18.rs
@@ -43,6 +43,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_18 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -51,6 +52,9 @@ mod tests {
             "/vulnerabilities/0/metrics/0/content/qualitative_severity_rating".to_string(),
         )]);
 
-        TESTS_2_1.test_6_3_18.expect(case_01, Ok(()));
+        TESTS_2_1.test_6_3_18.expect(ExpectedResults {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_18.rs
+++ b/csaf-rs/src/validations/test_6_3_18.rs
@@ -2,7 +2,7 @@ use crate::csaf_traits::{ContentTrait, CsafTrait, MetricTrait, VulnerabilityTrai
 use crate::validation::{TestFinding, TestFindingData};
 
 fn create_qualitative_severity_rating_error(instance_path: String) -> TestFinding {
-    TestFinding::Error ( TestFindingData {
+    TestFinding::Information ( TestFindingData {
         message: "The metric uses a qualitative severity rating. The use of qualitative severity ratings is generally discouraged.".to_string(),
         instance_path,
     })

--- a/csaf-rs/src/validations/test_6_3_20.rs
+++ b/csaf-rs/src/validations/test_6_3_20.rs
@@ -1,20 +1,20 @@
 use crate::csaf_traits::{CsafTrait, VulnerabilityIdTrait, VulnerabilityTrait};
-use crate::validation::ValidationError;
+use crate::validation::{TestFinding, TestFindingData};
 use crate::validations::utils::rvisc;
 
-fn create_unregistered_id_system_error(system_name: &str, vuln_index: usize, id_index: usize) -> ValidationError {
-    ValidationError {
+fn create_unregistered_id_system_error(system_name: &str, vuln_index: usize, id_index: usize) -> TestFinding {
+    TestFinding::Information(TestFindingData {
         message: format!("The system_name '{system_name}' is not registered in RVISC."),
         instance_path: format!("/vulnerabilities/{vuln_index}/ids/{id_index}/system_name"),
-    }
+    })
 }
 
 /// 6.3.20 Use of Unregistered ID System
 ///
 /// For each item in `/vulnerabilities[]/ids` it MUST be tested that the value of `system_name`
 /// belongs to a registered vulnerability ID system in RVISC.
-pub fn test_6_3_20_use_of_unregistered_id_system(doc: &impl CsafTrait) -> Result<(), Vec<ValidationError>> {
-    let mut errors: Option<Vec<ValidationError>> = None;
+pub fn test_6_3_20_use_of_unregistered_id_system(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
 
     for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
         if let Some(ids) = vuln.get_ids() {

--- a/csaf-rs/src/validations/test_6_3_20.rs
+++ b/csaf-rs/src/validations/test_6_3_20.rs
@@ -42,6 +42,7 @@ crate::test_validation::impl_validator!(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::csaf2_1::testcases::ExpectedResults_6_3_20 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
 
     #[test]
@@ -54,6 +55,9 @@ mod tests {
 
         // Case 11: Valid OASIS CSAF TC Issues system name
 
-        TESTS_2_1.test_6_3_20.expect(case_01, Ok(()));
+        TESTS_2_1.test_6_3_20.expect(ExpectedResults {
+            case_01,
+            case_11: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_schema.rs
+++ b/csaf-rs/src/validations/test_schema.rs
@@ -5,7 +5,7 @@ use serde_json::Value;
 
 use crate::{
     csaf::raw::RawDocument,
-    validation::ValidationError,
+    validation::{TestFinding, TestFindingData},
     validations::utils::{
         validation_schema_urls::{
             CVSS_V2_SCHEMA_URL, CVSS_V3_0_SCHEMA_URL, CVSS_V3_1_SCHEMA_URL, CVSS_V4_0_SCHEMA_URL,
@@ -73,17 +73,17 @@ static VALIDATOR_2_1: LazyLock<jsonschema::Validator> = LazyLock::new(|| {
         .unwrap()
 });
 
-fn create_schema_error(err: String, path: &str) -> ValidationError {
-    ValidationError {
+fn create_schema_error(err: String, path: &str) -> TestFinding {
+    TestFinding::Error(TestFindingData {
         message: err,
         instance_path: match path.len() {
             0 => "/".to_string(),
             _ => path.to_string(),
         },
-    }
+    })
 }
 
-fn validate_schema(document: &Value, validator: &jsonschema::Validator) -> Result<(), Vec<ValidationError>> {
+fn validate_schema(document: &Value, validator: &jsonschema::Validator) -> Result<(), Vec<TestFinding>> {
     let errors: Vec<_> = validator
         .iter_errors(document)
         .map(|error| create_schema_error(format!("{error}"), error.instance_path().as_str()))
@@ -96,13 +96,13 @@ fn validate_schema(document: &Value, validator: &jsonschema::Validator) -> Resul
 
 pub fn validate_schema_csaf_2_0(
     document: &RawDocument<crate::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework>,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     validate_schema(document.get_json(), &VALIDATOR_2_0)
 }
 
 pub fn validate_schema_csaf_2_1(
     document: &RawDocument<crate::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework>,
-) -> Result<(), Vec<ValidationError>> {
+) -> Result<(), Vec<TestFinding>> {
     validate_schema(document.get_json(), &VALIDATOR_2_1)
     // TODO: validate extensions
 }

--- a/type-generator/src/testcases/generate.rs
+++ b/type-generator/src/testcases/generate.rs
@@ -33,6 +33,7 @@ pub(crate) fn generate_test_cases_from_entries(
         let struct_ident = Ident::new(&format!("Test{id_formatted}"), Span::call_site());
         let validator_ident = Ident::new(&format!("ValidatorForTest{id_formatted}"), Span::call_site());
         let instance_ident = Ident::new(&format!("test_{id_formatted}"), Span::call_site());
+        let expect_ident = Ident::new(&format!("ExpectedResults_{id_formatted}"), Span::call_site());
         let test_id = &test.id;
 
         let csaf_version = match csaf_version {
@@ -45,6 +46,7 @@ pub(crate) fn generate_test_cases_from_entries(
             crate::macros::define_csaf_test!(
                 #struct_ident,
                 #validator_ident,
+                #expect_ident,
                 id: #test_id,
                 doc_type: #csaf_doc_type,
                 version: #csaf_version,


### PR DESCRIPTION
Refactors the validation error handling to use a new, more expressive `TestFinding` type instead of the previous `ValidationError`. The changes affect how errors, warnings, and informational messages are represented and propagated, improving flexibility and clarity in validation results. The update also removes the custom `Severity` enum and related logic, replacing it with filtering based on `TestFinding` variants.

* Replaced all uses of `ValidationError` (except surface level) with the new `TestFinding`
* Updated the `to_test_result` function in both CSAF 2.0 and 2.1 validation modules -> authority of error level now belongs to the test itself ❗ 

resolves #792 