### PR TITLE
chore: integrate new ssvc version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1819,8 +1819,9 @@ dependencies = [
 
 [[package]]
 name = "ssvc"
-version = "0.2.1"
-source = "git+https://github.com/csaf-rs/ssvc?branch=main#98ee0a15624399f1e0a77f954ff335647ae8dd74"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9a244219da28fbef8c23d34e71eb66d263862252728e8c85eda19f6c392054"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1820,16 +1820,18 @@ dependencies = [
 [[package]]
 name = "ssvc"
 version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591d8eb7f7ab8f67baa6250ede8c342b3022528020e360055528afbadae69042"
+source = "git+https://github.com/csaf-rs/ssvc?branch=main#98ee0a15624399f1e0a77f954ff335647ae8dd74"
 dependencies = [
+ "anyhow",
  "chrono",
- "prettyplease 0.2.37",
+ "jsonschema",
+ "prettyplease 0.3.0",
  "regress",
  "rust-embed",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 3.0.3",
+ "thiserror 2.0.20",
  "typify",
 ]
 

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -35,14 +35,14 @@ semver = { version = "1" }
 jsonschema = { version = "0.49.1", default-features = false }
 spdx = "0.13.4"
 oxilangtag = "0.1.5"
-ssvc = { git = "https://github.com/csaf-rs/ssvc", branch = "main" }
+ssvc = "0.3.0"
 strum = { version = "0.28", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.17.0", features = ["v7", "serde", "js"] }
 
 [build-dependencies]
-ssvc = { git = "https://github.com/csaf-rs/ssvc", branch = "main" }
+ssvc = "0.3.0"
 serde_json = { version = "1", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/csaf-rs/Cargo.toml
+++ b/csaf-rs/Cargo.toml
@@ -35,14 +35,14 @@ semver = { version = "1" }
 jsonschema = { version = "0.49.1", default-features = false }
 spdx = "0.13.4"
 oxilangtag = "0.1.5"
-ssvc = "0.2.1"
+ssvc = { git = "https://github.com/csaf-rs/ssvc", branch = "main" }
 strum = { version = "0.28", features = ["derive"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { version = "1.17.0", features = ["v7", "serde", "js"] }
 
 [build-dependencies]
-ssvc = "0.2.1"
+ssvc = { git = "https://github.com/csaf-rs/ssvc", branch = "main" }
 serde_json = { version = "1", features = ["preserve_order"] }
 
 [dev-dependencies]

--- a/csaf-rs/build/ssvc_validation.rs
+++ b/csaf-rs/build/ssvc_validation.rs
@@ -1,5 +1,5 @@
 /// Validate that the SSVC selection list schema (used in custom.rs) is valid JSON, similar to the checks in the type-generator
 pub fn validate_ssvc_lib_json() {
-    serde_json::from_str::<serde_json::Value>(ssvc::assets::SELECTION_LIST_SCHEMA)
-        .expect("ssvc::assets::SELECTION_LIST_SCHEMA is not valid JSON");
+    serde_json::from_str::<serde_json::Value>(ssvc::SELECTION_LIST_SCHEMA)
+        .expect("ssvc::SELECTION_LIST_SCHEMA is not valid JSON");
 }

--- a/csaf-rs/src/validations/test_6_1_48.rs
+++ b/csaf-rs/src/validations/test_6_1_48.rs
@@ -28,7 +28,7 @@ fn test_6_1_48_ssvc_decision_points_internal(
                 if content.has_ssvc_v2() {
                     match content.get_ssvc_v2() {
                         Ok(ssvc) => {
-                            let result = ssvc::validation::validate_selection_list(&ssvc, allow_test_namespaces);
+                            let result = ssvc::validate_selection_list(&ssvc, allow_test_namespaces);
                             if !result.success {
                                 let validation_errors: Vec<TestFinding> = result
                                     .errors
@@ -134,7 +134,7 @@ mod tests {
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/values/2".to_string(),
         })]);
         let case_21 = Err(vec![TestFinding::Error(TestFindingData {
-            message: "Invalid SSVC namespace: Reserved namespace 'invalid' must not be used".to_string(),
+            message: "Invalid SSVC namespace: Reserved forbidden namespace 'invalid' must not be used".to_string(),
             instance_path: "/vulnerabilities/0/metrics/0/content/ssvc_v2/selections/0/namespace".to_string(),
         })]);
         let case_16 = case_06.clone();

--- a/csaf-rs/src/validations/utils/validation_schemas/custom.rs
+++ b/csaf-rs/src/validations/utils/validation_schemas/custom.rs
@@ -2,6 +2,6 @@ use serde_json::Value;
 use std::sync::LazyLock;
 
 pub static SSVC_2_SCHEMA: LazyLock<Value> = LazyLock::new(|| {
-    let schema_str = ssvc::assets::SELECTION_LIST_SCHEMA;
-    serde_json::from_str(schema_str).expect("The referenced JSON schema ssvc::assets::SELECTION_LIST_SCHEMA should be valid JSON. This is validated at build-time. (This looks like a dev error)")
+    let schema_str = ssvc::SELECTION_LIST_SCHEMA;
+    serde_json::from_str(schema_str).expect("The referenced JSON schema ssvc::SELECTION_LIST_SCHEMA should be valid JSON. This is validated at build-time. (This looks like a dev error)")
 });


### PR DESCRIPTION
ssvc v0.3.0 is in the works, this PR (and following stack) will test if the implementation is now able to handle all requirements needed for the CSAF 2.1 SSVC tests.

This will include implementations of the SSVC tests, which will be polished iteratively on merge to main.

Do not merge this stack until a) ssvc v0.3.0 was released and b) the temp changes to cargo.toml were reverted.

EDIT: 0.3.0 is released, merging.