### PR TITLE
feat: add test 6.1.36 for CSAF 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ For further configuration options, please refer to the [csaf-service README](csa
 | 6.1.33 | ✅ | ✅ |
 | 6.1.34 | ⭕ | ✅ |
 | 6.1.35 | ⭕ | ✅ |
-| 6.1.36 | ⭕ |   |
+| 6.1.36 | ⭕ | ✅ |
 | 6.1.37 | ⭕ |   |
 | 6.1.38 | ⭕ | ✅ |
 | 6.1.39 | ⭕ | ✅ |

--- a/csaf-rs/src/csaf2_1/validation.rs
+++ b/csaf-rs/src/csaf2_1/validation.rs
@@ -273,7 +273,7 @@ impl Validatable for CommonSecurityAdvisoryFramework {
                 "6.1.33" => Some(ValidatorForTest6_1_33.validate(self)),
                 "6.1.34" => Some(ValidatorForTest6_1_34.validate(self)),
                 "6.1.35" => Some(ValidatorForTest6_1_35.validate(self)),
-                "6.1.36" => None, // Some(ValidatorForTest6_1_36.validate(self)),
+                "6.1.36" => Some(ValidatorForTest6_1_36.validate(self)),
                 "6.1.37" => None, // Some(ValidatorForTest6_1_37.validate(self)),
                 "6.1.38" => Some(ValidatorForTest6_1_38.validate(self)),
                 "6.1.39" => Some(ValidatorForTest6_1_39.validate(self)),


### PR DESCRIPTION
This PR resolves https://github.com/csaf-rs/csaf/issues/369.

It enables the existing implementation of rule 6.1.36 for CSAF 2.1.

I also verified the existing implementation against the corresponding OASIS test files for CSAF 2.1.

Additional supplementary test cases will be created in https://github.com/csaf-rs/csaf/issues/980.