### PR TITLE
fix: 6-3-9-S11 is known invalid

### DIFF
--- a/csaf-rs/src/validations/test_6_3_09.rs
+++ b/csaf-rs/src/validations/test_6_3_09.rs
@@ -233,6 +233,7 @@ mod tests {
         // Case 13: vendor -> family -> split to 2x name -> version
         // Case 14: vendor -> split to 2x name -> version
         // Case 15: Deep tree, split after 2x after name
+        // Note: Stacked categories violate 6.1.57, making this test file mandatory invalid on CSAF 2.1
         // Case S11: Stacked categories vendor x2, product_name x2, product_version x2
 
         TESTS_2_0.test_6_3_9.expect(ExpectedResults_2_0 {

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -922,7 +922,7 @@
       "valid": [
         {
           "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-09-s11.json",
-          "valid": true
+          "valid": false
         }
       ]
     },


### PR DESCRIPTION
This PR:
* correctly states that 6-3-09-S11 is invalid, as its stacked categories violate 6.1.57
* adds inline comment for that

Working on a script to detect these, will add one PR per preset / csaf version.