### PR TITLE
ci: use shared cargo publish workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -375,24 +375,12 @@ jobs:
           done
 
   publish-crates:
-    runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     needs:
       - build-platforms
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, 'beta') && !contains(github.ref, 'alpha')
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          submodules: "true"
-      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
-        id: auth
-      - name: Update rustup
-        run: rustup update stable --no-self-update
-      - name: Publish
-        run: cargo publish --locked --verbose
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+    uses: csaf-rs/shared-workflows/.github/workflows/cargo-publish.yml@a55e51a118eb3d0beae0fed4a616eec29dc01ca2 # v1.10.0
 
   publish-npm:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR resolves https://github.com/csaf-rs/csaf/issues/889.

It replaces the repository-specific cargo publish job with the reusable workflow from [`csaf-rs/shared-workflows`](https://github.com/csaf-rs/shared-workflows).

As [discussed](https://github.com/csaf-rs/shared-workflows/issues/38#issuecomment-5489411629), no additional checks for `alpha` or `beta` releases are added, since we currently don't use these tags.

The submodule checkout is removed as it is not required for publishing. Relevant assets are copied via `update_assets` ([Comment](https://github.com/csaf-rs/shared-workflows/pull/26#discussion_r3854913843)).