### PR TITLE
Use shared CI documentation check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,14 +56,10 @@ jobs:
         run: ./scripts/json/check_json_sorting.sh --quiet
       - name: Update rustup
         run: rustup update stable --no-self-update
-      - name: Run shared format check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@d86c333cc6d773ebd9694d090df9d222392f7281 # v1.1.0
+      - name: Run shared format and doc checks
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
         with:
           run-clippy: "false"
-      - name: Doc check
-        run: cargo doc --no-deps --document-private-items --locked
-        env:
-          RUSTDOCFLAGS: "-D warnings"
       - name: Run type-generator
         run: cargo run --locked -p type-generator
       - name: Check for uncommitted changes in generated files
@@ -80,7 +76,7 @@ jobs:
           fi
       - name: Compute Rust build context
         id: build-context
-        uses: csaf-rs/shared-workflows/.github/actions/rust-build-context@d86c333cc6d773ebd9694d090df9d222392f7281 # v1.1.0
+        uses: csaf-rs/shared-workflows/.github/actions/rust-build-context@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
       - name: Compute Go build targets
         id: get-go-targets
         run: |
@@ -131,9 +127,10 @@ jobs:
         shell: bash
         run: command -v cargo-auditable || cargo install cargo-auditable --locked
       - name: Run shared clippy check
-        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@d86c333cc6d773ebd9694d090df9d222392f7281 # v1.1.0
+        uses: csaf-rs/shared-workflows/.github/actions/rust-checks@8d7fd6241752c334d1c60e80a355722f44d9b99e # v1.2.0
         with:
           run-format: "false"
+          run-doc: "false"
           clippy-extra-args: "--target=${{ matrix.target.arch }}"
       - name: Build
         run: cargo auditable build --locked --target=${{ matrix.target.arch }} --release --verbose


### PR DESCRIPTION
This PR addresses https://github.com/csaf-rs/shared-workflows/issues/6

It updates the shared CI Rust checks and rust-build-context to v1.2.0 and enables the centralized documentation check.