### PR TITLE
feat: enable rule 6.1.33 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ For further configuration options, please refer to the [csaf-service README](csa
 | 6.1.30 | ✅ | ✅ |
 | 6.1.31 | ✅ | ✅ |
 | 6.1.32 | ✅ | ✅ |
-| 6.1.33 | ✅ |   |
+| 6.1.33 | ✅ | ✅ |
 | 6.1.34 | ⭕ | ✅ |
 | 6.1.35 | ⭕ | ✅ |
 | 6.1.36 | ⭕ |   |

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -270,7 +270,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.1.30" => Some(ValidatorForTest6_1_30.validate(self)),
                 "6.1.31" => Some(ValidatorForTest6_1_31.validate(self)),
                 "6.1.32" => Some(ValidatorForTest6_1_32.validate(self)),
-                "6.1.33" => None, // Some(ValidatorForTest6_1_33.validate(self)),
+                "6.1.33" => Some(ValidatorForTest6_1_33.validate(self)),
                 "6.1.34" => Some(ValidatorForTest6_1_34.validate(self)),
                 "6.1.35" => Some(ValidatorForTest6_1_35.validate(self)),
                 "6.1.36" => None, // Some(ValidatorForTest6_1_36.validate(self)),


### PR DESCRIPTION
This PR resolves https://github.com/csaf-rs/csaf/issues/366.

It enables the existing implementation of rule 6.1.33 for CSAF 2.1.

I also verified the existing implementation against the corresponding OASIS test files for CSAF 2.1.

Additional supplementary test cases will be created in https://github.com/csaf-rs/csaf/issues/976.