### PR TITLE
feat: improve 6.2.17 test suite for CSAF 2.0 and CSAF 2.1

### DIFF
--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -877,9 +877,19 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
     cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-01.json",
-    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-01.json"), (case_11, "11",
+    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-01.json"), (case_s01, "s01",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s01.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s01.json"), (case_s02, "s02",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s02.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s02.json"), (case_s03, "s03",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s03.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s03.json"), (case_s04, "s04",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s04.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s04.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-11.json",
-    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-11.json")]
+    "optional/oasis_csaf_tc-csaf_2_0-2021-6-2-17-11.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s11.json",
+    "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_2_18, ValidatorForTest6_2_18, ExpectedResults_6_2_18, id : "6.2.18", doc_type :

--- a/csaf-rs/src/validations/test_6_2_17.rs
+++ b/csaf-rs/src/validations/test_6_2_17.rs
@@ -60,6 +60,17 @@ mod tests {
         TESTS_2_0.test_6_2_17.expect(ExpectedResults_2_0 {
             case_01: case_01.clone(),
             case_11: Ok(()),
+
+            // Failing test for two ids for the same vulnerability with CVEs in the text field
+            case_s01: case_s01.clone(),
+            // Failing test for two vulnerability each containing one id with a CVE in the text field
+            case_s02: case_s02.clone(),
+            // Failing test for two ids for the same vulnerability with the second having a CVE in the text field
+            case_s03: case_s03.clone(),
+            // Failing test for two vulnerabilities with the second having a CVE in its id's text field
+            case_s04: case_s04.clone(),
+            // Valid test for two vulnerabilities each with two ids with correctly set text fields
+            case_s11: Ok(()),
         });
         TESTS_2_1.test_6_2_17.expect(ExpectedResults_2_1 {
             case_01,

--- a/csaf-rs/src/validations/test_6_2_17.rs
+++ b/csaf-rs/src/validations/test_6_2_17.rs
@@ -45,45 +45,41 @@ mod tests {
 
     #[test]
     fn test_test_6_2_17() {
-        let case_01 = Err(vec![create_cve_in_ids_error("CVE-2021-44228", 0, 0)]);
-        let case_s01 = Err(vec![
+        let id_with_cve_in_text_field = Err(vec![create_cve_in_ids_error("CVE-2021-44228", 0, 0)]);
+        let multiple_ids_with_cve_in_text_field_fail_distinct = Err(vec![
             create_cve_in_ids_error("CVE-2021-44228", 0, 0),
             create_cve_in_ids_error("CVE-2021-44229", 0, 1),
         ]);
-        let case_s02 = Err(vec![
+        let two_vulnerabilities_with_ids_with_cve_in_text_field = Err(vec![
             create_cve_in_ids_error("CVE-2021-44228", 0, 0),
             create_cve_in_ids_error("CVE-2021-44229", 1, 0),
         ]);
-        let case_s03 = Err(vec![create_cve_in_ids_error("CVE-2021-44228", 0, 1)]);
-        let case_s04 = Err(vec![create_cve_in_ids_error("CVE-2021-44228", 1, 0)]);
+        let second_id_of_a_vulnerability_with_cve_in_text_field =
+            Err(vec![create_cve_in_ids_error("CVE-2021-44228", 0, 1)]);
+        let second_vulnerability_with_an_id_with_cve_in_text_field =
+            Err(vec![create_cve_in_ids_error("CVE-2021-44228", 1, 0)]);
 
         TESTS_2_0.test_6_2_17.expect(ExpectedResults_2_0 {
-            case_01: case_01.clone(),
+            case_01: id_with_cve_in_text_field.clone(),
+            // Valid test with one vulnerability containing an id with a correctly set text field
             case_11: Ok(()),
 
-            // Failing test for two ids for the same vulnerability with CVEs in the text field
-            case_s01: case_s01.clone(),
-            // Failing test for two vulnerability each containing one id with a CVE in the text field
-            case_s02: case_s02.clone(),
-            // Failing test for two ids for the same vulnerability with the second having a CVE in the text field
-            case_s03: case_s03.clone(),
-            // Failing test for two vulnerabilities with the second having a CVE in its id's text field
-            case_s04: case_s04.clone(),
+            case_s01: multiple_ids_with_cve_in_text_field_fail_distinct.clone(),
+            case_s02: two_vulnerabilities_with_ids_with_cve_in_text_field.clone(),
+            case_s03: second_id_of_a_vulnerability_with_cve_in_text_field.clone(),
+            case_s04: second_vulnerability_with_an_id_with_cve_in_text_field.clone(),
             // Valid test for two vulnerabilities each with two ids with correctly set text fields
             case_s11: Ok(()),
         });
         TESTS_2_1.test_6_2_17.expect(ExpectedResults_2_1 {
-            case_01,
+            case_01: id_with_cve_in_text_field,
+            // Valid test with one vulnerability containing an id with a correctly set text field
             case_11: Ok(()),
 
-            // Failing test for two ids for the same vulnerability with CVEs in the text field
-            case_s01,
-            // Failing test for two vulnerability each containing one id with a CVE in the text field
-            case_s02,
-            // Failing test for two ids for the same vulnerability with the second having a CVE in the text field
-            case_s03,
-            // Failing test for two vulnerabilities with the second having a CVE in its id's text field
-            case_s04,
+            case_s01: multiple_ids_with_cve_in_text_field_fail_distinct,
+            case_s02: two_vulnerabilities_with_ids_with_cve_in_text_field,
+            case_s03: second_id_of_a_vulnerability_with_cve_in_text_field,
+            case_s04: second_vulnerability_with_an_id_with_cve_in_text_field,
             // Valid test for two vulnerabilities each with two ids with correctly set text fields
             case_s11: Ok(()),
         });

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s01.json
@@ -1,0 +1,40 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: CVE in field IDs (failing supplementary example 1 - two ids with CVE in text property)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-17-S01",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "CVE Project",
+          "text": "CVE-2021-44228"
+        },
+        {
+          "system_name": "CVE Project",
+          "text": "CVE-2021-44229"
+        }
+      ]
+    }
+  ]
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s02.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s02.json
@@ -1,0 +1,44 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: CVE in field IDs (failing supplementary example 2 - two vulnerabilities with ids with CVE in text property)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-17-S02",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "CVE Project",
+          "text": "CVE-2021-44228"
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "system_name": "CVE Project",
+          "text": "CVE-2021-44229"
+        }
+      ]
+    }
+  ]
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s03.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s03.json
@@ -1,0 +1,40 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: CVE in field IDs (failing supplementary example 3 - two ids with a CVE in the second's text field)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-17-S03",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "GitHub Issue",
+          "text": "csaf-tools/CVRF-CSAF-Converter#78"
+        },
+        {
+          "system_name": "CVE Project",
+          "text": "CVE-2021-44228"
+        }
+      ]
+    }
+  ]
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s04.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s04.json
@@ -1,0 +1,44 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: CVE in field IDs (failing supplementary example 4 - two vulnerabilities where the second's id has a CVE in text property)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-17-S04",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "GitHub Issue",
+          "text": "csaf-tools/CVRF-CSAF-Converter#78"
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "system_name": "CVE Project",
+          "text": "CVE-2021-44228"
+        }
+      ]
+    }
+  ]
+}

--- a/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/optional/csaf-rs_csaf-csaf_2_0-6-2-17-s11.json
@@ -1,0 +1,52 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Optional test: CVE in field IDs (valid supplementary example 1 - two vulnerabilities with two ids each with properly used text field)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-2-17-S11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "vulnerabilities": [
+    {
+      "ids": [
+        {
+          "system_name": "GitHub Issue",
+          "text": "csaf-tools/CVRF-CSAF-Converter#78"
+        },
+        {
+          "system_name": "GitHub Issue",
+          "text": "csaf-tools/CVRF-CSAF-Converter#79"
+        }
+      ]
+    },
+    {
+      "ids": [
+        {
+          "system_name": "GitHub Issue",
+          "text": "csaf-tools/CVRF-CSAF-Converter#80"
+        },
+        {
+          "system_name": "GitHub Issue",
+          "text": "csaf-tools/CVRF-CSAF-Converter#81"
+        }
+      ]
+    }
+  ]
+}

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -673,6 +673,34 @@
       ]
     },
     {
+      "id": "6.2.17",
+      "group": "optional",
+      "failures": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s01.json",
+          "valid": true
+        },
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s02.json",
+          "valid": true
+        },
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s03.json",
+          "valid": true
+        },
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s04.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-17-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.9",
       "group": "informative",
       "failures": [

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s01.json
@@ -10,13 +10,13 @@
     },
     "publisher": {
       "category": "other",
-      "name": "OASIS CSAF TC",
-      "namespace": "https://csaf.io"
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Recommended Test: CVE in field IDs (failing supplementary example 1)",
+    "title": "Recommended Test: CVE in field IDs (failing supplementary example 1 - two ids with a CVE in the text field)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-17-01",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-17-S01",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s02.json
@@ -10,13 +10,13 @@
     },
     "publisher": {
       "category": "other",
-      "name": "OASIS CSAF TC",
-      "namespace": "https://csaf.io"
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Recommended Test: CVE in field IDs (failing supplementary example 2)",
+    "title": "Recommended Test: CVE in field IDs (failing supplementary example 2 - two vulnerabilities with one id each that contains a CVE in the text field)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-17-01",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-17-S02",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s03.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s03.json
@@ -10,13 +10,13 @@
     },
     "publisher": {
       "category": "other",
-      "name": "OASIS CSAF TC",
-      "namespace": "https://csaf.io"
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Recommended Test: CVE in field IDs (failing supplementary example 3)",
+    "title": "Recommended Test: CVE in field IDs (failing supplementary example 3 - two ids with the second one containing a CVE in the text field)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-17-01",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-17-S03",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s04.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s04.json
@@ -10,13 +10,13 @@
     },
     "publisher": {
       "category": "other",
-      "name": "OASIS CSAF TC",
-      "namespace": "https://csaf.io"
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Recommended Test: CVE in field IDs (failing supplementary example 4)",
+    "title": "Recommended Test: CVE in field IDs (failing supplementary example 4 - two vulnerabilities with one id each; the second containing a CVE in the text field)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-17-01",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-17-S04",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {

--- a/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/recommended/csaf-rs_csaf-csaf_2_1-6-2-17-s11.json
@@ -10,13 +10,13 @@
     },
     "publisher": {
       "category": "other",
-      "name": "OASIS CSAF TC",
-      "namespace": "https://csaf.io"
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Recommended Test: CVE in field IDs (info supplementary example 1)",
+    "title": "Recommended Test: CVE in field IDs (valid supplementary example 1 - two vulnerabilities with two ids each without CVEs in the text field)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
-      "id": "OASIS_CSAF_TC-CSAF_2.1-2024-6-2-17-01",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-2-17-S11",
       "initial_release_date": "2024-01-24T10:00:00.000Z",
       "revision_history": [
         {


### PR DESCRIPTION
This change ports the 6.2.17 supplementary test cases from CSAF 2.1 to CSAF 2.0.

In addition small fixes are applied to use better naming for test cases and use correct metadata in 2.1 test case files.

Resolves #912 