### PR TITLE
fix: wrong instance_path in 6.1.27.12 and 6.1.38

### DIFF
--- a/csaf-rs/src/validations/test_6_1_27_12.rs
+++ b/csaf-rs/src/validations/test_6_1_27_12.rs
@@ -11,7 +11,7 @@ fn create_missing_affected_products_error(
         message: format!(
             "Document with category '{document_category}' must have a '/vulnerabilities[]/product_status/known_affected' element"
         ),
-        instance_path: format!("/vulnerabilities[{vulnerability_index}]/product_status/known_affected"),
+        instance_path: format!("/vulnerabilities/{vulnerability_index}/product_status/known_affected"),
     })
 }
 

--- a/csaf-rs/src/validations/test_6_1_38.rs
+++ b/csaf-rs/src/validations/test_6_1_38.rs
@@ -7,7 +7,7 @@ use crate::validation::{TestFinding, TestFindingData};
 static NON_PUBLIC_SHARING_GROUP_ERROR: LazyLock<TestFinding> = LazyLock::new(|| {
     TestFinding::Error(TestFindingData {
         message: "Document must be public (TLP:CLEAR) when using max UUID as sharing group ID.".to_string(),
-        instance_path: "/document/distribution/sharing_group/tlp/label".to_string(),
+        instance_path: "/document/distribution/tlp/label".to_string(),
     })
 });
 


### PR DESCRIPTION
Relates to #850 

Just two wrong instance_path strings:
6.1.27.12 has brackets instead of slashes around the index
6.1.38 has tlp as child of sharing_group, but its a sibling