### PR TITLE
refactor: extract shared logic between 6.1.27.17,18, bugfixes

### DIFF
--- a/csaf-rs/src/validations/test_6_1_27_17.rs
+++ b/csaf-rs/src/validations/test_6_1_27_17.rs
@@ -1,34 +1,9 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
-use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
-use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::{TestFinding, TestFindingData};
+use crate::csaf_traits::{CsafTrait, DocumentTrait};
+use crate::validation::TestFinding;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
-
-fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> TestFinding {
-    TestFinding::Error(TestFindingData {
-        message: format!(
-            "The document does not contain a note with title `Reasoning for Withdrawal` and category `description`  which is required for documents with category {document_category}"
-        ),
-        instance_path: "/document/notes".to_string(),
-    })
-}
-
-fn create_duplicated_reasoning_error(document_category: &CsafDocumentCategory, note_index: usize) -> TestFinding {
-    TestFinding::Error(TestFindingData {
-        message: format!(
-            "Duplicate note with title `Reasoning for Withdrawal` found while only one is allowed for documents with category {document_category}"
-        ),
-        instance_path: format!("/document/notes[{note_index}]"),
-    })
-}
-
-fn create_incorrect_category_error(note_index: usize) -> TestFinding {
-    TestFinding::Error(TestFindingData {
-        message: "The note has the correct title. However it uses the wrong category.".to_string(),
-        instance_path: format!("/document/notes[{note_index}]"),
-    })
-}
+use crate::validations::utils::document_notes_with_title_and_category::check_document_notes_with_title_and_category;
 
 /// 6.1.27.17 Reasoning for withdrawal
 ///
@@ -49,35 +24,11 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
         None => {},    // no language set
     }
 
-    let mut errors: Option<Vec<TestFinding>> = None;
-    let mut withdrawals = Vec::new();
-
-    if let Some(notes) = doc.get_document().get_notes() {
-        for (i_n, note) in notes.iter().enumerate() {
-            if let Some(title) = note.get_title()
-                && title == "Reasoning for Withdrawal"
-            {
-                if note.get_category() != NoteCategory::Description {
-                    errors
-                        .get_or_insert_default()
-                        .push(create_incorrect_category_error(i_n));
-                }
-                withdrawals.push(i_n);
-            }
-        }
-    }
-
-    // The fact that there is none or more than one note with the required title is the primary error and we ignore the category check, which is
-    // only relevant if there is exactly one occurrence.
-    if withdrawals.is_empty() {
-        return Err(vec![create_missing_reasoning_error(&doc_category)]);
-    } else if withdrawals.len() > 1 {
-        return Err(withdrawals
-            .iter()
-            .map(|f| create_duplicated_reasoning_error(&doc_category, *f))
-            .collect::<Vec<_>>());
-    }
-    errors.map_or(Ok(()), Err)
+    check_document_notes_with_title_and_category(
+        doc.get_document().get_notes().map(Vec::as_slice),
+        "Reasoning for Withdrawal",
+        &doc_category,
+    )
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =
@@ -94,9 +45,18 @@ mod tests {
     use super::*;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_27_17 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::validations::utils::document_notes_with_title_and_category::{
+        create_duplicated_note_error, create_incorrect_category_error, create_missing_note_error,
+    };
 
     #[test]
     fn test_test_6_1_27_17() {
+        const TITLE: &str = "Reasoning for Withdrawal";
+        let create_missing_reasoning_error =
+            |doc_category: &CsafDocumentCategory| create_missing_note_error(TITLE, doc_category);
+        let create_duplicated_reasoning_error =
+            |doc_category: &CsafDocumentCategory, index| create_duplicated_note_error(TITLE, doc_category, index);
+
         let undefined_lang_wrong_category = Err(vec![create_incorrect_category_error(0)]);
         let undefined_lang_duplicate_title = Err(vec![
             create_duplicated_reasoning_error(&CsafDocumentCategory::CsafWithdrawn, 0),

--- a/csaf-rs/src/validations/test_6_1_27_17.rs
+++ b/csaf-rs/src/validations/test_6_1_27_17.rs
@@ -1,9 +1,10 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
+use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::TestFinding;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
-use crate::validations::utils::document_notes_with_title_and_category::check_document_notes_with_title_and_category;
+use crate::validations::utils::document_notes_with_title_and_category::check_notes_with_title_and_category;
 
 /// 6.1.27.17 Reasoning for withdrawal
 ///
@@ -24,9 +25,10 @@ pub fn test_6_1_27_17_document_notes_for_withdrawal(doc: &impl CsafTrait) -> Res
         None => {},    // no language set
     }
 
-    check_document_notes_with_title_and_category(
+    check_notes_with_title_and_category(
         doc.get_document().get_notes().map(Vec::as_slice),
         "Reasoning for Withdrawal",
+        &NoteCategory::Description,
         &doc_category,
     )
 }
@@ -45,6 +47,7 @@ mod tests {
     use super::*;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_27_17 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::schema::csaf2_1::schema::NoteCategory;
     use crate::validations::utils::document_notes_with_title_and_category::{
         create_duplicated_note_error, create_incorrect_category_error, create_missing_note_error,
     };
@@ -52,28 +55,43 @@ mod tests {
     #[test]
     fn test_test_6_1_27_17() {
         const TITLE: &str = "Reasoning for Withdrawal";
-        let create_missing_reasoning_error =
-            |doc_category: &CsafDocumentCategory| create_missing_note_error(TITLE, doc_category);
-        let create_duplicated_reasoning_error =
-            |doc_category: &CsafDocumentCategory, index| create_duplicated_note_error(TITLE, doc_category, index);
+        const DOC_CATEGORY: &CsafDocumentCategory = &CsafDocumentCategory::CsafWithdrawn;
+        const NOTE_CATEGORY: &NoteCategory = &NoteCategory::Description;
+        let create_incorrect_category_error = |wrong_category: &NoteCategory, index| {
+            create_incorrect_category_error(TITLE, wrong_category, NOTE_CATEGORY, DOC_CATEGORY, index)
+        };
+        let create_missing_reasoning_error = create_missing_note_error(TITLE, NOTE_CATEGORY, DOC_CATEGORY);
+        let create_duplicated_reasoning_error = |index| create_duplicated_note_error(TITLE, DOC_CATEGORY, index);
 
-        let undefined_lang_wrong_category = Err(vec![create_incorrect_category_error(0)]);
-        let undefined_lang_duplicate_title = Err(vec![
-            create_duplicated_reasoning_error(&CsafDocumentCategory::CsafWithdrawn, 0),
-            create_duplicated_reasoning_error(&CsafDocumentCategory::CsafWithdrawn, 1),
+        let case_01_wrong_category_summary = Err(vec![create_incorrect_category_error(&NoteCategory::Summary, 0)]);
+        // Case 02: duplicate titles, different category
+        // Case 04: duplicate titles, same category
+        let duplicate_title = Err(vec![
+            create_duplicated_reasoning_error(0),
+            create_duplicated_reasoning_error(1),
         ]);
-        let lang_en_us_wrong_category = Err(vec![create_incorrect_category_error(0)]);
-        let undefined_lang_missing_reasoning = Err(vec![create_missing_reasoning_error(
-            &CsafDocumentCategory::CsafWithdrawn,
-        )]);
+        // Case 03: 2 notes, one with correct title, wrong category, one with wrong title, correct category
+        // We only report the correct title, wrong category note
+        let case_03_wrong_category = Err(vec![create_incorrect_category_error(&NoteCategory::Details, 0)]);
+        // Case 05: 2 notes, one with correct title, wrong category, one with wrong title, correct category, also language is en-US
+        // We only report the correct title, wrong category note
+        let case_05_lang_en_us_wrong_category = Err(vec![create_incorrect_category_error(&NoteCategory::General, 0)]);
+        // Case S01: no notes at all
+        // Case S02: only one note, wrong category, wrong title, also en-GB
+        let missing_reasoning = Err(vec![create_missing_reasoning_error]);
+
+        // Case 11: no lang, correct title / description
+        // Case 12: en-GB, correct title / description
+        // Case 13: de-DE, test does not apply
+
         TESTS_2_1.test_6_1_27_17.expect(ExpectedResults {
-            case_01: undefined_lang_wrong_category.clone(),
-            case_02: undefined_lang_duplicate_title.clone(),
-            case_03: undefined_lang_wrong_category,
-            case_04: undefined_lang_duplicate_title,
-            case_05: lang_en_us_wrong_category,
-            case_s01: undefined_lang_missing_reasoning.clone(),
-            case_s02: undefined_lang_missing_reasoning,
+            case_01: case_01_wrong_category_summary,
+            case_02: duplicate_title.clone(),
+            case_03: case_03_wrong_category,
+            case_04: duplicate_title,
+            case_05: case_05_lang_en_us_wrong_category,
+            case_s01: missing_reasoning.clone(),
+            case_s02: missing_reasoning,
             case_11: Ok(()),
             case_12: Ok(()),
             case_13: Ok(()),

--- a/csaf-rs/src/validations/test_6_1_27_18.rs
+++ b/csaf-rs/src/validations/test_6_1_27_18.rs
@@ -1,34 +1,9 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
-use crate::csaf_traits::{CsafTrait, DocumentTrait, NoteTrait};
-use crate::schema::csaf2_1::schema::NoteCategory;
-use crate::validation::{TestFinding, TestFindingData};
+use crate::csaf_traits::{CsafTrait, DocumentTrait};
+use crate::validation::TestFinding;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
-
-fn create_missing_reasoning_error(document_category: &CsafDocumentCategory) -> TestFinding {
-    TestFinding::Error(TestFindingData {
-        message: format!(
-            "The document does not contain a note with title `Reasoning for Withdrawal` and category `description`  which is required for documents with category {document_category}"
-        ),
-        instance_path: "/document/notes".to_string(),
-    })
-}
-
-fn create_duplicated_reasoning_error(document_category: &CsafDocumentCategory, note_index: usize) -> TestFinding {
-    TestFinding::Error(TestFindingData {
-        message: format!(
-            "Duplicate note with title `Reasoning for Withdrawal` found while only one is allowed for documents with category {document_category}"
-        ),
-        instance_path: format!("/document/notes[{note_index}]"),
-    })
-}
-
-fn create_incorrect_category_error(note_index: usize) -> TestFinding {
-    TestFinding::Error(TestFindingData {
-        message: "The note has the correct title. However it uses the wrong category.".to_string(),
-        instance_path: format!("/document/notes[{note_index}]"),
-    })
-}
+use crate::validations::utils::document_notes_with_title_and_category::check_document_notes_with_title_and_category;
 
 /// 6.1.27.18 Reasoning for supersession
 ///
@@ -49,35 +24,11 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
         None => {},    // no language set
     }
 
-    let mut errors: Option<Vec<TestFinding>> = None;
-    let mut supersessions = Vec::new();
-
-    if let Some(notes) = doc.get_document().get_notes() {
-        for (i_n, note) in notes.iter().enumerate() {
-            if let Some(title) = note.get_title()
-                && title == "Reasoning for Supersession"
-            {
-                if note.get_category() != NoteCategory::Description {
-                    errors
-                        .get_or_insert_default()
-                        .push(create_incorrect_category_error(i_n));
-                }
-                supersessions.push(i_n);
-            }
-        }
-    }
-
-    // The fact that there is none or more than one note with the required title is the primary error and we ignore the category check, which is
-    // only relevant if there is exactly one occurrence.
-    if supersessions.is_empty() {
-        return Err(vec![create_missing_reasoning_error(&doc_category)]);
-    } else if supersessions.len() > 1 {
-        return Err(supersessions
-            .iter()
-            .map(|f| create_duplicated_reasoning_error(&doc_category, *f))
-            .collect::<Vec<_>>());
-    }
-    errors.map_or(Ok(()), Err)
+    check_document_notes_with_title_and_category(
+        doc.get_document().get_notes().map(Vec::as_slice),
+        "Reasoning for Supersession",
+        &doc_category,
+    )
 }
 
 const PROFILE_TEST_CONFIG: DocumentCategoryTestConfig =
@@ -94,9 +45,18 @@ mod tests {
     use super::*;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_27_18 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::validations::utils::document_notes_with_title_and_category::{
+        create_duplicated_note_error, create_incorrect_category_error, create_missing_note_error,
+    };
 
     #[test]
     fn test_test_6_1_27_18() {
+        const TITLE: &str = "Reasoning for Supersession";
+        let create_missing_reasoning_error =
+            |doc_category: &CsafDocumentCategory| create_missing_note_error(TITLE, doc_category);
+        let create_duplicated_reasoning_error =
+            |doc_category: &CsafDocumentCategory, index| create_duplicated_note_error(TITLE, doc_category, index);
+
         let undefined_lang_wrong_category = Err(vec![create_incorrect_category_error(0)]);
         let undefined_lang_duplicate_title = Err(vec![
             create_duplicated_reasoning_error(&CsafDocumentCategory::CsafSuperseded, 0),

--- a/csaf-rs/src/validations/test_6_1_27_18.rs
+++ b/csaf-rs/src/validations/test_6_1_27_18.rs
@@ -1,9 +1,10 @@
 use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
 use crate::csaf::types::language::CsafLanguage;
 use crate::csaf_traits::{CsafTrait, DocumentTrait};
+use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::TestFinding;
 use crate::validations::utils::document_category_test_config::DocumentCategoryTestConfig;
-use crate::validations::utils::document_notes_with_title_and_category::check_document_notes_with_title_and_category;
+use crate::validations::utils::document_notes_with_title_and_category::check_notes_with_title_and_category;
 
 /// 6.1.27.18 Reasoning for supersession
 ///
@@ -24,9 +25,10 @@ pub fn test_6_1_27_18_document_notes_for_supersession(doc: &impl CsafTrait) -> R
         None => {},    // no language set
     }
 
-    check_document_notes_with_title_and_category(
+    check_notes_with_title_and_category(
         doc.get_document().get_notes().map(Vec::as_slice),
         "Reasoning for Supersession",
+        &NoteCategory::Description,
         &doc_category,
     )
 }
@@ -45,35 +47,53 @@ mod tests {
     use super::*;
     use crate::csaf2_1::testcases::ExpectedResults_6_1_27_18 as ExpectedResults;
     use crate::csaf2_1::testcases::TESTS_2_1;
+    use crate::schema::csaf2_1::schema::NoteCategory;
     use crate::validations::utils::document_notes_with_title_and_category::{
         create_duplicated_note_error, create_incorrect_category_error, create_missing_note_error,
     };
 
     #[test]
     fn test_test_6_1_27_18() {
+        // Setup test functions / consts
         const TITLE: &str = "Reasoning for Supersession";
-        let create_missing_reasoning_error =
-            |doc_category: &CsafDocumentCategory| create_missing_note_error(TITLE, doc_category);
-        let create_duplicated_reasoning_error =
-            |doc_category: &CsafDocumentCategory, index| create_duplicated_note_error(TITLE, doc_category, index);
+        const DOC_CATEGORY: &CsafDocumentCategory = &CsafDocumentCategory::CsafSuperseded;
+        const NOTE_CATEGORY: &NoteCategory = &NoteCategory::Description;
+        let create_incorrect_category_error = |wrong_category: &NoteCategory, index| {
+            create_incorrect_category_error(TITLE, wrong_category, NOTE_CATEGORY, DOC_CATEGORY, index)
+        };
+        let create_missing_reasoning_error = || create_missing_note_error(TITLE, NOTE_CATEGORY, DOC_CATEGORY);
+        let create_duplicated_reasoning_error = |index| create_duplicated_note_error(TITLE, DOC_CATEGORY, index);
 
-        let undefined_lang_wrong_category = Err(vec![create_incorrect_category_error(0)]);
-        let undefined_lang_duplicate_title = Err(vec![
-            create_duplicated_reasoning_error(&CsafDocumentCategory::CsafSuperseded, 0),
-            create_duplicated_reasoning_error(&CsafDocumentCategory::CsafSuperseded, 1),
+        // Case 01: correct title, wrong category
+        let case_01_wrong_category_details = Err(vec![create_incorrect_category_error(&NoteCategory::Details, 0)]);
+        // Case 02: duplicate titles, different category
+        // Case 04: duplicate titles, same category
+        let duplicate_title = Err(vec![
+            create_duplicated_reasoning_error(0),
+            create_duplicated_reasoning_error(1),
         ]);
-        let lang_en_us_wrong_category = Err(vec![create_incorrect_category_error(0)]);
-        let lang_en_gb_missing_reasoning = Err(vec![create_missing_reasoning_error(
-            &CsafDocumentCategory::CsafSuperseded,
-        )]);
+        // Case 03: 2 notes, one with correct title, wrong category, one with wrong title, correct category
+        // We only report the correct title, wrong category note
+        let case_03_wrong_category = Err(vec![create_incorrect_category_error(&NoteCategory::Summary, 0)]);
+        // Case 05: 2 notes, one with correct title, wrong category, one with wrong title, correct category, also language is en-US
+        // We only report the correct title, wrong category note
+        let case_05_lang_en_us_wrong_category = Err(vec![create_incorrect_category_error(&NoteCategory::General, 0)]);
+        // Case S01: no notes at all
+        // Case S02: only one note, wrong category, wrong title, also en-GB
+        let missing_reasoning = Err(vec![create_missing_reasoning_error()]);
+
+        // Case 11: no lang, correct title / description
+        // Case 12: en-GB, correct title / description
+        // Case 13: de-DE, test does not apply
+
         TESTS_2_1.test_6_1_27_18.expect(ExpectedResults {
-            case_01: undefined_lang_wrong_category.clone(),
-            case_02: undefined_lang_duplicate_title.clone(),
-            case_03: undefined_lang_wrong_category,
-            case_04: undefined_lang_duplicate_title,
-            case_05: lang_en_us_wrong_category,
-            case_s01: lang_en_gb_missing_reasoning.clone(),
-            case_s02: lang_en_gb_missing_reasoning,
+            case_01: case_01_wrong_category_details,
+            case_02: duplicate_title.clone(),
+            case_03: case_03_wrong_category,
+            case_04: duplicate_title,
+            case_05: case_05_lang_en_us_wrong_category,
+            case_s01: missing_reasoning.clone(),
+            case_s02: missing_reasoning,
             case_11: Ok(()),
             case_12: Ok(()),
             case_13: Ok(()),

--- a/csaf-rs/src/validations/utils/document_notes_with_title_and_category.rs
+++ b/csaf-rs/src/validations/utils/document_notes_with_title_and_category.rs
@@ -3,10 +3,14 @@ use crate::csaf_traits::NoteTrait;
 use crate::schema::csaf2_1::schema::NoteCategory;
 use crate::validation::{TestFinding, TestFindingData};
 
-pub(crate) fn create_missing_note_error(required_title: &str, document_category: &CsafDocumentCategory) -> TestFinding {
+pub(crate) fn create_missing_note_error(
+    required_title: &str,
+    required_category: &NoteCategory,
+    document_category: &CsafDocumentCategory,
+) -> TestFinding {
     TestFinding::Error(TestFindingData {
         message: format!(
-            "The document does not contain a note with title `{required_title}` and category `description` which is required for documents with category {document_category}"
+            "The document does not contain a note with title `{required_title}` and category `{required_category}` which is required for documents with category `{document_category}`"
         ),
         instance_path: "/document/notes".to_string(),
     })
@@ -19,40 +23,63 @@ pub(crate) fn create_duplicated_note_error(
 ) -> TestFinding {
     TestFinding::Error(TestFindingData {
         message: format!(
-            "Duplicate note with title `{required_title}` found while only one is allowed for documents with category {document_category}"
+            "Duplicate note with title `{required_title}` found while only one is allowed for documents with category `{document_category}`"
         ),
         instance_path: format!("/document/notes/{note_index}"),
     })
 }
 
-pub(crate) fn create_incorrect_category_error(note_index: usize) -> TestFinding {
+pub(crate) fn create_incorrect_category_error(
+    required_title: &str,
+    wrong_category: &NoteCategory,
+    required_category: &NoteCategory,
+    doc_category: &CsafDocumentCategory,
+    note_index: usize,
+) -> TestFinding {
     TestFinding::Error(TestFindingData {
-        message: "The note has the correct title. However it uses the wrong category.".to_string(),
+        message: format!(
+            "The document contains a note with title `{required_title}`, but it uses the wrong note category `{wrong_category}` (required is: `{required_category}`) for documents with category `{doc_category}`."
+        ),
         instance_path: format!("/document/notes/{note_index}"),
     })
 }
 
-/// Checks that exactly one document note exists with the given `required_title` and that its
-/// category is `description`.
+/// Checks that exactly one document note exists with the given `required_title` and
+/// `required_category` among the provided `notes`, in the context of a document with
+/// `doc_category`. `doc_category` is forwarded to error generation functions and not
+/// used in the error detection logic.
+///
+/// The following findings are reported in that order / prioritization:
+/// - If no note with `required_title` is found: a single missing-note error.
+/// - If more than one note with `required_title` is found: one duplicate error per matching note.
+/// - If exactly one note with `required_title` is found but its category differs from
+///   `required_category`: a wrong-category error.
 ///
 /// Returns `Ok(())` if the check passes, or `Err` with a list of [`TestFinding`]s otherwise.
-pub(crate) fn check_document_notes_with_title_and_category<N: NoteTrait>(
-    notes: Option<&[N]>,
+pub(crate) fn check_notes_with_title_and_category<Note: NoteTrait>(
+    notes: Option<&[Note]>,
     required_title: &str,
+    required_category: &NoteCategory,
     doc_category: &CsafDocumentCategory,
 ) -> Result<(), Vec<TestFinding>> {
     let mut errors: Option<Vec<TestFinding>> = None;
     let mut matching_indices = Vec::new();
 
+    // filter notes for required title and category
+    // collect correct title, wrong category errors
     if let Some(notes) = notes {
         for (i_n, note) in notes.iter().enumerate() {
             if let Some(title) = note.get_title()
                 && title == required_title
             {
-                if note.get_category() != NoteCategory::Description {
-                    errors
-                        .get_or_insert_default()
-                        .push(create_incorrect_category_error(i_n));
+                if note.get_category() != *required_category {
+                    errors.get_or_insert_default().push(create_incorrect_category_error(
+                        required_title,
+                        &note.get_category(),
+                        required_category,
+                        doc_category,
+                        i_n,
+                    ));
                 }
                 matching_indices.push(i_n);
             }
@@ -63,7 +90,11 @@ pub(crate) fn check_document_notes_with_title_and_category<N: NoteTrait>(
     // error and we ignore the category check, which is only relevant if there is exactly one
     // occurrence.
     if matching_indices.is_empty() {
-        return Err(vec![create_missing_note_error(required_title, doc_category)]);
+        return Err(vec![create_missing_note_error(
+            required_title,
+            required_category,
+            doc_category,
+        )]);
     } else if matching_indices.len() > 1 {
         return Err(matching_indices
             .iter()

--- a/csaf-rs/src/validations/utils/document_notes_with_title_and_category.rs
+++ b/csaf-rs/src/validations/utils/document_notes_with_title_and_category.rs
@@ -1,0 +1,74 @@
+use crate::csaf::types::csaf_document_category::CsafDocumentCategory;
+use crate::csaf_traits::NoteTrait;
+use crate::schema::csaf2_1::schema::NoteCategory;
+use crate::validation::{TestFinding, TestFindingData};
+
+pub(crate) fn create_missing_note_error(required_title: &str, document_category: &CsafDocumentCategory) -> TestFinding {
+    TestFinding::Error(TestFindingData {
+        message: format!(
+            "The document does not contain a note with title `{required_title}` and category `description` which is required for documents with category {document_category}"
+        ),
+        instance_path: "/document/notes".to_string(),
+    })
+}
+
+pub(crate) fn create_duplicated_note_error(
+    required_title: &str,
+    document_category: &CsafDocumentCategory,
+    note_index: usize,
+) -> TestFinding {
+    TestFinding::Error(TestFindingData {
+        message: format!(
+            "Duplicate note with title `{required_title}` found while only one is allowed for documents with category {document_category}"
+        ),
+        instance_path: format!("/document/notes/{note_index}"),
+    })
+}
+
+pub(crate) fn create_incorrect_category_error(note_index: usize) -> TestFinding {
+    TestFinding::Error(TestFindingData {
+        message: "The note has the correct title. However it uses the wrong category.".to_string(),
+        instance_path: format!("/document/notes/{note_index}"),
+    })
+}
+
+/// Checks that exactly one document note exists with the given `required_title` and that its
+/// category is `description`.
+///
+/// Returns `Ok(())` if the check passes, or `Err` with a list of [`TestFinding`]s otherwise.
+pub(crate) fn check_document_notes_with_title_and_category<N: NoteTrait>(
+    notes: Option<&[N]>,
+    required_title: &str,
+    doc_category: &CsafDocumentCategory,
+) -> Result<(), Vec<TestFinding>> {
+    let mut errors: Option<Vec<TestFinding>> = None;
+    let mut matching_indices = Vec::new();
+
+    if let Some(notes) = notes {
+        for (i_n, note) in notes.iter().enumerate() {
+            if let Some(title) = note.get_title()
+                && title == required_title
+            {
+                if note.get_category() != NoteCategory::Description {
+                    errors
+                        .get_or_insert_default()
+                        .push(create_incorrect_category_error(i_n));
+                }
+                matching_indices.push(i_n);
+            }
+        }
+    }
+
+    // The fact that there is none or more than one note with the required title is the primary
+    // error and we ignore the category check, which is only relevant if there is exactly one
+    // occurrence.
+    if matching_indices.is_empty() {
+        return Err(vec![create_missing_note_error(required_title, doc_category)]);
+    } else if matching_indices.len() > 1 {
+        return Err(matching_indices
+            .iter()
+            .map(|f| create_duplicated_note_error(required_title, doc_category, *f))
+            .collect::<Vec<_>>());
+    }
+    errors.map_or(Ok(()), Err)
+}

--- a/csaf-rs/src/validations/utils/document_notes_with_title_and_category.rs
+++ b/csaf-rs/src/validations/utils/document_notes_with_title_and_category.rs
@@ -38,7 +38,7 @@ pub(crate) fn create_incorrect_category_error(
 ) -> TestFinding {
     TestFinding::Error(TestFindingData {
         message: format!(
-            "The document contains a note with title `{required_title}`, but it uses the wrong note category `{wrong_category}` (required is: `{required_category}`) for documents with category `{doc_category}`."
+            "The document contains a note with title `{required_title}`, but it uses the wrong note category `{wrong_category}` for documents with category `{doc_category}` (should be `{required_category}`)."
         ),
         instance_path: format!("/document/notes/{note_index}"),
     })

--- a/csaf-rs/src/validations/utils/mod.rs
+++ b/csaf-rs/src/validations/utils/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod document_category_test_config;
+pub(crate) mod document_notes_with_title_and_category;
 pub(crate) mod language_specific_translations;
 pub(crate) mod rvisc;
 pub(crate) mod validation_schema_urls;

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-17-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-17-s02.json
@@ -8,6 +8,7 @@
         "label": "CLEAR"
       }
     },
+    "lang": "en-GB",
     "notes": [
       {
         "category": "description",
@@ -23,7 +24,7 @@
     "title": "Mandatory Test: Reasoning for Withdrawal (failing example 2: withdrawal note missing, but other description note present)",
     "tracking": {
       "current_release_date": "2024-05-24T10:00:00.000Z",
-      "id": "CSAF-RS_CSAF-CSAF_2_1-6-1-27-17-S01",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-1-27-17-S02",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {


### PR DESCRIPTION
This PR:
* moves the shared validation logic / error generation from 6.1.27.17 & 18 into a seperate helper
* helper will also be re-used by 6.2.39.2 (#825) & 3 (#826)
* fixes #819 in the process