### PR TITLE
fix: 6-1-27-19-S11 uses csaf_base category

### DIFF
--- a/csaf-rs/src/validations/test_6_1_27_19.rs
+++ b/csaf-rs/src/validations/test_6_1_27_19.rs
@@ -103,7 +103,7 @@ mod tests {
             case_11: Ok(()),  // lang: unspecified, single correct reference
             case_12: Ok(()),  // lang: en-us, multiple correct references
             case_13: Ok(()),  // lang: de-DE is ignored
-            case_s11: Ok(()), // lang: en-us, wrong category
+            case_s11: Ok(()), // lang: en-us, category not csaf_superseded
         });
     }
 }

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-19-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-19-s11.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
   "document": {
-    "category": "csaf_security_advisory",
+    "category": "csaf_base",
     "csaf_version": "2.1",
     "distribution": {
       "tlp": {


### PR DESCRIPTION
csaf_security_advisory requires product tree and vulnerabilites to be present, S11 violated 6.1.27.4 and 11.

Any category except for csaf_superseded works for the test, and csaf_base does not have the above requirement