### PR TITLE
fix: 6-1-30-S11 typo

### DIFF
--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-30-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-30-s11.json
@@ -25,7 +25,7 @@
         }
       ],
       "status": "draft",
-      "version": "3"
+      "version": "2"
     }
   }
 }

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-30-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-30-s11.json
@@ -31,7 +31,7 @@
         }
       ],
       "status": "draft",
-      "version": "3"
+      "version": "2"
     }
   }
 }


### PR DESCRIPTION
@tziemek The version being "3" violates 6.1.16 and should not matter to 6.1.30, correct?