### PR TITLE
feat: add 6.2.12 passing supplementary test

### DIFF
--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -806,7 +806,9 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
     cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-12-01.json",
-    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-12-01.json")]
+    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-12-01.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-12-s11.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-12-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_2_13, ValidatorForTest6_2_13, ExpectedResults_6_2_13, id : "6.2.13", doc_type :

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -1749,7 +1749,9 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
     cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json",
-    "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json")]
+    "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-12-01.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-12-s11.json",
+    "recommended/csaf-rs_csaf-csaf_2_1-6-2-12-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_2_13, ValidatorForTest6_2_13, ExpectedResults_6_2_13, id : "6.2.13", doc_type :

--- a/csaf-rs/src/validations/test_6_2_12.rs
+++ b/csaf-rs/src/validations/test_6_2_12.rs
@@ -31,12 +31,15 @@ mod tests {
 
     #[test]
     fn test_test_6_2_12() {
-        let err = Err(vec![MISSING_DOCUMENT_LANGUAGE.clone()]);
+        let missing_document_language_property = Err(vec![MISSING_DOCUMENT_LANGUAGE.clone()]);
 
-        // Both CSAF 2.0 and 2.1 have 2 test cases
-        TESTS_2_0
-            .test_6_2_12
-            .expect(ExpectedResults_2_0 { case_01: err.clone() });
-        TESTS_2_1.test_6_2_12.expect(ExpectedResults_2_1 { case_01: err });
+        TESTS_2_0.test_6_2_12.expect(ExpectedResults_2_0 {
+            case_01: missing_document_language_property.clone(),
+            case_s11: Ok(()),
+        });
+        TESTS_2_1.test_6_2_12.expect(ExpectedResults_2_1 {
+            case_01: missing_document_language_property,
+            case_s11: Ok(()),
+        });
     }
 }

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-12-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-12-s11.json
@@ -1,0 +1,27 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "lang": "en",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Missing Document Language (valid supplementary example 1 - file with lang item contained)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-12-S11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -639,6 +639,16 @@
       ]
     },
     {
+      "id": "6.2.12",
+      "group": "optional",
+      "valid": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-12-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.2.14",
       "group": "optional",
       "failures": [

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-12-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-12-s11.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "lang": "en",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Missing Document Language (valid supplementary example 1 - file with lang item contained)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-12-S11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -743,6 +743,16 @@
       ]
     },
     {
+      "id": "6.2.12",
+      "group": "recommended",
+      "valid": [
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-12-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.2.14",
       "group": "recommended",
       "failures": [


### PR DESCRIPTION
This PR addresses #298.

It documents compliance with the recommended test case 6.2.12 for 2.0.

In addition a valid supplementary test case was added for 2.1 and 2.0 to ensure that compliant documents are not reported.