### PR TITLE
feat: add test 6.3.3 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ For further configuration options, please refer to the [csaf-service README](csa
 | Test specification | 2.0               | 2.1 (experimental) |
 |--------|-------------------|--------------------|
 | 6.3.1  |  |  |
-| 6.3.5 | ✅ | ✅ |
+| 6.3.3  | ✅ | ✅ |
+| 6.3.5  | ✅ | ✅ |
 | 6.3.11 | ✅ | ✅ |
 | 6.3.14 | ⭕ | ✅ |
 | 6.3.15 | ⭕ | ✅ |

--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -981,7 +981,9 @@ crate::macros::define_csaf_test!(
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-11.json",
     "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-11.json"), (case_12, "12",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-12.json",
-    "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-12.json")]
+    "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-03-12.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json",
+    "informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_3_4, ValidatorForTest6_3_4, ExpectedResults_6_3_4, id : "6.3.4", doc_type :

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -2565,7 +2565,9 @@ crate::macros::define_csaf_test!(
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-11.json",
     "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-11.json"), (case_12, "12",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-12.json",
-    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-12.json")]
+    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-03-12.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_3_4, ValidatorForTest6_3_4, ExpectedResults_6_3_4, id : "6.3.4", doc_type :

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -374,7 +374,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 // informative tests
                 "6.3.1" => None, // Some(ValidatorForTest6_3_1.validate(self)),
                 "6.3.2" => Some(ValidatorForTest6_3_2.validate(self)),
-                "6.3.3" => None, // Some(ValidatorForTest6_3_3.validate(self)),
+                "6.3.3" => Some(ValidatorForTest6_3_3.validate(self)),
                 "6.3.4" => None, // Some(ValidatorForTest6_3_4.validate(self)),
                 "6.3.5" => Some(ValidatorForTest6_3_5.validate(self)),
                 "6.3.6" => None, // Some(ValidatorForTest6_3_6.validate(self)),

--- a/csaf-rs/src/validations/test_6_3_03.rs
+++ b/csaf-rs/src/validations/test_6_3_03.rs
@@ -14,7 +14,14 @@ fn create_missing_cve_error(vulnerability_index: usize) -> TestFinding {
 pub fn test_6_3_3_missing_cve(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
     let mut errors: Option<Vec<TestFinding>> = None;
 
-    for (v_i, vuln) in doc.get_vulnerabilities().iter().enumerate() {
+    let vulnerabilities = doc.get_vulnerabilities();
+
+    if vulnerabilities.is_empty() {
+        // TODO #409 wasSkipped
+        return Ok(());
+    }
+
+    for (v_i, vuln) in vulnerabilities.iter().enumerate() {
         if vuln.get_cve().is_none() {
             errors.get_or_insert_default().push(create_missing_cve_error(v_i));
         }
@@ -35,21 +42,28 @@ mod tests {
 
     #[test]
     fn test_test_6_3_3() {
-        let case_01 = Err(vec![create_missing_cve_error(0)]);
-        let case_02 = Err(vec![create_missing_cve_error(0), create_missing_cve_error(2)]);
+        let single_vuln_no_cve = Err(vec![create_missing_cve_error(0)]);
+        let multi_vuln_alternating_no_cve = Err(vec![create_missing_cve_error(0), create_missing_cve_error(2)]);
 
-        // Both CSAF 2.0 and 2.1 have 4 test cases
+        // Case 11: 1 vuln, with CVE (fixed case 01)
+        // Case 12: 3 vuln, with CWE (fixed case 02)
+        // Case S11: no vulns, this might be wasSkipped later #409
+
+        // TODO: Clarify upstream if this test should actually be "present and set" instead.
+        // TODO If so, add present and set test coverage
         TESTS_2_0.test_6_3_3.expect(ExpectedResults_2_0 {
-            case_01: case_01.clone(),
-            case_02: case_02.clone(),
+            case_01: single_vuln_no_cve.clone(),
+            case_02: multi_vuln_alternating_no_cve.clone(),
             case_11: Ok(()),
             case_12: Ok(()),
+            case_s11: Ok(()),
         });
         TESTS_2_1.test_6_3_3.expect(ExpectedResults_2_1 {
-            case_01,
-            case_02,
+            case_01: single_vuln_no_cve,
+            case_02: multi_vuln_alternating_no_cve,
             case_11: Ok(()),
             case_12: Ok(()),
+            case_s11: Ok(()),
         });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_03.rs
+++ b/csaf-rs/src/validations/test_6_3_03.rs
@@ -46,7 +46,7 @@ mod tests {
         let multi_vuln_alternating_no_cve = Err(vec![create_missing_cve_error(0), create_missing_cve_error(2)]);
 
         // Case 11: 1 vuln, with CVE (fixed case 01)
-        // Case 12: 3 vuln, with CWE (fixed case 02)
+        // Case 12: 3 vuln, all with CVEs (fixed case 02)
         // Case S11: no vulns, this might be wasSkipped later #409
 
         // TODO: Clarify upstream if this test should actually be "present and set" instead.

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json
@@ -1,0 +1,26 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative test: Missing CVE (valid supplementary example 1)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-3-03-S11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json
@@ -7,7 +7,7 @@
       "name": "CSAF-RS Test Files",
       "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Informative test: Missing CVE (valid supplementary example 1)",
+    "title": "Informative test: Missing CVE (valid supplementary example 1 - no vulnerabilities)",
     "tracking": {
       "current_release_date": "2021-07-21T10:00:00.000Z",
       "id": "CSAF-RS_CSAF-CSAF_2_0-6-3-03-S11",

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -769,6 +769,16 @@
           "valid": true
         }
       ]
+    },
+    {
+      "id": "6.3.3",
+      "group": "informative",
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json",
+          "valid": true
+        }
+      ]
     }
   ]
 }

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -727,6 +727,16 @@
       ]
     },
     {
+      "id": "6.3.3",
+      "group": "informative",
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.9",
       "group": "informative",
       "failures": [
@@ -766,16 +776,6 @@
         },
         {
           "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-11-s12.json",
-          "valid": true
-        }
-      ]
-    },
-    {
-      "id": "6.3.3",
-      "group": "informative",
-      "valid": [
-        {
-          "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-03-s11.json",
           "valid": true
         }
       ]

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative test: Missing CVE (valid supplementary example 1)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-03-S11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json
@@ -13,7 +13,7 @@
       "name": "CSAF-RS Test Files",
       "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
     },
-    "title": "Informative test: Missing CVE (valid supplementary example 1)",
+    "title": "Informative test: Missing CVE (valid supplementary example 1 - no vulnerabilities)",
     "tracking": {
       "current_release_date": "2024-01-24T10:00:00.000Z",
       "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-03-S11",

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -973,6 +973,16 @@
       ]
     },
     {
+      "id": "6.3.3",
+      "group": "informative",
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.5",
       "group": "informative",
       "failures": [
@@ -1055,16 +1065,6 @@
         {
           "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-12-s01.json",
           "valid": false
-        }
-      ]
-    },
-    {
-      "id": "6.3.3",
-      "group": "informative",
-      "valid": [
-        {
-          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json",
-          "valid": true
         }
       ]
     }

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -1057,6 +1057,16 @@
           "valid": false
         }
       ]
+    },
+    {
+      "id": "6.3.3",
+      "group": "informative",
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-03-s11.json",
+          "valid": true
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Resolves https://github.com/csaf-rs/csaf/issues/271

This PR:
* minor refactor, semantically more obvious early exist if no vulns exist
* new valid test case for doc with no vulns
* wire in for CSAF 2.1
* update README.md 

#978 for clarification if prose should use "present and set" requirement