### PR TITLE
Pin shared CI workflows to v1.1.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Update rustup
         run: rustup update stable --no-self-update
       - name: Run shared format check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@d86c333cc6d773ebd9694d090df9d222392f7281 # v1.1.0
         with:
           run-clippy: "false"
       - name: Doc check
@@ -80,7 +80,7 @@ jobs:
           fi
       - name: Compute Rust build context
         id: build-context
-        uses: csaf-rs/shared-workflows/.github/actions/rust-build-context@main
+        uses: csaf-rs/shared-workflows/.github/actions/rust-build-context@d86c333cc6d773ebd9694d090df9d222392f7281 # v1.1.0
       - name: Compute Go build targets
         id: get-go-targets
         run: |
@@ -131,7 +131,7 @@ jobs:
         shell: bash
         run: command -v cargo-auditable || cargo install cargo-auditable --locked
       - name: Run shared clippy check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@main
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@d86c333cc6d773ebd9694d090df9d222392f7281 # v1.1.0
         with:
           run-format: "false"
           clippy-extra-args: "--target=${{ matrix.target.arch }}"


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/7.

It pins the shared composite action calls to a specific commit SHA, with `v1.1.0` included as a version comment, instead of using main. This ensures that future changes to [shared-workflows](https://github.com/csaf-rs/shared-workflows) do not affect this repository until a new version is released and updated by Dependabot.

**Note:** This PR should be merged only after https://github.com/csaf-rs/csaf/pull/801, because it modifies the changes introduced in https://github.com/csaf-rs/csaf/pull/801.