### PR TITLE
fix: 6-1-27-10-S11, S12 and 6-1-27-11-S12 has vulnerabilities notes

### DIFF
--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -113,6 +113,9 @@ mod tests {
             test_6_1_27_10_err_generator("CSAFPID-9080701".to_string(), 0, 1),
             test_6_1_27_10_err_generator("CSAFPID-9080702".to_string(), 0, 2),
         ]);
+        
+        // Case S11: remediations for all products
+        // Case S12: remediations for all products, also via groups
 
         TESTS_2_0.test_6_1_27_10.expect(ExpectedResults_2_0 {
             case_01: case_one_product_missing_from_group.clone(),

--- a/csaf-rs/src/validations/test_6_1_27_10.rs
+++ b/csaf-rs/src/validations/test_6_1_27_10.rs
@@ -113,7 +113,7 @@ mod tests {
             test_6_1_27_10_err_generator("CSAFPID-9080701".to_string(), 0, 1),
             test_6_1_27_10_err_generator("CSAFPID-9080702".to_string(), 0, 2),
         ]);
-        
+
         // Case S11: remediations for all products
         // Case S12: remediations for all products, also via groups
 

--- a/csaf-rs/src/validations/test_6_1_27_11.rs
+++ b/csaf-rs/src/validations/test_6_1_27_11.rs
@@ -60,6 +60,9 @@ mod tests {
             &CsafDocumentCategory::CsafDeprecatedSecurityAdvisory,
         )]);
 
+        // Case S11: vulns are missing, but category is csaf_base
+        // Case S12: vulns are not missing
+        
         TESTS_2_0.test_6_1_27_11.expect(ExpectedResults_2_0 {
             case_01: case_security_advisory.clone(),
             case_s01: case_vex.clone(),

--- a/csaf-rs/src/validations/test_6_1_27_11.rs
+++ b/csaf-rs/src/validations/test_6_1_27_11.rs
@@ -62,7 +62,7 @@ mod tests {
 
         // Case S11: vulns are missing, but category is csaf_base
         // Case S12: vulns are not missing
-        
+
         TESTS_2_0.test_6_1_27_11.expect(ExpectedResults_2_0 {
             case_01: case_security_advisory.clone(),
             case_s01: case_vex.clone(),

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s11.json
@@ -42,6 +42,13 @@
   "vulnerabilities": [
     {
       "cve": "CVE-2017-0145",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
+      ],
       "product_status": {
         "known_affected": [
           "CSAFPID-9080700",
@@ -58,13 +65,6 @@
             "CSAFPID-9080701",
             "CSAFPID-9080702"
           ]
-        }
-      ],
-      "notes": [
-        {
-          "category": "description",
-          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
-          "title": "CVE description"
         }
       ]
     }

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s11.json
@@ -59,6 +59,13 @@
             "CSAFPID-9080702"
           ]
         }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
       ]
     }
   ]

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s12.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s12.json
@@ -68,6 +68,13 @@
             "CSAFGID-0001"
           ]
         }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
       ]
     }
   ]

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s12.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-10-s12.json
@@ -53,6 +53,13 @@
   "vulnerabilities": [
     {
       "cve": "CVE-2017-0145",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
+      ],
       "product_status": {
         "known_affected": [
           "CSAFPID-9080700",
@@ -67,13 +74,6 @@
           "group_ids": [
             "CSAFGID-0001"
           ]
-        }
-      ],
-      "notes": [
-        {
-          "category": "description",
-          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
-          "title": "CVE description"
         }
       ]
     }

--- a/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-11-s12.json
+++ b/type-generator/assets/tests/csaf_2.0/mandatory/csaf-rs_csaf-csaf_2_0-6-1-27-11-s12.json
@@ -33,7 +33,14 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2017-0143"
+      "cve": "CVE-2017-0143",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability\". This vulnerability is different from those described in CVE-2017-0144, CVE-2017-0145, CVE-2017-0146, and CVE-2017-0148.",
+          "title": "CVE description"
+        }
+      ]
     }
   ]
 }

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s11.json
@@ -65,6 +65,13 @@
             "CSAFPID-9080702"
           ]
         }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
       ]
     }
   ]

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s11.json
@@ -48,6 +48,13 @@
   "vulnerabilities": [
     {
       "cve": "CVE-2017-0145",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
+      ],
       "product_status": {
         "known_affected": [
           "CSAFPID-9080700",
@@ -64,13 +71,6 @@
             "CSAFPID-9080701",
             "CSAFPID-9080702"
           ]
-        }
-      ],
-      "notes": [
-        {
-          "category": "description",
-          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
-          "title": "CVE description"
         }
       ]
     }

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s12.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s12.json
@@ -74,6 +74,13 @@
             "CSAFGID-0001"
           ]
         }
+      ],
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
       ]
     }
   ]

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s12.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-10-s12.json
@@ -59,6 +59,13 @@
   "vulnerabilities": [
     {
       "cve": "CVE-2017-0145",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
+          "title": "CVE description"
+        }
+      ],
       "product_status": {
         "known_affected": [
           "CSAFPID-9080700",
@@ -73,13 +80,6 @@
           "group_ids": [
             "CSAFGID-0001"
           ]
-        }
-      ],
-      "notes": [
-        {
-          "category": "description",
-          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability.\" This vulnerability is different from those described in CVE-2017-0143, CVE-2017-0144, CVE-2017-0146, and CVE-2017-0148. ",
-          "title": "CVE description"
         }
       ]
     }

--- a/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-11-s12.json
+++ b/type-generator/assets/tests/csaf_2.1/mandatory/csaf-rs_csaf-csaf_2_1-6-1-27-11-s12.json
@@ -39,7 +39,14 @@
   },
   "vulnerabilities": [
     {
-      "cve": "CVE-2017-0143"
+      "cve": "CVE-2017-0143",
+      "notes": [
+        {
+          "category": "description",
+          "text": "The SMBv1 server in Microsoft Windows Vista SP2; Windows Server 2008 SP2 and R2 SP1; Windows 7 SP1; Windows 8.1; Windows Server 2012 Gold and R2; Windows RT 8.1; and Windows 10 Gold, 1511, and 1607; and Windows Server 2016 allows remote attackers to execute arbitrary code via crafted packets, aka \"Windows SMB Remote Code Execution Vulnerability\". This vulnerability is different from those described in CVE-2017-0144, CVE-2017-0145, CVE-2017-0146, and CVE-2017-0148.",
+          "title": "CVE description"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
This PR:
* adds comment explaining the (supplemental) passing test cases of 6-1-27-11
* fixes 6-1-27-S12 to contain notes, which is required by 6-1-27-05