### PR TITLE
feat: add test 6.3.10 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,7 +340,8 @@ For further configuration options, please refer to the [csaf-service README](csa
 | Test specification | 2.0               | 2.1 (experimental) |
 |--------|-------------------|--------------------|
 | 6.3.1  |  |  |
-| 6.3.5 | ✅ | ✅ |
+| 6.3.5  | ✅ | ✅ |
+| 6.3.10 | ✅ | ✅ |
 | 6.3.11 | ✅ | ✅ |
 | 6.3.14 | ⭕ | ✅ |
 | 6.3.15 | ⭕ | ✅ |

--- a/csaf-rs/src/csaf2_0/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_0/testcases.generated.rs
@@ -1072,9 +1072,15 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_0::schema::CommonSecurityAdvisoryFramework, version : "V2_0",
     cases : [(case_01, "01",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-01.json",
-    "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-01.json"), (case_11, "11",
+    "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-01.json"), (case_s01, "s01",
+    "../type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json",
+    "informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json"), (case_s02, "s02",
+    "../type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json",
+    "informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json"), (case_11, "11",
     "../csaf/csaf_2.0/test/validator/data/informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-11.json",
-    "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-11.json")]
+    "informative/oasis_csaf_tc-csaf_2_0-2021-6-3-10-11.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s11.json",
+    "informative/csaf-rs_csaf-csaf_2_0-6-3-10-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_3_11, ValidatorForTest6_3_11, ExpectedResults_6_3_11, id : "6.3.11", doc_type :

--- a/csaf-rs/src/csaf2_1/testcases.generated.rs
+++ b/csaf-rs/src/csaf2_1/testcases.generated.rs
@@ -2668,9 +2668,15 @@ crate::macros::define_csaf_test!(
     crate ::schema::csaf2_1::schema::CommonSecurityAdvisoryFramework, version : "V2_1",
     cases : [(case_01, "01",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json",
-    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json"), (case_11, "11",
+    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-01.json"), (case_s01, "s01",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json"), (case_s02, "s02",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json"), (case_11, "11",
     "../csaf/csaf_2.1/test/validator/data/informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json",
-    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json")]
+    "informative/oasis_csaf_tc-csaf_2_1-2024-6-3-10-11.json"), (case_s11, "s11",
+    "../type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s11.json",
+    "informative/csaf-rs_csaf-csaf_2_1-6-3-10-s11.json")]
 );
 crate::macros::define_csaf_test!(
     Test6_3_11, ValidatorForTest6_3_11, ExpectedResults_6_3_11, id : "6.3.11", doc_type :

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -381,7 +381,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.3.7" => None, // Some(ValidatorForTest6_3_7.validate(self)),
                 "6.3.8" => None, // Some(ValidatorForTest6_3_8.validate(self)),
                 "6.3.9" => Some(ValidatorForTest6_3_9.validate(self)),
-                "6.3.10" => None, // Some(ValidatorForTest6_3_10.validate(self)),
+                "6.3.10" => Some(ValidatorForTest6_3_10.validate(self)),
                 "6.3.11" => Some(ValidatorForTest6_3_11.validate(self)),
                 "6.3.12" => Some(ValidatorForTest6_3_12.validate(self)),
                 "6.3.13" => None, // Some(ValidatorForTest6_3_13.validate(self)),

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -41,18 +41,38 @@ mod tests {
 
     #[test]
     fn test_test_6_3_10() {
-        let case_01 = Err(vec![create_product_version_range_error(
+        let tree_with_product_version_range = Err(vec![create_product_version_range_error(
             "/product_tree/branches/0/branches/0/branches/0",
         )]);
 
+        let tree_with_parallel_product_version_range = Err(vec![
+            create_product_version_range_error("/product_tree/branches/0/branches/0/branches/0"),
+            create_product_version_range_error("/product_tree/branches/0/branches/0/branches/1"),
+        ]);
+
+        // Stacked product categories violate 6.1.57 on CSAF 2.1, making this test file invalid there
+        let tree_with_stacked_product_version_range = Err(vec![
+            create_product_version_range_error("/product_tree/branches/0/branches/0/branches/0"),
+            create_product_version_range_error("/product_tree/branches/0/branches/0/branches/0/branches/0"),
+        ]);
+
+        // Case 11: product tree without product version range
+        // Case S11: no product tree
+
         // Both CSAF 2.0 and 2.1 have 2 test cases
         TESTS_2_0.test_6_3_10.expect(ExpectedResults_2_0 {
-            case_01: case_01.clone(),
+            case_01: tree_with_product_version_range.clone(),
+            case_s01: tree_with_parallel_product_version_range.clone(),
+            case_s02: tree_with_stacked_product_version_range.clone(),
             case_11: Ok(()),
+            case_s11: Ok(()), // TODO #409 wasSkipped
         });
         TESTS_2_1.test_6_3_10.expect(ExpectedResults_2_1 {
-            case_01,
+            case_01: tree_with_product_version_range,
+            case_s01: tree_with_parallel_product_version_range,
+            case_s02: tree_with_stacked_product_version_range,
             case_11: Ok(()),
+            case_s11: Ok(()), // TODO #409 wasSkipped
         });
     }
 }

--- a/csaf-rs/src/validations/test_6_3_10.rs
+++ b/csaf-rs/src/validations/test_6_3_10.rs
@@ -12,17 +12,19 @@ fn create_product_version_range_error(path: &str) -> TestFinding {
 ///
 /// Tests that the `product_version_range` branch category is not used anywhere in the product tree.
 pub fn test_6_3_10_usage_of_product_version_range(doc: &impl CsafTrait) -> Result<(), Vec<TestFinding>> {
+    let Some(product_tree) = doc.get_product_tree() else {
+        return Ok(()); // TODO #409 wasSkipped
+    };
+
     let mut errors: Option<Vec<TestFinding>> = None;
 
-    if let Some(product_tree) = doc.get_product_tree() {
-        product_tree.visit_all_branches(&mut |branch, path| {
-            if branch.get_category() == CategoryOfTheBranch::ProductVersionRange {
-                errors
-                    .get_or_insert_default()
-                    .push(create_product_version_range_error(path));
-            }
-        });
-    }
+    product_tree.visit_all_branches(&mut |branch, path| {
+        if branch.get_category() == CategoryOfTheBranch::ProductVersionRange {
+            errors
+                .get_or_insert_default()
+                .push(create_product_version_range_error(path));
+        }
+    });
 
     errors.map_or(Ok(()), Err)
 }

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json
@@ -1,0 +1,58 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Usage of Product Version Range (failing supplementary example 1 - parallel product version range branches)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-3-10-S01",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example Company",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Product A",
+            "branches": [
+              {
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.2.0|<2.3.0",
+                "product": {
+                  "product_id": "CSAFPID-9080700",
+                  "name": "Example Company Product A from 2.2.0 and before 2.3.0"
+                }
+              },
+              {
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.3.0|<2.4.0",
+                "product": {
+                  "product_id": "CSAFPID-9080701",
+                  "name": "Example Company Product A from 2.3.0 and before 2.4.0"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json
@@ -26,32 +26,32 @@
   "product_tree": {
     "branches": [
       {
-        "category": "vendor",
-        "name": "Example Company",
         "branches": [
           {
-            "category": "product_name",
-            "name": "Product A",
             "branches": [
               {
                 "category": "product_version_range",
                 "name": "vers:npm/>=2.2.0|<2.3.0",
                 "product": {
-                  "product_id": "CSAFPID-9080700",
-                  "name": "Example Company Product A from 2.2.0 and before 2.3.0"
+                  "name": "Example Company Product A from 2.2.0 and before 2.3.0",
+                  "product_id": "CSAFPID-9080700"
                 }
               },
               {
                 "category": "product_version_range",
                 "name": "vers:npm/>=2.3.0|<2.4.0",
                 "product": {
-                  "product_id": "CSAFPID-9080701",
-                  "name": "Example Company Product A from 2.3.0 and before 2.4.0"
+                  "name": "Example Company Product A from 2.3.0 and before 2.4.0",
+                  "product_id": "CSAFPID-9080701"
                 }
               }
-            ]
+            ],
+            "category": "product_name",
+            "name": "Product A"
           }
-        ]
+        ],
+        "category": "vendor",
+        "name": "Example Company"
       }
     ]
   }

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json
@@ -26,30 +26,30 @@
   "product_tree": {
     "branches": [
       {
-        "category": "vendor",
-        "name": "Example Company",
         "branches": [
           {
-            "category": "product_name",
-            "name": "Product A",
             "branches": [
               {
-                "category": "product_version_range",
-                "name": "vers:npm/>=2.2.0|<2.3.0",
                 "branches": [
                   {
                     "category": "product_version_range",
                     "name": "vers:npm/>=2.3.1|<2.3.3",
                     "product": {
-                      "product_id": "CSAFPID-9080701",
-                      "name": "Example Company Product A from 2.3.1 and before 2.3.3"
+                      "name": "Example Company Product A from 2.3.1 and before 2.3.3",
+                      "product_id": "CSAFPID-9080701"
                     }
                   }
-                ]
+                ],
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.2.0|<2.3.0"
               }
-            ]
+            ],
+            "category": "product_name",
+            "name": "Product A"
           }
-        ]
+        ],
+        "category": "vendor",
+        "name": "Example Company"
       }
     ]
   }

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json
@@ -1,0 +1,56 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Usage of Product Version Range (failing supplementary example 2 - stacked product version range branches)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-3-10-S02",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example Company",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Product A",
+            "branches": [
+              {
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.2.0|<2.3.0",
+                "branches": [
+                  {
+                    "category": "product_version_range",
+                    "name": "vers:npm/>=2.3.1|<2.3.3",
+                    "product": {
+                      "product_id": "CSAFPID-9080701",
+                      "name": "Example Company Product A from 2.3.1 and before 2.3.3"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.0/informative/csaf-rs_csaf-csaf_2_0-6-3-10-s11.json
@@ -1,0 +1,26 @@
+{
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Usage of Product Version Range (valid supplementary example 1 - no product tree)",
+    "tracking": {
+      "current_release_date": "2021-07-21T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_0-6-3-10-S11",
+      "initial_release_date": "2021-07-21T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2021-07-21T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.0/testcases.json
+++ b/type-generator/assets/tests/csaf_2.0/testcases.json
@@ -743,6 +743,26 @@
       ]
     },
     {
+      "id": "6.3.10",
+      "group": "informative",
+      "failures": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-10-s01.json",
+          "valid": true
+        },
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-10-s02.json",
+          "valid": true
+        }
+      ],
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_0-6-3-10-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.11",
       "group": "informative",
       "failures": [

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Usage of Product Version Range (failing supplementary example 1 - parallel product version range branches)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-10-S01",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example Company",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Product A",
+            "branches": [
+              {
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.2.0|<2.3.0",
+                "product": {
+                  "product_id": "CSAFPID-9080700",
+                  "name": "Example Company Product A from 2.2.0 and before 2.3.0"
+                }
+              },
+              {
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.3.0|<2.4.0",
+                "product": {
+                  "product_id": "CSAFPID-9080701",
+                  "name": "Example Company Product A from 2.3.0 and before 2.4.0"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json
@@ -32,32 +32,32 @@
   "product_tree": {
     "branches": [
       {
-        "category": "vendor",
-        "name": "Example Company",
         "branches": [
           {
-            "category": "product_name",
-            "name": "Product A",
             "branches": [
               {
                 "category": "product_version_range",
                 "name": "vers:npm/>=2.2.0|<2.3.0",
                 "product": {
-                  "product_id": "CSAFPID-9080700",
-                  "name": "Example Company Product A from 2.2.0 and before 2.3.0"
+                  "name": "Example Company Product A from 2.2.0 and before 2.3.0",
+                  "product_id": "CSAFPID-9080700"
                 }
               },
               {
                 "category": "product_version_range",
                 "name": "vers:npm/>=2.3.0|<2.4.0",
                 "product": {
-                  "product_id": "CSAFPID-9080701",
-                  "name": "Example Company Product A from 2.3.0 and before 2.4.0"
+                  "name": "Example Company Product A from 2.3.0 and before 2.4.0",
+                  "product_id": "CSAFPID-9080701"
                 }
               }
-            ]
+            ],
+            "category": "product_name",
+            "name": "Product A"
           }
-        ]
+        ],
+        "category": "vendor",
+        "name": "Example Company"
       }
     ]
   }

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Usage of Product Version Range (failing supplementary example 2 - stacked product version range branches)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-10-S02",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "Example Company",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Product A",
+            "branches": [
+              {
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.2.0|<2.3.0",
+                "branches": [
+                  {
+                    "category": "product_version_range",
+                    "name": "vers:npm/>=2.3.1|<2.3.3",
+                    "product": {
+                      "product_id": "CSAFPID-9080701",
+                      "name": "Example Company Product A from 2.3.1 and before 2.3.3"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json
@@ -32,30 +32,30 @@
   "product_tree": {
     "branches": [
       {
-        "category": "vendor",
-        "name": "Example Company",
         "branches": [
           {
-            "category": "product_name",
-            "name": "Product A",
             "branches": [
               {
-                "category": "product_version_range",
-                "name": "vers:npm/>=2.2.0|<2.3.0",
                 "branches": [
                   {
                     "category": "product_version_range",
                     "name": "vers:npm/>=2.3.1|<2.3.3",
                     "product": {
-                      "product_id": "CSAFPID-9080701",
-                      "name": "Example Company Product A from 2.3.1 and before 2.3.3"
+                      "name": "Example Company Product A from 2.3.1 and before 2.3.3",
+                      "product_id": "CSAFPID-9080701"
                     }
                   }
-                ]
+                ],
+                "category": "product_version_range",
+                "name": "vers:npm/>=2.2.0|<2.3.0"
               }
-            ]
+            ],
+            "category": "product_name",
+            "name": "Product A"
           }
-        ]
+        ],
+        "category": "vendor",
+        "name": "Example Company"
       }
     ]
   }

--- a/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s11.json
+++ b/type-generator/assets/tests/csaf_2.1/informative/csaf-rs_csaf-csaf_2_1-6-3-10-s11.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://docs.oasis-open.org/csaf/csaf/v2.1/schema/csaf.json",
+  "document": {
+    "category": "csaf_base",
+    "csaf_version": "2.1",
+    "distribution": {
+      "tlp": {
+        "label": "CLEAR"
+      }
+    },
+    "publisher": {
+      "category": "other",
+      "name": "CSAF-RS Test Files",
+      "namespace": "https://github.com/csaf-rs/csaf/tree/main/type-generator/assets/tests"
+    },
+    "title": "Informative Test: Usage of Product Version Range (valid supplementary example 1 - no product tree)",
+    "tracking": {
+      "current_release_date": "2024-01-24T10:00:00.000Z",
+      "id": "CSAF-RS_CSAF-CSAF_2_1-6-3-10-S11",
+      "initial_release_date": "2024-01-24T10:00:00.000Z",
+      "revision_history": [
+        {
+          "date": "2024-01-24T10:00:00.000Z",
+          "number": "1",
+          "summary": "Initial version."
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  }
+}

--- a/type-generator/assets/tests/csaf_2.1/testcases.json
+++ b/type-generator/assets/tests/csaf_2.1/testcases.json
@@ -1021,6 +1021,26 @@
       ]
     },
     {
+      "id": "6.3.10",
+      "group": "informative",
+      "failures": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-10-s01.json",
+          "valid": true
+        },
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-10-s02.json",
+          "valid": false
+        }
+      ],
+      "valid": [
+        {
+          "name": "informative/csaf-rs_csaf-csaf_2_1-6-3-10-s11.json",
+          "valid": true
+        }
+      ]
+    },
+    {
       "id": "6.3.11",
       "group": "informative",
       "failures": [


### PR DESCRIPTION
Resolves #278 

This PR adds:
* minor refactor for no product tree early exit
* 3 new test cases
   * nested offending categories
   * stacked offending categories
   * no product tree
* wires in validation.rs for CSAF 2.1
* updates README.md