### PR TITLE
remove cargo auditable cache, it is already cached by rust-cache. Check for binary directly.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Run benchmarks
         run: cargo bench --bench validation_benchmark -- --output-format bencher > output.txt
 
+      - name: Remove criterion output from cache
+        # target/criterion holds Criterion's own baseline comparison state, which is unused here
+        # (benchmark-action tracks trends itself via gh-pages) and can become stale/inconsistent
+        # across cached runs, breaking the bencher-format output. Exclude it from rust-cache by
+        # deleting it before the cache is saved in the action's post step.
+        if: always()
+        run: rm -rf target/criterion
+
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,7 @@ jobs:
         run: rustup update stable --no-self-update
 
       - name: Run benchmarks
-        run: cargo bench --bench validation_benchmark -- --output-format bencher | tee output.txt
+        run: cargo bench --bench validation_benchmark -- --output-format bencher > output.txt
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,15 +161,8 @@ jobs:
           rustup toolchain install ${{ matrix.version }} --profile minimal --component clippy
           rustup default ${{ matrix.version }}
           rustup target add ${{ matrix.target.arch }}
-      - name: Cache cargo-auditable
-        id: auditable-cache
-        uses: actions/cache@v6
-        with:
-          path: ~/.cargo/bin/cargo-auditable
-          key: cargo-auditable-${{ runner.os }}-${{ runner.arch }}
       - name: Install cargo-auditable
-        if: steps.auditable-cache.outputs.cache-hit != 'true'
-        run: cargo install cargo-auditable --locked
+        run: test -x ~/.cargo/bin/cargo-auditable || cargo install cargo-auditable --locked
       - name: Clippy check
         run: cargo clippy --all-targets --locked --target=${{ matrix.target.arch }} --release -- -D warnings
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,7 +162,8 @@ jobs:
           rustup default ${{ matrix.version }}
           rustup target add ${{ matrix.target.arch }}
       - name: Install cargo-auditable
-        run: test -x ~/.cargo/bin/cargo-auditable || cargo install cargo-auditable --locked
+        shell: bash
+        run: command -v cargo-auditable || cargo install cargo-auditable --locked
       - name: Clippy check
         run: cargo clippy --all-targets --locked --target=${{ matrix.target.arch }} --release -- -D warnings
       - name: Build


### PR DESCRIPTION
We have some build conflicts due to concurrent builds and caching.