### PR TITLE
fix: correct CSAF 2.1 recommended supplementary test validity

### DIFF
--- a/csaf-rs/src/validations/test_6_2_15.rs
+++ b/csaf-rs/src/validations/test_6_2_15.rs
@@ -68,6 +68,8 @@ mod tests {
             "/document/source_lang",
         )]);
 
+        // Having both doc lang and source lang set to the same value violates 6.1.28
+        // making this test file mandatory invalid
         let case_s01_default_both_langs = Err(vec![
             create_default_language_error("i-default".to_string(), "/document/lang"),
             create_default_language_error("i-default".to_string(), "/document/source_lang"),

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -724,11 +724,11 @@
       "failures": [
         {
           "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s01.json",
-          "valid": false
+          "valid": true
         },
         {
           "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-14-s02.json",
-          "valid": false
+          "valid": true
         }
       ]
     },
@@ -742,7 +742,7 @@
         },
         {
           "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-15-s02.json",
-          "valid": false
+          "valid": true
         }
       ],
       "valid": [


### PR DESCRIPTION
This PR:
* corrects the CSAF 2.1 validity from 6-2-14 and 6-2-15
* adds a comment why 6-2-15-S01 is correctly invalid