### PR TITLE
fix: correct 6.2.14, 6.2.15, 6.3.9 suppl test case validity

### DIFF
--- a/csaf-rs/src/validations/test_6_3_09.rs
+++ b/csaf-rs/src/validations/test_6_3_09.rs
@@ -212,6 +212,7 @@ mod tests {
             ),
         ]);
 
+        // Note: Stacked categories violate 6.1.57, making this test file mandatory invalid on CSAF 2.1
         let case_s01_stacked_wrong_order = Err(vec![create_branch_categories_error(
             &[
                 CategoryOfTheBranch::Vendor,

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -670,11 +670,11 @@
       "failures": [
         {
           "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s01.json",
-          "valid": false
+          "valid": true
         },
         {
           "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-14-s02.json",
-          "valid": false
+          "valid": true
         }
       ]
     },

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -732,7 +732,7 @@
       "failures": [
         {
           "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-09-s01.json",
-          "valid": false
+          "valid": true
         }
       ],
       "valid": [

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -688,7 +688,7 @@
         },
         {
           "name": "optional/csaf-rs_csaf-csaf_2_0-6-2-15-s02.json",
-          "valid": false
+          "valid": true
         }
       ],
       "valid": [


### PR DESCRIPTION
This PR corrects the last "incorrect" validity fields for CSAF 2.0 suppl tests:
* 6-3-9-S01 is invalid on CSAF 2.1, but 6.1.57 does not exist on CSAF 2.0, so its valid there
* 6-2-14-S01 and S02 and 6-2-15-S02 were just incorrectly labeled

Resolves #667 