### PR TITLE
feat: add tests 6.2.4 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ This creates TypeScript + WASM output in `wasm/`.
 | Test specification | 2.0                | 2.1 (experimental) |
 |----------|--------------------|--------------------|
 | 6.2.1    |  |  |
+| 6.2.4   | ✅ | ✅ |
 | 6.2.11   | ✅ | ✅ |
 | 6.2.16   | ✅ | ✅ |
 | 6.2.17   | ✅ | ✅ |

--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -726,7 +726,15 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
     cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-04-01.json",
-    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-04-01.json")]
+    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-04-01.json"), (case_s01, "s01",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s01.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s01.json"), (case_s02, "s02",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s02.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s02.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s11.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s11.json"), (case_s12, "s12",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s12.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s12.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_2_5, ValidatorForTest6_2_5, ExpectedResults_6_2_5, id : "6.2.5", doc_type :

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -1632,7 +1632,15 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
     cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json",
-    "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json")]
+    "recommended/oasis_csaf_tc-csaf_2_1-2024-6-2-04-01.json"), (case_s01, "s01",
+    "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s01.json",
+    "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s01.json"), (case_s02, "s02",
+    "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s02.json",
+    "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s02.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s11.json",
+    "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s11.json"), (case_s12, "s12",
+    "../type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s12.json",
+    "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s12.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_2_5, ValidatorForTest6_2_5, ExpectedResults_6_2_5, id : "6.2.5", doc_type :

--- a/csaf-rs/src/validations/test_6_2_04.rs
+++ b/csaf-rs/src/validations/test_6_2_04.rs
@@ -52,12 +52,12 @@ mod tests {
 
     #[test]
     fn test_test_6_2_04() {
-        let case_01_build_metadata = Err(vec![create_build_metadata_in_rev_history_error(
+        let revision_history_with_build_metadata = Err(vec![create_build_metadata_in_rev_history_error(
             &SemVerVersion::from(Version::from_str("1.0.0+exp.sha.ac00785").unwrap()),
             &0,
         )]);
 
-        let case_s01_mixed_build_metadata_presence = Err(vec![
+        let revision_history_with_alternating_build_metadata = Err(vec![
             create_build_metadata_in_rev_history_error(
                 &SemVerVersion::from(Version::from_str("1.1.0+exp.sha.ac00785").unwrap()),
                 &1,
@@ -68,22 +68,23 @@ mod tests {
             ),
         ]);
 
-        let case_s02_build_metadata_after_pre_release = Err(vec![create_build_metadata_in_rev_history_error(
-            &SemVerVersion::from(Version::from_str("1.1.0-rc.1+exp.sha.ac00785").unwrap()),
-            &1,
-        )]);
+        let revision_history_with_build_metadata_after_pre_release =
+            Err(vec![create_build_metadata_in_rev_history_error(
+                &SemVerVersion::from(Version::from_str("1.1.0-rc.1+exp.sha.ac00785").unwrap()),
+                &1,
+            )]);
 
         TESTS_2_0.test_6_2_4.expect(ExpectedResults_2_0 {
-            case_01: case_01_build_metadata.clone(),
+            case_01: revision_history_with_build_metadata.clone(),
         });
 
-        // Case s11: no build metadata
-        // Case s12: integer version numbers (no build metadata allowed by schema)
+        // Case s11: revision_history without build metadata
+        // Case s12: revision_history with integer versions (no build metadata allowed by schema)
 
         TESTS_2_1.test_6_2_4.expect(ExpectedResults_2_1 {
-            case_01: case_01_build_metadata,
-            case_s01: case_s01_mixed_build_metadata_presence,
-            case_s02: case_s02_build_metadata_after_pre_release,
+            case_01: revision_history_with_build_metadata,
+            case_s01: revision_history_with_alternating_build_metadata,
+            case_s02: revision_history_with_build_metadata_after_pre_release,
             case_s11: Ok(()),
             case_s12: Ok(()),
         });

--- a/csaf-rs/src/validations/test_6_2_04.rs
+++ b/csaf-rs/src/validations/test_6_2_04.rs
@@ -52,15 +52,40 @@ mod tests {
 
     #[test]
     fn test_test_6_2_04() {
-        let case_01 = Err(vec![create_build_metadata_in_rev_history_error(
+        let case_01_build_metadata = Err(vec![create_build_metadata_in_rev_history_error(
             &SemVerVersion::from(Version::from_str("1.0.0+exp.sha.ac00785").unwrap()),
             &0,
         )]);
 
-        // Both CSAF 2.0 and 2.1 have 2 test cases
+        let case_s01_mixed_build_metadata_presence = Err(vec![
+            create_build_metadata_in_rev_history_error(
+                &SemVerVersion::from(Version::from_str("1.1.0+exp.sha.ac00785").unwrap()),
+                &1,
+            ),
+            create_build_metadata_in_rev_history_error(
+                &SemVerVersion::from(Version::from_str("1.3.0+exp.sha.ac00785").unwrap()),
+                &3,
+            ),
+        ]);
+
+        let case_s02_build_metadata_after_pre_release = Err(vec![create_build_metadata_in_rev_history_error(
+            &SemVerVersion::from(Version::from_str("1.1.0-rc.1+exp.sha.ac00785").unwrap()),
+            &1,
+        )]);
+
         TESTS_2_0.test_6_2_4.expect(ExpectedResults_2_0 {
-            case_01: case_01.clone(),
+            case_01: case_01_build_metadata.clone(),
         });
-        TESTS_2_1.test_6_2_4.expect(ExpectedResults_2_1 { case_01 });
+
+        // Case s11: no build metadata
+        // Case s12: integer version numbers (no build metadata allowed by schema)
+
+        TESTS_2_1.test_6_2_4.expect(ExpectedResults_2_1 {
+            case_01: case_01_build_metadata,
+            case_s01: case_s01_mixed_build_metadata_presence,
+            case_s02: case_s02_build_metadata_after_pre_release,
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
     }
 }

--- a/csaf-rs/src/validations/test_6_2_04.rs
+++ b/csaf-rs/src/validations/test_6_2_04.rs
@@ -74,12 +74,16 @@ mod tests {
                 &1,
             )]);
 
-        TESTS_2_0.test_6_2_4.expect(ExpectedResults_2_0 {
-            case_01: revision_history_with_build_metadata.clone(),
-        });
-
         // Case s11: revision_history without build metadata
         // Case s12: revision_history with integer versions (no build metadata allowed by schema)
+
+        TESTS_2_0.test_6_2_4.expect(ExpectedResults_2_0 {
+            case_01: revision_history_with_build_metadata.clone(),
+            case_s01: revision_history_with_alternating_build_metadata.clone(),
+            case_s02: revision_history_with_build_metadata_after_pre_release.clone(),
+            case_s11: Ok(()),
+            case_s12: Ok(()),
+        });
 
         TESTS_2_1.test_6_2_4.expect(ExpectedResults_2_1 {
             case_01: revision_history_with_build_metadata,

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s01.json
@@ -1,0 +1,41 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Build Metadata in Revision History (failing supplementary example 1 - alternating presence of build metadata across multiple revisions)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-04-S01",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-18T10:00:00.000Z",
+          "number": "1.0.0",
+          "summary": "Initial version."
+        },
+        {
+          "date": "2021-07-19T10:00:00.000Z",
+          "number": "1.1.0+exp.sha.ac00785",
+          "summary": "Second version."
+        },
+        {
+          "date": "2021-07-20T10:00:00.000Z",
+          "number": "1.2.0",
+          "summary": "Third version."
+        },
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1.3.0+exp.sha.ac00785",
+          "summary": "Fourth version."
+        }
+      ],
+      "status": "final",
+      "version": "1.3.0"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s02.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s02.json
@@ -1,0 +1,31 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Build Metadata in Revision History (failing supplementary example 2 - build metadata following pre-release versions)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-04-S02",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-20T10:00:00.000Z",
+          "number": "1.0.0-rc.1",
+          "summary": "Initial version."
+        },
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1.1.0-rc.1+exp.sha.ac00785",
+          "summary": "Second version."
+        }
+      ],
+      "status": "draft",
+      "version": "1.1.0-rc.1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s11.json
@@ -1,0 +1,26 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Build Metadata in Revision History (valid supplementary example 1 - no build metadata)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-04-S11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1.0.0",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s12.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-04-s12.json
@@ -1,0 +1,31 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: Build Metadata in Revision History (valid supplementary example 2 - integer versioning)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-04-S12",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-20T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        },
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "2",
+          "summary": "Second version."
+        }
+      ],
+      "status": "final",
+      "version": "2"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -573,6 +573,30 @@
       ]
     },
     {
+      "id": "6.2.4",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s01.json",
+          "valid": true
+        },
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s02.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s11.json",
+          "valid": true
+        },
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-04-s12.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.2.8",
       "group": "optional",
       "failures": [

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s01.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Build Metadata in Revision History (failing supplementary example 1 - alternating presence of build metadata across multiple revisions)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-04-S01",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-21T10:00:00.000Z",
+          "number": "1.0.0",
+          "summary": "Initial version."
+        },
+        {
+          "date": "2024-01-22T10:00:00.000Z",
+          "number": "1.1.0+exp.sha.ac00785",
+          "summary": "Second version."
+        },
+        {
+          "date": "2024-01-23T10:00:00.000Z",
+          "number": "1.2.0",
+          "summary": "Third version."
+        },
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1.3.0+exp.sha.ac00785",
+          "summary": "Fourth version."
+        }
+      ],
+      "status": "final",
+      "version": "1.3.0"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s02.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Build Metadata in Revision History (failing supplementary example 2 - build metadata following pre-release versions)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-04-S02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-23T10:00:00.000Z",
+          "number": "1.0.0-rc.1",
+          "summary": "Initial version."
+        },
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1.1.0-rc.1+exp.sha.ac00785",
+          "summary": "Second version."
+        }
+      ],
+      "status": "draft",
+      "version": "1.1.0-rc.1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s11.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Build Metadata in Revision History (valid supplementary example 1 - no build metadata)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-04-S11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1.0.0",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s12.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s12.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Recommended Test: Build Metadata in Revision History (valid supplementary example 2 - integer versioning)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-04-S12",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-23T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        },
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "2",
+          "summary": "Second version."
+        }
+      ],
+      "status": "final",
+      "version": "2"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -631,6 +631,30 @@
       ]
     },
     {
+      "id": "6.2.4",
+      "group": "recommended",
+      "failures": [
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s01.json",
+          "valid": true
+        },
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s02.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s11.json",
+          "valid": true
+        },
+        {
+          "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-04-s12.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.2.8",
       "group": "recommended",
       "valid": [


### PR DESCRIPTION
This PR resolves https://github.com/csaf-rs/csaf/issues/290.

It adds a new supplementary test cases and tests the implementation of 6.2.4 for CSAF 2.1. Since the rule is almost identical in CSAF 2.0, the supplementary test coverage is also reused for CSAF 2.0

Failing supplementary test cases:

- s01 - alternating presence of build metadata across multiple revisions (four semantic-versioned revisions alternating between values without and with build metadata to verify that all occurrences of build metadata are detected regardless of their position in the revision history, and that validation continues after a finding)
- s02 - build metadata following pre-release information (two pre-release semantic versions, one without and one with build metadata, to verify that build metadata is detected when it follows a pre-release part) (breaks 6.1.19, therefore - mandatory invalid, but represents an interesting case)

Valid supplementary test cases:

- s11 - one semantic-versioned revision without build metadata (counterpart to OASIS case 01)
- s12 - two revisions using integer versioning (without build metadata, because schema doesn't allow that)