### PR TITLE
fix: correct 6-2-38-S11 validity, add comment for in test code

### DIFF
--- a/csaf-rs/src/validations/test_6_2_38.rs
+++ b/csaf-rs/src/validations/test_6_2_38.rs
@@ -43,6 +43,9 @@ mod tests {
         // Case 11: different profile ("csaf_security_advisory")
         // Case 12: with prefix ("Example Company csaf_deprecated_security_advisory")´
         // Case 13: casing ("CSAF_deprecated_security_advisory")
+        // TODO: This test file is schema-invalid, as the leading whitespace violates the category regex
+        // TODO: Currently, this test case is "failing upwards", as schema-invalid files are reported as passing without actually running the test (bug #411)
+        // TODO: Leaving it in, as this file will become relevant when lenient parsing is implemented.
         // Case S11: leading whitespace (" csaf_deprecated_some_other_type")
         TESTS_2_1.test_6_2_38.expect(ExpectedResults {
             case_01,

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -902,7 +902,7 @@
       "valid": [
         {
           "name": "recommended/csaf-rs_csaf-csaf_2_1-6-2-38-s11.json",
-          "valid": true
+          "valid": false
         }
       ]
     },


### PR DESCRIPTION
This PR:
* correctly labels 6-2-38-S11 as valid: false
* adds comment explaining why