### PR TITLE
feat: add test 6.3.5 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ This creates TypeScript + WASM output in `wasm/`.
 | Test specification | 2.0               | 2.1 (experimental) |
 |--------|-------------------|--------------------|
 | 6.3.1  |  |  |
+| 6.3.5 | ✅ | ✅ |
 | 6.3.14 | ⭕ | ✅ |
 | 6.3.15 | ⭕ | ✅ |
 

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -2527,7 +2527,19 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
     cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json",
-    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json")]
+    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-05-01.json"), (case_s01, "s01",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s01.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s01.json"), (case_s02, "s02",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s02.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s02.json"), (case_s03, "s03",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s03.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s03.json"), (case_s04, "s04",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s04.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s04.json"), (case_s05, "s05",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s05.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s05.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s11.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_3_6, ValidatorForTest6_3_6, ExpectedResults_6_3_6, id : "6.3.6", doc_type :

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -236,7 +236,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
                 "6.3.3" => None, // Some(ValidatorForTest6_3_3.validate(self)),
                 "6.3.4" => None, // Some(ValidatorForTest6_3_4.validate(self)),
-                "6.3.5" => None, // Some(ValidatorForTest6_3_5.validate(self)),
+                "6.3.5" => Some(ValidatorForTest6_3_5.validate(self)),
                 "6.3.6" => None, // Some(ValidatorForTest6_3_6.validate(self)),
                 "6.3.7" => None, // Some(ValidatorForTest6_3_7.validate(self)),
                 "6.3.8" => None, // Some(ValidatorForTest6_3_8.validate(self)),

--- a/csaf-rs/src/validations/test_6_3_05.rs
+++ b/csaf-rs/src/validations/test_6_3_05.rs
@@ -66,10 +66,62 @@ mod tests {
             32,
         )]);
 
-        // Both CSAF 2.0 and 2.1 have 1 test case
+        let case_s01 = Err(vec![
+            create_short_hash_error("/product_tree/branches/0/branches/0/branches/0/product", 0, 1, 32),
+            create_short_hash_error("/product_tree/branches/0/branches/1/product", 0, 1, 40),
+            create_short_hash_error("/product_tree/branches/1/product", 1, 0, 56),
+        ]);
+
+        let case_s02 = Err(vec![
+            create_short_hash_error("/product_tree/full_product_names/0", 0, 1, 32),
+            create_short_hash_error("/product_tree/full_product_names/1", 1, 0, 40),
+        ]);
+
+        let case_s03 = Err(vec![
+            create_short_hash_error("/product_tree/product_paths/0/full_product_name", 0, 1, 32),
+            create_short_hash_error("/product_tree/product_paths/1/full_product_name", 1, 0, 40),
+        ]);
+
+        let case_s04 = Err(vec![
+            create_short_hash_error("/product_tree/branches/0/product", 0, 0, 32),
+            create_short_hash_error("/product_tree/full_product_names/0", 0, 0, 40),
+            create_short_hash_error("/product_tree/product_paths/0/full_product_name", 0, 0, 56),
+        ]);
+
+        let case_s05 = Err(vec![create_short_hash_error(
+            "/product_tree/full_product_names/0",
+            0,
+            0,
+            63,
+        )]);
+
+        // TODO: Add a test case for an empty hash value once lenient parsing is supported
+
+        let case_s11 = Ok(());
+
         TESTS_2_0.test_6_3_5.expect(ExpectedResults_2_0 {
             case_01: case_01.clone(),
         });
-        TESTS_2_1.test_6_3_5.expect(ExpectedResults_2_1 { case_01 });
+
+        // Failing test cases:
+        // 01  - hash value with exactly 32 characters
+        // s01 - multiple short hashes in nested branches, mixed with valid hashes
+        // s02 - multiple short hashes in full product names, mixed with valid hashes
+        // s03 - multiple short hashes in product paths, mixed with valid hashes
+        // s04 - multiple short hashes across all three product tree locations
+        // s05 - hash value with exactly 63 characters
+
+        // Valid test cases:
+        // s11 - hash value with exactly 64 characters
+
+        TESTS_2_1.test_6_3_5.expect(ExpectedResults_2_1 {
+            case_01,
+            case_s01,
+            case_s02,
+            case_s03,
+            case_s04,
+            case_s05,
+            case_s11,
+        });
     }
 }

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s01.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Use of Short Hash (failing supplementary example 1 - nested branches and multiple findings)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-05-S01",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "branches": [
+          {
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.0",
+                "product": {
+                  "name": "Example Company Product A 1.0",
+                  "product_id": "CSAFPID-0001",
+                  "product_identification_helper": {
+                    "hashes": [
+                      {
+                        "file_hashes": [
+                          {
+                            "algorithm": "sha256",
+                            "value": "d212f3b9e587f61a89ff39f70fb8669c033f799d5417c47467a0a7d9b76fee20"
+                          },
+                          {
+                            "algorithm": "md4",
+                            "value": "3202b50e2e5b2fcd75e284c3d9d5f8d6"
+                          }
+                        ],
+                        "filename": "product_a_1_0.so"
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "category": "product_name",
+            "name": "Product A"
+          },
+          {
+            "category": "product_name",
+            "name": "Product B",
+            "product": {
+              "name": "Example Company Product B",
+              "product_id": "CSAFPID-0002",
+              "product_identification_helper": {
+                "hashes": [
+                  {
+                    "file_hashes": [
+                      {
+                        "algorithm": "sha256",
+                        "value": "5f8d3c4b2a190e7d6c5b4a39281716151413121110ffeeddccbbaa9988776655"
+                      },
+                      {
+                        "algorithm": "sha1",
+                        "value": "b4d25eefd8ebd2b48ee4bcca7362f55279d55764"
+                      }
+                    ],
+                    "filename": "product_b.so"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        "category": "vendor",
+        "name": "Example Company"
+      },
+      {
+        "category": "product_name",
+        "name": "Product C",
+        "product": {
+          "name": "Product C",
+          "product_id": "CSAFPID-0003",
+          "product_identification_helper": {
+            "hashes": [
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "sha512",
+                    "value": "fd22cb886ab930a5a45c61a15f2f4dc6291ce67ce9751d66a4e1d65a890345f3d8ead486afb88a36a13398bd37070725eb5f794644add1848e6e1e05aed47678"
+                  }
+                ],
+                "filename": "product_c_valid.so"
+              },
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "sha224",
+                    "value": "446c5231729981edb88d685834509e348475830efe1328e5712e9972"
+                  }
+                ],
+                "filename": "product_c_short.so"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s02.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Use of Short Hash (failing supplementary example 2 - multiple full product names and findings)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-05-S02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-0001",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha256",
+                  "value": "e9f3a00a7cc88c33acfa94a4eb40a51072c82bce1836babca47621fced6838f9"
+                },
+                {
+                  "algorithm": "md5",
+                  "value": "98db59d2b0b59a7c99278541e448be75"
+                }
+              ],
+              "filename": "product-a.so"
+            }
+          ]
+        }
+      },
+      {
+        "name": "Product B",
+        "product_id": "CSAFPID-0002",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha512",
+                  "value": "0edf658ed7e51c2127d81ec688626f84159712e32fe7361ea6a7823ac401a8887aa87a042145ce448fb24cd235574f69c6227e8df5e689c0ac495872a466a334"
+                }
+              ],
+              "filename": "product-b-valid.so"
+            },
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha1",
+                  "value": "e75923cfd14799f1d4c2d7073f28c07f91dfde17"
+                }
+              ],
+              "filename": "product-b-short.so"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s03.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s03.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Use of Short Hash (failing supplementary example 3 - multiple product paths and findings)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-05-S03",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-0001"
+      },
+      {
+        "name": "Product B",
+        "product_id": "CSAFPID-0002"
+      },
+      {
+        "name": "Product C",
+        "product_id": "CSAFPID-0003"
+      }
+    ],
+    "product_paths": [
+      {
+        "beginning_product_reference": "CSAFPID-0001",
+        "full_product_name": {
+          "name": "Product A installed on Product B",
+          "product_id": "CSAFPID-0101",
+          "product_identification_helper": {
+            "hashes": [
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "sha256",
+                    "value": "13ef03ded9c5faac78d438399a976aec9fecb50f811380a08a8752ce27fd463f"
+                  },
+                  {
+                    "algorithm": "md5",
+                    "value": "d3eb6b243389b8a84295f20010e095be"
+                  }
+                ],
+                "filename": "product-ab.so"
+              }
+            ]
+          }
+        },
+        "subpaths": [
+          {
+            "category": "installed_on",
+            "next_product_reference": "CSAFPID-0002"
+          }
+        ]
+      },
+      {
+        "beginning_product_reference": "CSAFPID-0001",
+        "full_product_name": {
+          "name": "Product A installed on Product C",
+          "product_id": "CSAFPID-0102",
+          "product_identification_helper": {
+            "hashes": [
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "sha512",
+                    "value": "cd7584ed240b4e05b55c85be0ee1dd7815327b36f009577da5752700ef6d60717de2e06b33c7e8dc2dfe9c366f97426b8c2b4c6e19b887b08797b887b0ea0cd6"
+                  }
+                ],
+                "filename": "product-ac-valid.so"
+              },
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "sha1",
+                    "value": "9cff6ee97dca39bfb114d278c997324a8609ebec"
+                  }
+                ],
+                "filename": "product-ac-short.so"
+              }
+            ]
+          }
+        },
+        "subpaths": [
+          {
+            "category": "installed_on",
+            "next_product_reference": "CSAFPID-0003"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s04.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s04.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Use of Short Hash (failing supplementary example 4 - multiple findings across all product tree locations)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-05-S04",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "product_name",
+        "name": "Product A",
+        "product": {
+          "name": "Product A",
+          "product_id": "CSAFPID-0001",
+          "product_identification_helper": {
+            "hashes": [
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "md5",
+                    "value": "236caee52739a4708937ba49ee742e71"
+                  }
+                ],
+                "filename": "product-a.so"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "full_product_names": [
+      {
+        "name": "Product B",
+        "product_id": "CSAFPID-0002",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha1",
+                  "value": "9220a196bd44b94eeab14928c275ec68906ea91e"
+                }
+              ],
+              "filename": "product-b.so"
+            }
+          ]
+        }
+      },
+      {
+        "name": "Product C",
+        "product_id": "CSAFPID-0003"
+      }
+    ],
+    "product_paths": [
+      {
+        "beginning_product_reference": "CSAFPID-0002",
+        "full_product_name": {
+          "name": "Product B installed on Product C",
+          "product_id": "CSAFPID-0004",
+          "product_identification_helper": {
+            "hashes": [
+              {
+                "file_hashes": [
+                  {
+                    "algorithm": "sha224",
+                    "value": "2b70d3018f2cf9bb541fe4f126d1afae229cc21bdbf17ac4080ef23f"
+                  }
+                ],
+                "filename": "product-bc.so"
+              }
+            ]
+          }
+        },
+        "subpaths": [
+          {
+            "category": "installed_on",
+            "next_product_reference": "CSAFPID-0003"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s05.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s05.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Use of Short Hash (failing supplementary example 5 - hash value with exactly 63 characters)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-05-S05",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-0001",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "test-63-char-hash-algo",
+                  "value": "133c80200b9dbe30323f51efe05999a8f00b22b2eccd1ebb825463f7742d732"
+                }
+              ],
+              "filename": "product-a.so"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-05-s11.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Use of Short Hash (passing supplementary example 1 - hash value with exactly 64 characters)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-05-S11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "name": "Product A",
+        "product_id": "CSAFPID-0001",
+        "product_identification_helper": {
+          "hashes": [
+            {
+              "file_hashes": [
+                {
+                  "algorithm": "sha256",
+                  "value": "2cc0a7bf9d0990e556b9e385d836a31c78a3a5619a6a26a5d3f7d1b216ccc85a"
+                }
+              ],
+              "filename": "product-a.so"
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -795,6 +795,38 @@
       ]
     },
     {
+      "id": "6.3.5",
+      "group": "informative",
+      "failures": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s01.json",
+          "valid": true
+        },
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s02.json",
+          "valid": true
+        },
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s03.json",
+          "valid": true
+        },
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s04.json",
+          "valid": true
+        },
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s05.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-05-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.9",
       "group": "informative",
       "failures": [


### PR DESCRIPTION
This PR resolves https://github.com/csaf-rs/csaf/issues/273.

It adds new supplementary test cases and tests the implementation of 6.3.5 for CSAF 2.1.

Failing supplementary test cases:
- s01 - nested branches with mixed valid and short hashes (`64/32`, `64/40`, `128/56`)
- s02 - multiple full product names with mixed valid and short hashes (`64/32`, `128/40`)
- s03 - multiple product paths with mixed valid and short hashes (`64/32`, `128/40`)
- s04 - one short hash in each product tree location (`branches: 32`, `full_product_names: 40`, `product_paths: 56`)
- s05 - hash value with exactly 63 characters

Valid supplementary test cases:
- s11 - hash value with exactly 64 characters